### PR TITLE
Pin audio transport bar to bottom of meeting panel

### DIFF
--- a/Packages/BiscottiKit/Sources/DesignSystem/AudioTransport.swift
+++ b/Packages/BiscottiKit/Sources/DesignSystem/AudioTransport.swift
@@ -1,8 +1,12 @@
 import SwiftUI
 
 /// Standard audio transport card: play/pause + scrubber + elapsed/total +
-/// speed menu, rendered inside a rounded card.
+/// speed menu, optionally rendered inside a rounded card.
 /// Disabled state grays out controls with an explanation.
+///
+/// Set `showCard` to `false` to render the controls without the rounded
+/// card background/stroke — useful when the transport is embedded in a
+/// pinned bar that supplies its own full-width background.
 public struct AudioTransport: View {
     public let isPlaying: Bool
     public let currentTime: TimeInterval
@@ -10,6 +14,7 @@ public struct AudioTransport: View {
     public let isDisabled: Bool
     public let rate: Float
     public let speedOptions: [Float]
+    public let showCard: Bool
     public let onPlayPause: () -> Void
     public let onSeek: (TimeInterval) -> Void
     public let onRate: (Float) -> Void
@@ -23,6 +28,7 @@ public struct AudioTransport: View {
         isDisabled: Bool,
         rate: Float = 1.0,
         speedOptions: [Float] = [0.5, 1.0, 1.25, 1.5, 2.0],
+        showCard: Bool = true,
         onPlayPause: @escaping () -> Void,
         onSeek: @escaping (TimeInterval) -> Void,
         onRate: @escaping (Float) -> Void = { _ in }
@@ -33,6 +39,7 @@ public struct AudioTransport: View {
         self.isDisabled = isDisabled
         self.rate = rate
         self.speedOptions = speedOptions
+        self.showCard = showCard
         self.onPlayPause = onPlayPause
         self.onSeek = onSeek
         self.onRate = onRate
@@ -48,14 +55,18 @@ public struct AudioTransport: View {
         }
         .padding(.horizontal, Tokens.spacingMD)
         .padding(.vertical, Tokens.spacingSM)
-        .background(
-            RoundedRectangle(cornerRadius: Tokens.cardRadius)
-                .fill(Tokens.cardFill)
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: Tokens.cardRadius)
-                .stroke(Color.cardStroke, lineWidth: 0.5)
-        )
+        .background {
+            if showCard {
+                RoundedRectangle(cornerRadius: Tokens.cardRadius)
+                    .fill(Tokens.cardFill)
+            }
+        }
+        .overlay {
+            if showCard {
+                RoundedRectangle(cornerRadius: Tokens.cardRadius)
+                    .stroke(Color.cardStroke, lineWidth: 0.5)
+            }
+        }
     }
 
     private var enabledContent: some View {

--- a/Packages/BiscottiKit/Sources/DesignSystem/Tokens.swift
+++ b/Packages/BiscottiKit/Sources/DesignSystem/Tokens.swift
@@ -143,6 +143,10 @@ public enum Tokens {
 
     // MARK: - Home Layout
 
+    /// Maximum width for readable content columns (meeting detail,
+    /// event preview, pinned transport bar).
+    public static let readableContentMaxWidth: CGFloat = 760
+
     /// Maximum width for the Home content column.
     public static let homeColumnMaxWidth: CGFloat = 800
 

--- a/Packages/BiscottiKit/Sources/MeetingDetailUI/EventPreviewView.swift
+++ b/Packages/BiscottiKit/Sources/MeetingDetailUI/EventPreviewView.swift
@@ -59,7 +59,7 @@ public struct EventPreviewView: View {
             .padding(.horizontal, Tokens.homeHorizontalPadding)
             .padding(.top, Tokens.homeVerticalPadding)
             .padding(.bottom, Tokens.homeVerticalPadding)
-            .frame(maxWidth: 760, alignment: .leading)
+            .frame(maxWidth: Tokens.readableContentMaxWidth, alignment: .leading)
         }
         .background(Tokens.contentBackground)
         .frame(

--- a/Packages/BiscottiKit/Sources/MeetingDetailUI/MeetingDetailView.swift
+++ b/Packages/BiscottiKit/Sources/MeetingDetailUI/MeetingDetailView.swift
@@ -12,18 +12,23 @@ import TranscriptionService
 ///
 /// Layout: while loading, shows a centered spinner. Once loaded, a
 /// single outer `ScrollView` containing a chrome section (header,
-/// calendar card, transport, tab bar) measured via a preference key,
-/// and a tab-content area sized to fill the remaining viewport. The
-/// Notes editor scrolls internally; the Transcript tab grows with
-/// content and the outer scroll handles it.
+/// calendar card, tab bar) measured via a preference key, and a
+/// tab-content area sized to fill the remaining viewport. The audio
+/// transport bar is pinned to the bottom of the panel via
+/// `safeAreaInset`, staying fixed regardless of scroll position.
+/// The Notes editor scrolls internally; the Transcript tab grows
+/// with content and the outer scroll handles it.
 public struct MeetingDetailView: View {
     @Bindable private var viewModel: MeetingDetailViewModel
 
     /// The selected tab: Transcript (default) or Notes.
     @State private var tab: Tab = .transcript
 
-    /// Measured height of the chrome section (header + calendar + transport + tabs).
+    /// Measured height of the chrome section (header + calendar + tabs).
     @State private var chromeHeight: CGFloat = 0
+
+    /// Measured height of the pinned transport bar at the bottom.
+    @State private var transportHeight: CGFloat = 0
 
     /// Focus state for the inline title TextField. Set to false on
     /// submit so the field resigns first responder and deselects.
@@ -124,7 +129,13 @@ public struct MeetingDetailView: View {
     ///
     /// The ScrollView fills the full pane width (scrollbar at the
     /// window's right edge). Inside, the readable content is capped at
-    /// 760pt and left-aligned, with whitespace filling the right.
+    /// `Tokens.readableContentMaxWidth` and left-aligned, with whitespace
+    /// filling the right.
+    ///
+    /// The `AudioTransport` is pinned to the bottom of the panel via
+    /// `safeAreaInset(edge: .bottom)`, which automatically adjusts the
+    /// scroll content inset and scroll indicator so the last line of
+    /// content is never hidden behind the bar.
     private func loadedContent(geo: GeometryProxy) -> some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 0) {
@@ -138,13 +149,18 @@ public struct MeetingDetailView: View {
             .padding(.horizontal, Tokens.homeHorizontalPadding)
             .padding(.top, Tokens.homeVerticalPadding)
             .padding(.bottom, Tokens.homeVerticalPadding)
-            .frame(maxWidth: 760, alignment: .leading)
+            .frame(maxWidth: Tokens.readableContentMaxWidth, alignment: .leading)
             .frame(maxWidth: .infinity, alignment: .leading)
         }
         .onPreferenceChange(ChromeHeightKey.self) { chromeHeight = $0 }
+        .onPreferenceChange(TransportHeightKey.self) { transportHeight = $0 }
+        .safeAreaInset(edge: .bottom, spacing: 0) {
+            pinnedTransportBar
+        }
     }
 
-    /// Height available for tab content after subtracting chrome and padding.
+    /// Height available for tab content after subtracting chrome, padding,
+    /// and the pinned transport bar.
     ///
     /// The caller applies a 250pt floor via `max(250, contentFill(...))` so
     /// the notes editor stays usable in small windows. In normal/large
@@ -154,12 +170,16 @@ public struct MeetingDetailView: View {
     /// **Layout coupling:** the `verticalOverhead` constant mirrors the
     /// padding and divider in `loadedContent(geo:)`. If you change the
     /// padding values or divider there, update this calculation to match.
+    /// The `transportHeight` is measured via `TransportHeightKey` in
+    /// `pinnedTransportBar` — it accounts for the bottom `safeAreaInset`
+    /// that the outer `GeometryReader` does not subtract from its reported
+    /// size.
     private func contentFill(viewportHeight: CGFloat) -> CGFloat {
         let verticalOverhead =
             Tokens.homeVerticalPadding * 2 // top + bottom page padding
             + Tokens.spacingMD * 2 // divider vertical padding
             + 1 // divider pixel height
-        return max(0, viewportHeight - chromeHeight - verticalOverhead)
+        return max(0, viewportHeight - chromeHeight - transportHeight - verticalOverhead)
     }
 
     // MARK: - Tabs
@@ -359,8 +379,49 @@ public struct MeetingDetailView: View {
 // MARK: - Chrome sub-views
 
 private extension MeetingDetailView {
-    /// Header + calendar card + transport + tab bar, measured for the
-    /// chrome-height preference key.
+    /// Audio transport pinned to the bottom of the panel. Full-width
+    /// background (Liquid Glass on macOS 26+, vibrancy material on older);
+    /// inner content capped to the readable column width and left-aligned
+    /// to line up with content above. The transport renders without its
+    /// own rounded card (`showCard: false`) since the bar itself provides
+    /// the surface.
+    var pinnedTransportBar: some View {
+        VStack(spacing: 0) {
+            Divider()
+
+            AudioTransport(
+                isPlaying: viewModel.isPlaying,
+                currentTime: viewModel.playbackCurrentTime,
+                duration: viewModel.playbackDuration,
+                isDisabled: !viewModel.canPlay,
+                rate: viewModel.playbackRate,
+                speedOptions: MeetingDetailViewModel.speedOptions,
+                showCard: false,
+                onPlayPause: { viewModel.playPause() },
+                onSeek: { viewModel.seek(to: $0) },
+                onRate: { viewModel.setPlaybackRate($0) }
+            )
+            .padding(.horizontal, Tokens.homeHorizontalPadding)
+            .padding(.vertical, Tokens.spacingSM)
+            .frame(
+                maxWidth: Tokens.readableContentMaxWidth,
+                alignment: .leading
+            )
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .pinnedBarBackground()
+        .background(GeometryReader { transportProxy in
+            Color.clear
+                .preference(
+                    key: TransportHeightKey.self,
+                    value: transportProxy.size.height
+                )
+        })
+    }
+
+    /// Header + calendar card + tab bar, measured for the chrome-height
+    /// preference key. AudioTransport is now pinned to the bottom of
+    /// the panel (see `pinnedTransportBar`), outside this scroll region.
     var chrome: some View {
         VStack(alignment: .leading, spacing: Tokens.spacingMD) {
             header
@@ -375,18 +436,6 @@ private extension MeetingDetailView {
                     onOpenInCalendar: { viewModel.openInCalendar() }
                 )
             }
-
-            AudioTransport(
-                isPlaying: viewModel.isPlaying,
-                currentTime: viewModel.playbackCurrentTime,
-                duration: viewModel.playbackDuration,
-                isDisabled: !viewModel.canPlay,
-                rate: viewModel.playbackRate,
-                speedOptions: MeetingDetailViewModel.speedOptions,
-                onPlayPause: { viewModel.playPause() },
-                onSeek: { viewModel.seek(to: $0) },
-                onRate: { viewModel.setPlaybackRate($0) }
-            )
 
             tabBar
         }
@@ -735,12 +784,39 @@ private extension MeetingDetailView {
     }
 }
 
-// MARK: - Chrome height preference key
+// MARK: - Layout preference keys
 
 private struct ChromeHeightKey: PreferenceKey {
     static let defaultValue: CGFloat = 0
     static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
         value = max(value, nextValue())
+    }
+}
+
+private struct TransportHeightKey: PreferenceKey {
+    static let defaultValue: CGFloat = 0
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = max(value, nextValue())
+    }
+}
+
+// MARK: - Pinned bar background (glass / vibrancy)
+
+/// Applies Liquid Glass on macOS 26+ and falls back to the vibrancy
+/// material on older macOS versions.
+private struct PinnedBarBackgroundModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        if #available(macOS 26.0, *) {
+            content.glassEffect(.regular, in: Rectangle())
+        } else {
+            content.background(.ultraThinMaterial)
+        }
+    }
+}
+
+private extension View {
+    func pinnedBarBackground() -> some View {
+        modifier(PinnedBarBackgroundModifier())
     }
 }
 

--- a/Packages/BiscottiKit/Sources/MeetingDetailUI/TranscriptContent.swift
+++ b/Packages/BiscottiKit/Sources/MeetingDetailUI/TranscriptContent.swift
@@ -31,9 +31,12 @@ public enum TranscriptContent {
             speaker.foregroundColor = speakerColor(for: segment.speakerLabel)
             result.append(speaker)
 
-            // Two spaces + timestamp
+            // Two spaces + timestamp (+ play glyph when seekable)
             let timeText = TimeFormatting.formatPlaybackTime(segment.startTime)
-            var timestamp = AttributedString("  \(timeText)")
+            let timestampLabel = canSeek
+                ? "  \(timeText) \u{25B6}\u{FE0E}"
+                : "  \(timeText)"
+            var timestamp = AttributedString(timestampLabel)
             timestamp.font = Font.biscottiMono(12)
             timestamp.foregroundColor = Color.inkTertiary
             if canSeek {

--- a/Packages/BiscottiKit/Tests/MeetingDetailUITests/TranscriptContentTests.swift
+++ b/Packages/BiscottiKit/Tests/MeetingDetailUITests/TranscriptContentTests.swift
@@ -155,6 +155,45 @@ struct TranscriptContentAttributedStringTests {
         )
         #expect(attributed.characters.isEmpty)
     }
+
+    @Test("includes play glyph when canSeek is true")
+    func playGlyphPresent() {
+        let segments = [
+            SegmentData(
+                id: UUID(),
+                speakerLabel: "Speaker 0",
+                startTime: 5,
+                endTime: 10,
+                text: "Hello"
+            )
+        ]
+        let attributed = TranscriptContent.attributedString(
+            segments, canSeek: true
+        )
+        let plain = String(attributed.characters)
+
+        // U+25B6 (black right-pointing triangle) + U+FE0E (text presentation)
+        #expect(plain.contains("\u{25B6}\u{FE0E}"))
+    }
+
+    @Test("omits play glyph when canSeek is false")
+    func playGlyphAbsent() {
+        let segments = [
+            SegmentData(
+                id: UUID(),
+                speakerLabel: "Speaker 0",
+                startTime: 5,
+                endTime: 10,
+                text: "Hello"
+            )
+        ]
+        let attributed = TranscriptContent.attributedString(
+            segments, canSeek: false
+        )
+        let plain = String(attributed.characters)
+
+        #expect(!plain.contains("\u{25B6}"))
+    }
 }
 
 // MARK: - Speaker color


### PR DESCRIPTION
## Summary

Pins the audio playback/transport bar to the bottom of the meeting detail panel so it stays visible regardless of scroll position.

- Moves `AudioTransport` out of the scrolling `chrome` region and pins it to the bottom of the panel via `.safeAreaInset(edge: .bottom)`. The bar stays fixed while transcript/notes scroll underneath.
- **Full-width bar, capped content:** the bar background spans the full panel width, but the inner controls are capped to the readable column (`Tokens.readableContentMaxWidth`, 760pt) and left-aligned so they line up with the content above.
- **Flat bar, no card:** added a `showCard` option to the shared `AudioTransport` (defaults `true`, so existing uses are unchanged); the pinned bar renders card-less.
- **Glass on newer macOS, vibrancy on older:** a `PinnedBarBackgroundModifier` uses `.glassEffect` (Liquid Glass) on macOS 26+ behind an `#available` guard, falling back to `.ultraThinMaterial` on older macOS.
- **Scroll offset:** `safeAreaInset` adjusts the scroll content inset and indicator so the last line scrolls fully into view above the bar and the scrollbar sits above it. `contentFill` now subtracts the measured pinned-bar height (new `TransportHeightKey`) so content doesn't overshoot behind the bar on initial render.
- **Discoverable seek links:** seekable transcript timestamps now render as `3:15 ▶︎`, with the glyph inside the same `.link` run so the whole thing is one tappable seek affordance.
- Extracted the previously hard-coded `760` literal into `Tokens.readableContentMaxWidth`, shared across `MeetingDetailView` and `EventPreviewView`.

## Testing

- `make precommit-checks` green: format, lint, 1,191 tests across BiscottiKit / Transcription / AudioCapture.
- Added unit tests covering the play-glyph presence (`canSeek` true) and absence (`canSeek` false).
- UI reviewed and approved by the author on real hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)