### PR TITLE
Fix CI: pin Xcode 26.3 and remove force-unwrap lint violations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,12 +4,20 @@ on:
     branches: [main]
   pull_request:
 
+# Pin Xcode 26.3 — the macos-15 runner defaults to Xcode 16.4, whose SwiftData
+# SDK lacks Schema.Version: Sendable, breaking swift test/xcodebuild under Swift 6.
+# We target the macOS 15 *platform* (deployment target), not Xcode 16.
+env:
+  DEVELOPER_DIR: /Applications/Xcode_26.3.app/Contents/Developer
+
 jobs:
   package-tier:
     name: Packages (lint + test)
     runs-on: macos-15
     steps:
       - uses: actions/checkout@v4
+      - name: Verify Xcode version
+        run: xcodebuild -version
       - name: Cache Homebrew
         uses: actions/cache@v4
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,8 @@ All builds, tests, and checks go through the `Makefile`. Humans, CI, the pre-com
 
 ### CI (three tiers)
 
+CI pins **Xcode 26.3** via `DEVELOPER_DIR` in `ci.yml` while targeting the **macOS 15 platform** (deployment target). The `macos-15` runner defaults to Xcode 16.4, whose SwiftData SDK lacks `Schema.Version: Sendable` and breaks Swift 6 strict concurrency.
+
 - **`package-tier`** (gating, required check): runs `make ci` (lint + test + build) on `macos-15`. This is the merge gate.
 - **`app-tier`** (non-gating, `continue-on-error`): runs `make build-app` on `macos-15`. Reported on the PR for visibility but never blocks merge.
 - **`manual-tests-check`** (non-gating, `continue-on-error`): runs `make manual-tests-check` on `macos-15`. Expected RED until Phase 4.5 (when a human runs the manual tests on real hardware). Informational only — never blocks merge.

--- a/Packages/BiscottiKit/Sources/Permissions/Permissions.swift
+++ b/Packages/BiscottiKit/Sources/Permissions/Permissions.swift
@@ -60,14 +60,18 @@ public final class Permissions {
 
     /// Returns a URL that opens the correct System Settings pane for the given permission.
     public func settingsURL(for kind: PermissionKind) -> URL {
-        switch kind {
+        let urlString = switch kind {
         case .microphone:
             // Opens Privacy & Security > Microphone
-            URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone")!
-
+            "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone"
         case .systemAudio:
             // Opens Privacy & Security > Screen & System Audio Recording
-            URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture")!
+            "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture"
         }
+
+        guard let url = URL(string: urlString) else {
+            preconditionFailure("Invalid hardcoded settings URL: \(urlString)")
+        }
+        return url
     }
 }


### PR DESCRIPTION
## What

CI had never been green. Root cause: the `macos-15` runner defaulted to **Xcode 16.4**, whose SDK lacks `Sendable` conformances (e.g. SwiftData's `Schema.Version`) and ships an older Swift 6.1 — so `make test` and `make build-app` failed under Swift 6 strict concurrency. We target the **macOS 15 platform**, not Xcode 16, and both the dev machines and the runner image have **Xcode 26.3** available.

## Changes

- **`.github/workflows/ci.yml`** — set `DEVELOPER_DIR=/Applications/Xcode_26.3.app/Contents/Developer` (workflow-scoped, so all jobs use Xcode 26.3); add an `xcodebuild -version` diagnostic step to `package-tier` so future toolchain drift fails fast and legibly.
- **`Permissions.swift`** — replace two `URL(string:)!` force-unwraps with `guard let` + `preconditionFailure` (fixes the gating `swiftlint --strict force_unwrapping` failure; toolchain-independent).
- **`CLAUDE.md`** — document the Xcode 26.3 pin.

## Why no source workarounds for the Sendable errors

On Xcode 26.3 / Swift 6.2 the previously-failing cases compile cleanly with **no** `@preconcurrency`/`nonisolated(unsafe)` edits — Swift 6.2 region-based isolation (SE-0414) safely sends the freshly-constructed `WhisperKit` into the actor, and the 26.3 SDK makes `Schema.Version` `Sendable`. Verified empirically via clean builds (the package builds with `-warnings-as-errors`, so unnecessary annotations would themselves fail). Net diff is just the three files above.

## CI result

- `Packages (lint + test)` (gating) — ✅ pass
- `App build (xcodebuild)` (non-gating) — ✅ pass
- `Manual tests check` (non-gating) — 🔴 RED **by design** until a human runs the manual hardware tests at Phase 4.5; never blocks merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)