### PR TITLE
Add "Show next meeting in menu bar" setting with configurable lead time

### DIFF
--- a/Packages/BiscottiKit/Sources/AppCore/AppCore.swift
+++ b/Packages/BiscottiKit/Sources/AppCore/AppCore.swift
@@ -21,6 +21,13 @@ public extension Notification.Name {
     static let exitOnWindowCloseDidChange = Notification.Name(
         "net.scosman.biscotti.exitOnWindowCloseDidChange"
     )
+
+    /// Posted after the "menu bar lead time" setting is persisted.
+    /// `MenuBarViewModel` observes this to refresh its cached lead time
+    /// so `iconState` reflects the new threshold without restart.
+    static let menuBarLeadTimeDidChange = Notification.Name(
+        "net.scosman.biscotti.menuBarLeadTimeDidChange"
+    )
 }
 
 /// Thin MVP coordinator that wires Recording, TranscriptionService,
@@ -81,6 +88,10 @@ public final class AppCore {
     /// The current run state. UI + menu bar observe this.
     public private(set) var runState: RunState = .idle
 
+    /// Cached menu bar lead time setting. Drives how far before a meeting
+    /// the menu bar shows the detailed "next meeting" text.
+    public private(set) var menuBarLeadTime: MenuBarLeadTime = .oneHour
+
     // MARK: - Child services (publicly readable for the UI layer)
 
     /// The persistent store.
@@ -139,6 +150,9 @@ public final class AppCore {
 
     /// The fire-and-forget transcription task spawned by `stopRecording()`.
     package var pendingTranscriptionTask: Task<Void, Never>?
+
+    /// Observes `.menuBarLeadTimeDidChange` to refresh the cached lead time.
+    private var menuBarLeadTimeObserverTask: Task<Void, Never>?
 
     /// Auto-stop countdown duration in seconds.
     private let autoStopSeconds = 15
@@ -199,15 +213,17 @@ public final class AppCore {
         await recording.recoverOrphans()
         logger.info("onLaunch: recoverOrphans done")
 
-        // Check onboarding gate
+        // Check onboarding gate and load cached settings
         logger.info("onLaunch: reading settings")
         let onboardingComplete: Bool
         do {
             let settings = try await store.settings()
             onboardingComplete = settings.onboardingComplete
+            loadMenuBarLeadTime(from: settings)
         } catch {
             onboardingComplete = false
         }
+        startMenuBarLeadTimeObserver()
 
         if !onboardingComplete {
             logger.info("onLaunch: routing to onboarding")
@@ -464,12 +480,41 @@ public final class AppCore {
             summaries = []
         }
     }
+}
 
-    // MARK: - Test support
+// MARK: - Menu bar lead time
 
+extension AppCore {
+    /// Updates the cached `menuBarLeadTime` from a settings snapshot.
+    func loadMenuBarLeadTime(from settings: AppSettingsData) {
+        menuBarLeadTime = MenuBarLeadTime(
+            seconds: settings.menuBarLeadTimeSeconds
+        )
+    }
+
+    /// Starts an async observer that refreshes `menuBarLeadTime` when
+    /// the setting is changed from SettingsUI.
+    func startMenuBarLeadTimeObserver() {
+        menuBarLeadTimeObserverTask = Task { [weak self] in
+            for await _ in NotificationCenter.default.notifications(
+                named: .menuBarLeadTimeDidChange
+            ) {
+                guard let self else { return }
+                let settings = try? await store.settings()
+                if let settings {
+                    loadMenuBarLeadTime(from: settings)
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Test support
+
+package extension AppCore {
     /// Waits for any pending fire-and-forget transcription task spawned by
     /// `stopRecording()` to finish.
-    package func awaitPendingTranscription() async {
+    func awaitPendingTranscription() async {
         await pendingTranscriptionTask?.value
         pendingTranscriptionTask = nil
     }

--- a/Packages/BiscottiKit/Sources/DataStore/DataStore+ReadModels.swift
+++ b/Packages/BiscottiKit/Sources/DataStore/DataStore+ReadModels.swift
@@ -126,6 +126,10 @@ public struct AppSettingsData: Sendable, Equatable {
     /// When false (the default), those actions just hide the window and the app
     /// stays alive in the menu bar.
     public var exitOnWindowClose: Bool
+    /// Lead time (in seconds) before a meeting start at which the menu bar
+    /// shows the detailed "next meeting" text. `0` means never show.
+    /// Default: 3600 (1 hour before).
+    public var menuBarLeadTimeSeconds: Int
     public var onboardingComplete: Bool
     /// `nil` = all calendars enabled (the default).
     public var enabledCalendarIDs: Set<String>?
@@ -134,12 +138,14 @@ public struct AppSettingsData: Sendable, Equatable {
         customVocabulary: [String] = [],
         launchAtLogin: Bool = false,
         exitOnWindowClose: Bool = false,
+        menuBarLeadTimeSeconds: Int = 3600,
         onboardingComplete: Bool = false,
         enabledCalendarIDs: Set<String>? = nil
     ) {
         self.customVocabulary = customVocabulary
         self.launchAtLogin = launchAtLogin
         self.exitOnWindowClose = exitOnWindowClose
+        self.menuBarLeadTimeSeconds = menuBarLeadTimeSeconds
         self.onboardingComplete = onboardingComplete
         self.enabledCalendarIDs = enabledCalendarIDs
     }
@@ -380,6 +386,7 @@ public extension DataStore {
                 customVocabulary: existing.customVocabulary,
                 launchAtLogin: existing.launchAtLogin,
                 exitOnWindowClose: existing.exitOnWindowClose,
+                menuBarLeadTimeSeconds: existing.menuBarLeadTimeSeconds,
                 onboardingComplete: existing.onboardingComplete,
                 enabledCalendarIDs: existing.enabledCalendarIDs
             )
@@ -407,6 +414,7 @@ public extension DataStore {
             customVocabulary: model.customVocabulary,
             launchAtLogin: model.launchAtLogin,
             exitOnWindowClose: model.exitOnWindowClose,
+            menuBarLeadTimeSeconds: model.menuBarLeadTimeSeconds,
             onboardingComplete: model.onboardingComplete,
             enabledCalendarIDs: model.enabledCalendarIDs
         )
@@ -415,6 +423,7 @@ public extension DataStore {
         model.customVocabulary = dto.customVocabulary
         model.launchAtLogin = dto.launchAtLogin
         model.exitOnWindowClose = dto.exitOnWindowClose
+        model.menuBarLeadTimeSeconds = dto.menuBarLeadTimeSeconds
         model.onboardingComplete = dto.onboardingComplete
         model.enabledCalendarIDs = dto.enabledCalendarIDs
         try save()

--- a/Packages/BiscottiKit/Sources/DataStore/Models/AppSettings.swift
+++ b/Packages/BiscottiKit/Sources/DataStore/Models/AppSettings.swift
@@ -22,6 +22,11 @@ import SwiftData
     /// stays alive in the menu bar.
     public var exitOnWindowClose: Bool = false
 
+    /// Lead time (in seconds) before a meeting start at which the menu bar
+    /// shows the detailed "next meeting" text. `0` means never show.
+    /// Default: 3600 (1 hour before).
+    public var menuBarLeadTimeSeconds: Int = 3600
+
     /// Whether the user has completed the onboarding wizard.
     public var onboardingComplete: Bool = false
 
@@ -53,12 +58,14 @@ import SwiftData
         customVocabulary: [String] = [],
         launchAtLogin: Bool = false,
         exitOnWindowClose: Bool = false,
+        menuBarLeadTimeSeconds: Int = 3600,
         onboardingComplete: Bool = false,
         enabledCalendarIDs: Set<String>? = nil
     ) {
         customVocabularyData = (try? JSONEncoder().encode(customVocabulary)) ?? Data()
         self.launchAtLogin = launchAtLogin
         self.exitOnWindowClose = exitOnWindowClose
+        self.menuBarLeadTimeSeconds = menuBarLeadTimeSeconds
         self.onboardingComplete = onboardingComplete
         if let enabledCalendarIDs {
             enabledCalendarIDsData = (try? JSONEncoder().encode(Array(enabledCalendarIDs).sorted())) ?? Data()

--- a/Packages/BiscottiKit/Sources/DataStore/Models/MenuBarLeadTime.swift
+++ b/Packages/BiscottiKit/Sources/DataStore/Models/MenuBarLeadTime.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+/// How far before a meeting's start time the menu bar shows the
+/// detailed "next meeting" text. Backed by a stored `Int` (seconds)
+/// in `AppSettings.menuBarLeadTimeSeconds`.
+public enum MenuBarLeadTime: Int, CaseIterable, Sendable, Identifiable {
+    /// Never show the detailed meeting text.
+    case never = 0
+    case fiveMinutes = 300
+    case tenMinutes = 600
+    case fifteenMinutes = 900
+    case thirtyMinutes = 1800
+    case oneHour = 3600
+    case twoHours = 7200
+    case sixHours = 21600
+    case twelveHours = 43200
+    case twentyFourHours = 86400
+
+    public var id: Int {
+        rawValue
+    }
+
+    /// Human-readable label for the picker.
+    public var displayText: String {
+        switch self {
+        case .never: "Never"
+        case .fiveMinutes: "5 minutes before"
+        case .tenMinutes: "10 minutes before"
+        case .fifteenMinutes: "15 minutes before"
+        case .thirtyMinutes: "30 minutes before"
+        case .oneHour: "1 hour before"
+        case .twoHours: "2 hours before"
+        case .sixHours: "6 hours before"
+        case .twelveHours: "12 hours before"
+        case .twentyFourHours: "24 hours before"
+        }
+    }
+
+    /// The duration window after a meeting starts during which the
+    /// detailed text is still shown (for people running late).
+    /// All non-never options share the same 5-minute grace period.
+    public static let postStartGraceSeconds: TimeInterval = 5 * 60
+
+    /// Creates a `MenuBarLeadTime` from a stored seconds value,
+    /// falling back to `.oneHour` if the value doesn't match a known case.
+    public init(seconds: Int) {
+        self = Self(rawValue: seconds) ?? .oneHour
+    }
+
+    /// Whether a meeting starting at `meetingStart` should show the
+    /// detailed text in the menu bar at time `now`.
+    ///
+    /// Returns `true` when `self != .never` AND `now` is within
+    /// `[meetingStart - leadTime, meetingStart + 5 min]`.
+    public func shouldShowDetailedText(
+        meetingStart: Date,
+        now: Date
+    ) -> Bool {
+        guard self != .never else { return false }
+        let interval = meetingStart.timeIntervalSince(now)
+        let leadSeconds = TimeInterval(rawValue)
+        // now is before meeting: interval > 0, must be <= leadSeconds
+        // now is after meeting start: interval < 0, must be within grace
+        return interval <= leadSeconds
+            && interval >= -Self.postStartGraceSeconds
+    }
+}

--- a/Packages/BiscottiKit/Sources/MenuBarUI/MenuBarViewModel.swift
+++ b/Packages/BiscottiKit/Sources/MenuBarUI/MenuBarViewModel.swift
@@ -38,13 +38,14 @@ public final class MenuBarViewModel {
     public enum IconState: Equatable {
         /// No recording, no imminent meeting.
         case idle
-        /// A meeting-like event is within 2 hours.
+        /// A meeting-like event is within the configured lead time.
         case nextMeeting(title: String, timeText: String)
         /// Recording is active.
         case recording
     }
 
-    /// The current icon state, derived from core state.
+    /// The current icon state, derived from core state and the menu bar
+    /// lead time setting.
     public var iconState: IconState {
         if case .recording = core.runState {
             return .recording
@@ -53,8 +54,8 @@ public final class MenuBarViewModel {
             return .recording
         }
         if let next = core.displayedUpcoming.first,
-           Self.isWithin2Hours(
-               next.start, relativeTo: core.minuteTick
+           core.menuBarLeadTime.shouldShowDetailedText(
+               meetingStart: next.start, now: core.minuteTick
            )
         {
             let title = Self.truncateTitle(
@@ -174,14 +175,6 @@ public final class MenuBarViewModel {
         TimeFormatting.relativeTimeText(
             event.start, relativeTo: core.minuteTick
         )
-    }
-
-    /// Whether a date is within 2 hours from now.
-    public nonisolated static func isWithin2Hours(
-        _ date: Date, relativeTo now: Date = Date()
-    ) -> Bool {
-        let interval = date.timeIntervalSince(now)
-        return interval > 0 && interval <= 2 * 3600
     }
 
     /// Formats a time interval as "MM:SS" or "H:MM:SS".

--- a/Packages/BiscottiKit/Sources/SettingsUI/SettingsView.swift
+++ b/Packages/BiscottiKit/Sources/SettingsUI/SettingsView.swift
@@ -1,6 +1,7 @@
 import AppCore
 import AppKit
 import Calendar
+import DataStore
 import DesignSystem
 import Permissions
 import SwiftUI
@@ -60,6 +61,14 @@ public struct SettingsView: View {
                     .font(Tokens.metadataFont)
                     .foregroundStyle(Tokens.secondaryText)
             }
+            Picker(
+                "Show upcoming meetings in menu bar",
+                selection: menuBarLeadTimeBinding
+            ) {
+                ForEach(MenuBarLeadTime.allCases) { option in
+                    Text(option.displayText).tag(option)
+                }
+            }
         }
     }
 
@@ -77,6 +86,15 @@ public struct SettingsView: View {
             get: { viewModel.exitOnWindowClose },
             set: { newValue in
                 Task { await viewModel.setExitOnWindowClose(newValue) }
+            }
+        )
+    }
+
+    private var menuBarLeadTimeBinding: Binding<MenuBarLeadTime> {
+        Binding(
+            get: { viewModel.menuBarLeadTime },
+            set: { newValue in
+                Task { await viewModel.setMenuBarLeadTime(newValue) }
             }
         )
     }

--- a/Packages/BiscottiKit/Sources/SettingsUI/SettingsView.swift
+++ b/Packages/BiscottiKit/Sources/SettingsUI/SettingsView.swift
@@ -62,7 +62,7 @@ public struct SettingsView: View {
                     .foregroundStyle(Tokens.secondaryText)
             }
             Picker(
-                "Show upcoming meetings in menu bar",
+                "Show next meeting in menu bar",
                 selection: menuBarLeadTimeBinding
             ) {
                 ForEach(MenuBarLeadTime.allCases) { option in

--- a/Packages/BiscottiKit/Sources/SettingsUI/SettingsViewModel.swift
+++ b/Packages/BiscottiKit/Sources/SettingsUI/SettingsViewModel.swift
@@ -46,6 +46,9 @@ public final class SettingsViewModel {
     /// app stays alive in the menu bar.
     public private(set) var exitOnWindowClose: Bool = false
 
+    /// How far before a meeting the menu bar shows the detailed text.
+    public private(set) var menuBarLeadTime: MenuBarLeadTime = .oneHour
+
     // MARK: - Calendar state
 
     /// All calendars grouped by source, for the include/exclude toggles.
@@ -131,6 +134,26 @@ public final class SettingsViewModel {
         } catch {
             // Revert on failure
             exitOnWindowClose = !enabled
+        }
+    }
+
+    /// Updates the "show upcoming meetings in menu bar" lead time.
+    /// Persists to the store and posts `.menuBarLeadTimeDidChange`
+    /// so AppCore refreshes its cached lead time for the menu bar icon.
+    public func setMenuBarLeadTime(_ value: MenuBarLeadTime) async {
+        let previous = menuBarLeadTime
+        menuBarLeadTime = value
+        do {
+            try await core.store.updateSettings { settings in
+                settings.menuBarLeadTimeSeconds = value.rawValue
+            }
+            NotificationCenter.default.post(
+                name: .menuBarLeadTimeDidChange,
+                object: nil
+            )
+        } catch {
+            // Revert on failure
+            menuBarLeadTime = previous
         }
     }
 
@@ -267,6 +290,9 @@ public final class SettingsViewModel {
             let settings = try await core.store.settings()
             enabledCalendarIDs = settings.enabledCalendarIDs
             exitOnWindowClose = settings.exitOnWindowClose
+            menuBarLeadTime = MenuBarLeadTime(
+                seconds: settings.menuBarLeadTimeSeconds
+            )
         } catch {
             enabledCalendarIDs = nil
         }

--- a/Packages/BiscottiKit/Sources/SettingsUI/SettingsViewModel.swift
+++ b/Packages/BiscottiKit/Sources/SettingsUI/SettingsViewModel.swift
@@ -137,7 +137,7 @@ public final class SettingsViewModel {
         }
     }
 
-    /// Updates the "show upcoming meetings in menu bar" lead time.
+    /// Updates the "show next meeting in menu bar" lead time.
     /// Persists to the store and posts `.menuBarLeadTimeDidChange`
     /// so AppCore refreshes its cached lead time for the menu bar icon.
     public func setMenuBarLeadTime(_ value: MenuBarLeadTime) async {

--- a/Packages/BiscottiKit/Tests/DataStoreTests/MenuBarLeadTimeTests.swift
+++ b/Packages/BiscottiKit/Tests/DataStoreTests/MenuBarLeadTimeTests.swift
@@ -1,0 +1,178 @@
+import DataStore
+import Foundation
+import Testing
+
+@Suite("MenuBarLeadTime")
+struct MenuBarLeadTimeTests {
+    // MARK: - Init from seconds
+
+    @Test("init from known seconds returns matching case")
+    func initKnownSeconds() {
+        #expect(MenuBarLeadTime(seconds: 0) == .never)
+        #expect(MenuBarLeadTime(seconds: 300) == .fiveMinutes)
+        #expect(MenuBarLeadTime(seconds: 600) == .tenMinutes)
+        #expect(MenuBarLeadTime(seconds: 900) == .fifteenMinutes)
+        #expect(MenuBarLeadTime(seconds: 1800) == .thirtyMinutes)
+        #expect(MenuBarLeadTime(seconds: 3600) == .oneHour)
+        #expect(MenuBarLeadTime(seconds: 7200) == .twoHours)
+        #expect(MenuBarLeadTime(seconds: 21600) == .sixHours)
+        #expect(MenuBarLeadTime(seconds: 43200) == .twelveHours)
+        #expect(MenuBarLeadTime(seconds: 86400) == .twentyFourHours)
+    }
+
+    @Test("init from unknown seconds falls back to oneHour")
+    func initUnknownSeconds() {
+        #expect(MenuBarLeadTime(seconds: 42) == .oneHour)
+        #expect(MenuBarLeadTime(seconds: -1) == .oneHour)
+        #expect(MenuBarLeadTime(seconds: 999_999) == .oneHour)
+    }
+
+    // MARK: - Display text
+
+    @Test("all cases have non-empty display text")
+    func allCasesHaveDisplayText() {
+        for option in MenuBarLeadTime.allCases {
+            #expect(!option.displayText.isEmpty)
+        }
+    }
+
+    @Test("default is oneHour (3600 seconds)")
+    func defaultIsOneHour() {
+        #expect(MenuBarLeadTime.oneHour.rawValue == 3600)
+    }
+
+    // MARK: - shouldShowDetailedText
+
+    @Test("never returns false regardless of timing")
+    func neverAlwaysFalse() {
+        let now = Date()
+        let meetingStart = now.addingTimeInterval(60) // 1 min from now
+        #expect(
+            MenuBarLeadTime.never.shouldShowDetailedText(
+                meetingStart: meetingStart, now: now
+            ) == false
+        )
+    }
+
+    @Test("shows text when within lead time before meeting")
+    func withinLeadTimeBeforeMeeting() {
+        let now = Date()
+        // Meeting in 30 min, lead time is 1 hour
+        let meetingStart = now.addingTimeInterval(30 * 60)
+        #expect(
+            MenuBarLeadTime.oneHour.shouldShowDetailedText(
+                meetingStart: meetingStart, now: now
+            ) == true
+        )
+    }
+
+    @Test("hides text when outside lead time before meeting")
+    func outsideLeadTimeBeforeMeeting() {
+        let now = Date()
+        // Meeting in 2 hours, lead time is 1 hour
+        let meetingStart = now.addingTimeInterval(2 * 3600)
+        #expect(
+            MenuBarLeadTime.oneHour.shouldShowDetailedText(
+                meetingStart: meetingStart, now: now
+            ) == false
+        )
+    }
+
+    @Test("shows text at exact lead time boundary")
+    func exactLeadTimeBoundary() {
+        let now = Date()
+        // Meeting in exactly 1 hour, lead time is 1 hour
+        let meetingStart = now.addingTimeInterval(3600)
+        #expect(
+            MenuBarLeadTime.oneHour.shouldShowDetailedText(
+                meetingStart: meetingStart, now: now
+            ) == true
+        )
+    }
+
+    @Test("shows text within 5 min after meeting start (grace period)")
+    func withinGracePeriodAfterStart() {
+        let now = Date()
+        // Meeting started 3 min ago
+        let meetingStart = now.addingTimeInterval(-3 * 60)
+        #expect(
+            MenuBarLeadTime.oneHour.shouldShowDetailedText(
+                meetingStart: meetingStart, now: now
+            ) == true
+        )
+    }
+
+    @Test("shows text at exact grace period boundary (5 min after start)")
+    func exactGracePeriodBoundary() {
+        let now = Date()
+        // Meeting started exactly 5 min ago
+        let meetingStart = now.addingTimeInterval(-5 * 60)
+        #expect(
+            MenuBarLeadTime.oneHour.shouldShowDetailedText(
+                meetingStart: meetingStart, now: now
+            ) == true
+        )
+    }
+
+    @Test("hides text after grace period expires (>5 min after start)")
+    func afterGracePeriodExpires() {
+        let now = Date()
+        // Meeting started 6 min ago
+        let meetingStart = now.addingTimeInterval(-6 * 60)
+        #expect(
+            MenuBarLeadTime.oneHour.shouldShowDetailedText(
+                meetingStart: meetingStart, now: now
+            ) == false
+        )
+    }
+
+    @Test("5 min lead time: shows 3 min before, hides 10 min before")
+    func fiveMinuteLeadTime() {
+        let now = Date()
+        let meetingStart = now.addingTimeInterval(3 * 60) // 3 min from now
+        #expect(
+            MenuBarLeadTime.fiveMinutes.shouldShowDetailedText(
+                meetingStart: meetingStart, now: now
+            ) == true
+        )
+
+        let meetingStartFar = now.addingTimeInterval(10 * 60) // 10 min from now
+        #expect(
+            MenuBarLeadTime.fiveMinutes.shouldShowDetailedText(
+                meetingStart: meetingStartFar, now: now
+            ) == false
+        )
+    }
+
+    @Test("24h lead time: shows 23h before meeting")
+    func twentyFourHourLeadTime() {
+        let now = Date()
+        let meetingStart = now.addingTimeInterval(23 * 3600) // 23h from now
+        #expect(
+            MenuBarLeadTime.twentyFourHours.shouldShowDetailedText(
+                meetingStart: meetingStart, now: now
+            ) == true
+        )
+    }
+
+    @Test("grace period applies to all non-never options")
+    func gracePeriodAllOptions() {
+        let now = Date()
+        // Meeting started 3 min ago
+        let meetingStart = now.addingTimeInterval(-3 * 60)
+
+        for option in MenuBarLeadTime.allCases where option != .never {
+            #expect(
+                option.shouldShowDetailedText(
+                    meetingStart: meetingStart, now: now
+                ) == true,
+                "\(option) should show text within grace period"
+            )
+        }
+    }
+
+    @Test("all cases in expected count")
+    func allCasesCount() {
+        #expect(MenuBarLeadTime.allCases.count == 10)
+    }
+}

--- a/Packages/BiscottiKit/Tests/DataStoreTests/SettingsAndQueryTests.swift
+++ b/Packages/BiscottiKit/Tests/DataStoreTests/SettingsAndQueryTests.swift
@@ -41,6 +41,7 @@ struct SettingsTests {
         #expect(result.customVocabulary.isEmpty)
         #expect(result.launchAtLogin == false)
         #expect(result.exitOnWindowClose == false)
+        #expect(result.menuBarLeadTimeSeconds == 3600)
         #expect(result.onboardingComplete == false)
         #expect(result.enabledCalendarIDs == nil)
     }
@@ -59,6 +60,7 @@ struct SettingsTests {
         try await store.updateSettings { settings in
             settings.launchAtLogin = true
             settings.exitOnWindowClose = true
+            settings.menuBarLeadTimeSeconds = 300
             settings.onboardingComplete = true
             settings.customVocabulary = ["Biscotti", "WhisperKit"]
             settings.enabledCalendarIDs = Set(["cal1", "cal2"])
@@ -67,6 +69,7 @@ struct SettingsTests {
         let result = try await store.settings()
         #expect(result.launchAtLogin == true)
         #expect(result.exitOnWindowClose == true)
+        #expect(result.menuBarLeadTimeSeconds == 300)
         #expect(result.onboardingComplete == true)
         #expect(result.customVocabulary == ["Biscotti", "WhisperKit"])
         #expect(result.enabledCalendarIDs == Set(["cal1", "cal2"]))

--- a/Packages/BiscottiKit/Tests/MenuBarUITests/MenuBarViewModelTests.swift
+++ b/Packages/BiscottiKit/Tests/MenuBarUITests/MenuBarViewModelTests.swift
@@ -1,9 +1,9 @@
 import BiscottiTestSupport
 import Calendar
-import DataStore
 import Foundation
 import Testing
 @testable import AppCore
+@testable import DataStore
 @testable import MenuBarUI
 
 // MARK: - Formatting helper tests
@@ -73,54 +73,13 @@ struct MenuBarFormattingTests {
         )
         #expect(result == "in 2h")
     }
-
-    @Test("isWithin2Hours returns true for 1h future")
-    func isWithin2HoursTrue() {
-        let now = Date()
-        let future = now.addingTimeInterval(3600) // 1h
-        #expect(
-            MenuBarViewModel.isWithin2Hours(future, relativeTo: now)
-                == true
-        )
-    }
-
-    @Test("isWithin2Hours returns false for 3h future")
-    func isWithin2HoursFalse() {
-        let now = Date()
-        let future = now.addingTimeInterval(3 * 3600) // 3h
-        #expect(
-            MenuBarViewModel.isWithin2Hours(future, relativeTo: now)
-                == false
-        )
-    }
-
-    @Test("isWithin2Hours returns false for past dates")
-    func isWithin2HoursPast() {
-        let now = Date()
-        let past = now.addingTimeInterval(-60)
-        #expect(
-            MenuBarViewModel.isWithin2Hours(past, relativeTo: now)
-                == false
-        )
-    }
-
-    @Test("isWithin2Hours boundary: exactly 2h returns true")
-    func isWithin2HoursBoundary() {
-        let now = Date()
-        let exactly2h = now.addingTimeInterval(2 * 3600)
-        #expect(
-            MenuBarViewModel.isWithin2Hours(
-                exactly2h, relativeTo: now
-            ) == true
-        )
-    }
 }
 
 // MARK: - Icon state tests
 
 @Suite("MenuBarViewModel -- icon state")
 struct MenuBarIconStateTests {
-    @Test("iconState is idle when not recording and no upcoming within 2h")
+    @Test("iconState is idle when not recording and no upcoming within lead time")
     @MainActor
     func iconIdleNoUpcoming() throws {
         let fix = try makeCoreFixture(testName: "MenuBarTests")
@@ -140,6 +99,132 @@ struct MenuBarIconStateTests {
 
         let model = MenuBarViewModel(core: fix.core)
         #expect(model.iconState == .recording)
+    }
+
+    @Test("iconState shows nextMeeting when event is within lead time")
+    @MainActor
+    func iconShowsNextMeetingWithinLeadTime() async throws {
+        let now = Date()
+        let dtos = [
+            makeDTO(
+                eventIdentifier: "ev-1",
+                title: "Standup",
+                start: now.addingTimeInterval(30 * 60), // 30 min from now
+                end: now.addingTimeInterval(60 * 60)
+            )
+        ]
+
+        let fix = try makeCoreFixture(
+            calendarEventDTOs: dtos,
+            testName: "MenuBarLeadTimeTests"
+        )
+        defer { fix.cleanup() }
+
+        // Default lead time is 1 hour, meeting is 30 min away -> should show
+        try await fix.store.updateSettings {
+            $0.onboardingComplete = true
+        }
+        await fix.core.onLaunch()
+
+        let model = MenuBarViewModel(core: fix.core)
+        if case .nextMeeting = model.iconState {
+            // Expected
+        } else {
+            Issue.record("Expected nextMeeting, got \(model.iconState)")
+        }
+    }
+
+    @Test("iconState is idle when event is outside lead time")
+    @MainActor
+    func iconIdleWhenOutsideLeadTime() async throws {
+        let now = Date()
+        let dtos = [
+            makeDTO(
+                eventIdentifier: "ev-1",
+                title: "Standup",
+                start: now.addingTimeInterval(2 * 3600), // 2h from now
+                end: now.addingTimeInterval(3 * 3600)
+            )
+        ]
+
+        let fix = try makeCoreFixture(
+            calendarEventDTOs: dtos,
+            testName: "MenuBarLeadTimeTests"
+        )
+        defer { fix.cleanup() }
+
+        // Default lead time is 1 hour, meeting is 2h away -> should NOT show
+        try await fix.store.updateSettings {
+            $0.onboardingComplete = true
+        }
+        await fix.core.onLaunch()
+
+        let model = MenuBarViewModel(core: fix.core)
+        #expect(model.iconState == .idle)
+    }
+
+    @Test("iconState respects never setting even with imminent event")
+    @MainActor
+    func iconIdleWhenNever() async throws {
+        let now = Date()
+        let dtos = [
+            makeDTO(
+                eventIdentifier: "ev-1",
+                title: "Standup",
+                start: now.addingTimeInterval(5 * 60), // 5 min from now
+                end: now.addingTimeInterval(60 * 60)
+            )
+        ]
+
+        let fix = try makeCoreFixture(
+            calendarEventDTOs: dtos,
+            testName: "MenuBarLeadTimeTests"
+        )
+        defer { fix.cleanup() }
+
+        // Set to never
+        try await fix.store.updateSettings {
+            $0.onboardingComplete = true
+            $0.menuBarLeadTimeSeconds = MenuBarLeadTime.never.rawValue
+        }
+        await fix.core.onLaunch()
+
+        let model = MenuBarViewModel(core: fix.core)
+        #expect(model.iconState == .idle)
+    }
+
+    @Test("iconState shows event when lead time set to 24h")
+    @MainActor
+    func iconShowsEventWith24hLeadTime() async throws {
+        let now = Date()
+        let dtos = [
+            makeDTO(
+                eventIdentifier: "ev-1",
+                title: "Standup",
+                start: now.addingTimeInterval(12 * 3600), // 12h from now
+                end: now.addingTimeInterval(13 * 3600)
+            )
+        ]
+
+        let fix = try makeCoreFixture(
+            calendarEventDTOs: dtos,
+            testName: "MenuBarLeadTimeTests"
+        )
+        defer { fix.cleanup() }
+
+        // Set to 24 hours
+        try await fix.store.updateSettings {
+            $0.onboardingComplete = true
+            $0.menuBarLeadTimeSeconds = MenuBarLeadTime.twentyFourHours.rawValue
+        }
+        await fix.core.onLaunch()
+
+        let model = MenuBarViewModel(core: fix.core)
+        if case .nextMeeting = model.iconState {
+            // Expected
+        } else {
+            Issue.record("Expected nextMeeting, got \(model.iconState)")
+        }
     }
 }
 

--- a/Packages/BiscottiKit/Tests/SettingsUITests/SettingsViewModelTests.swift
+++ b/Packages/BiscottiKit/Tests/SettingsUITests/SettingsViewModelTests.swift
@@ -1,8 +1,8 @@
 import BiscottiTestSupport
 import Calendar
-import DataStore
 import Permissions
 import Testing
+@testable import DataStore
 @testable import SettingsUI
 
 @Suite("SettingsViewModel")
@@ -332,5 +332,65 @@ struct SettingsViewModelTests {
         let viewModel = SettingsViewModel(core: fixture.core)
         await viewModel.load()
         #expect(viewModel.exitOnWindowClose == true)
+    }
+}
+
+// MARK: - Menu bar lead time
+
+@Suite("SettingsViewModel -- menu bar lead time")
+@MainActor
+struct SettingsMenuBarLeadTimeTests {
+    @Test("menuBarLeadTime defaults to oneHour")
+    func menuBarLeadTimeDefault() throws {
+        let fixture = try makeCoreFixture()
+        defer { fixture.cleanup() }
+        let viewModel = SettingsViewModel(core: fixture.core)
+        #expect(viewModel.menuBarLeadTime == .oneHour)
+    }
+
+    @Test("setMenuBarLeadTime persists and reads back")
+    func setMenuBarLeadTimePersists() async throws {
+        let fixture = try makeCoreFixture()
+        defer { fixture.cleanup() }
+
+        let viewModel = SettingsViewModel(core: fixture.core)
+        await viewModel.load()
+        #expect(viewModel.menuBarLeadTime == .oneHour)
+
+        // Change to 5 minutes
+        await viewModel.setMenuBarLeadTime(.fiveMinutes)
+        #expect(viewModel.menuBarLeadTime == .fiveMinutes)
+
+        // Verify persisted
+        let settings = try await fixture.store.settings()
+        #expect(settings.menuBarLeadTimeSeconds == 300)
+    }
+
+    @Test("setMenuBarLeadTime to never persists zero")
+    func setMenuBarLeadTimeNever() async throws {
+        let fixture = try makeCoreFixture()
+        defer { fixture.cleanup() }
+
+        let viewModel = SettingsViewModel(core: fixture.core)
+        await viewModel.setMenuBarLeadTime(.never)
+        #expect(viewModel.menuBarLeadTime == .never)
+
+        let settings = try await fixture.store.settings()
+        #expect(settings.menuBarLeadTimeSeconds == 0)
+    }
+
+    @Test("load reads menuBarLeadTime from store")
+    func menuBarLeadTimeLoadedFromStore() async throws {
+        let fixture = try makeCoreFixture()
+        defer { fixture.cleanup() }
+
+        // Pre-set the value
+        try await fixture.store.updateSettings { settings in
+            settings.menuBarLeadTimeSeconds = MenuBarLeadTime.sixHours.rawValue
+        }
+
+        let viewModel = SettingsViewModel(core: fixture.core)
+        await viewModel.load()
+        #expect(viewModel.menuBarLeadTime == .sixHours)
     }
 }


### PR DESCRIPTION
## Summary

Adds a **"Show next meeting in menu bar"** setting that controls whether — and how early — the menu bar shows the detailed next-meeting text, replacing the previous hardcoded 2-hour window.

- New `MenuBarLeadTime` enum (DataStore) with 10 options: Never, 5/10/15/30 min, **1 hour (default)**, 2/6/12/24 hours before.
- Detailed text shows when the setting isn't *Never* and now is within `[meeting start − lead time, meeting start + 5 min]`. The **+5 min grace** after start applies to every non-never option (for people running late).
- Persisted via a new `menuBarLeadTimeSeconds` field on `AppSettings` (SwiftData, defaulted → migration-safe) + DTO wiring. `AppCore` caches it at launch and refreshes live via a `.menuBarLeadTimeDidChange` notification — same pattern as the existing `exitOnWindowClose` setting.
- New `Picker` in Settings → General. **The menu bar item's rendering (text/icon) is unchanged** — only the gating logic was touched.

## Tests

23 new tests: `MenuBarLeadTime` boundary/grace/fallback unit tests, icon-state integration tests, and `SettingsViewModel` persistence round-trips. `make ci` (lint + test + build) green via hooks-mcp.

## Notes

Built via `/spec task` with code review on each change. Two commits: the feature, then a copy rename of the setting label to "Show next meeting in menu bar".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
