### PR TITLE
Fix speaker.aac garbage audio after device/tap toggling

### DIFF
--- a/ManualTestApp/Results/manual_test_results.json
+++ b/ManualTestApp/Results/manual_test_results.json
@@ -2,69 +2,69 @@
   "ac_crash_safety_check" : {
     "status" : "pass",
     "stepID" : "ac_crash_safety_check",
-    "timestamp" : "2026-06-10T21:33:39Z"
+    "timestamp" : "2026-06-17T02:00:18Z"
   },
   "ac_files_exist" : {
     "note" : "Both .aac files exist with sane sizes",
     "status" : "pass",
     "stepID" : "ac_files_exist",
-    "timestamp" : "2026-06-10T03:50:23Z"
+    "timestamp" : "2026-06-17T01:42:55Z"
   },
   "ac_meet_close_midcapture" : {
     "status" : "pass",
     "stepID" : "ac_meet_close_midcapture",
-    "timestamp" : "2026-06-10T03:50:34Z"
+    "timestamp" : "2026-06-17T01:49:03Z"
   },
   "ac_meet_open_midcapture" : {
     "status" : "pass",
     "stepID" : "ac_meet_open_midcapture",
-    "timestamp" : "2026-06-10T21:28:37Z"
+    "timestamp" : "2026-06-17T01:49:54Z"
   },
   "ac_mega_timing" : {
     "status" : "pass",
     "stepID" : "ac_mega_timing",
-    "timestamp" : "2026-06-10T21:32:56Z"
+    "timestamp" : "2026-06-17T02:00:13Z"
   },
   "ac_mega_voice" : {
-    "note" : "some jitter as devices changed, but always stabilized. all modes work",
     "status" : "pass",
     "stepID" : "ac_mega_voice",
-    "timestamp" : "2026-06-10T21:32:53Z"
+    "timestamp" : "2026-06-17T02:00:10Z"
   },
   "ac_playback_mic" : {
     "status" : "pass",
     "stepID" : "ac_playback_mic",
-    "timestamp" : "2026-06-10T03:50:26Z"
+    "timestamp" : "2026-06-17T01:43:26Z"
   },
   "ac_playback_system" : {
     "status" : "pass",
     "stepID" : "ac_playback_system",
-    "timestamp" : "2026-06-10T03:50:27Z"
+    "timestamp" : "2026-06-17T01:43:27Z"
   },
   "ac_request_permissions" : {
     "status" : "pass",
     "stepID" : "ac_request_permissions",
-    "timestamp" : "2026-06-10T03:49:34Z"
+    "timestamp" : "2026-06-17T01:42:38Z"
   },
   "ac_route_change" : {
-    "status" : "pass",
+    "note" : "this fails, but I learned this never worked, past passes were poor testing. Okay to check in this failure, it's real failure. The input device isn't updating on new default input device.",
+    "status" : "fail",
     "stepID" : "ac_route_change",
-    "timestamp" : "2026-06-10T03:50:31Z"
+    "timestamp" : "2026-06-17T01:46:20Z"
   },
   "ac_start_recording" : {
     "status" : "pass",
     "stepID" : "ac_start_recording",
-    "timestamp" : "2026-06-10T21:33:14Z"
+    "timestamp" : "2026-06-17T01:50:04Z"
   },
   "ac_stop_recording" : {
     "status" : "pass",
     "stepID" : "ac_stop_recording",
-    "timestamp" : "2026-06-10T21:30:29Z"
+    "timestamp" : "2026-06-17T01:51:03Z"
   },
   "ac_two_dialogs" : {
     "status" : "pass",
     "stepID" : "ac_two_dialogs",
-    "timestamp" : "2026-06-10T03:49:37Z"
+    "timestamp" : "2026-06-17T01:42:39Z"
   },
   "tx_ai_test_passed" : {
     "status" : "pass",

--- a/Packages/AudioCapture/Sources/AudioCapture/LiveSystemCaptureEngine.swift
+++ b/Packages/AudioCapture/Sources/AudioCapture/LiveSystemCaptureEngine.swift
@@ -34,6 +34,14 @@ final class LiveSystemCaptureEngine: CaptureEngine, @unchecked Sendable { // swi
     private var clientFormatConfigured = false
     private var clientFormatFailed = false
 
+    /// The channel count used in the last successful `configureClientFormat`
+    /// call. Compared on reconnect to avoid a redundant
+    /// `kExtAudioFileProperty_ClientDataFormat` set (which replaces the
+    /// AAC encoder's internal AudioConverter mid-stream -- harmless when
+    /// the format genuinely changed, but a needless converter reset and
+    /// potential flush of stale encoder state when it didn't).
+    private var lastConfiguredChannelCount: UInt32 = 0
+
     // MARK: - Two-track alignment
 
     /// Host-clock seconds of the mic's first delivered sample -- the
@@ -93,6 +101,10 @@ final class LiveSystemCaptureEngine: CaptureEngine, @unchecked Sendable { // swi
     func start(writingTo url: URL) async throws {
         guard !capturingFlag.load(ordering: .acquiring) else { return }
 
+        // Clear any write error from a previous session (e.g. permission
+        // probe) so a fresh start reports only its own errors.
+        clearWriteError()
+
         // New session: restart the permission zero-detection window. A start()
         // can legitimately run again after a *failed* start (the recorder stays
         // retryable); without this the window stays closed and silent-system
@@ -134,26 +146,76 @@ final class LiveSystemCaptureEngine: CaptureEngine, @unchecked Sendable { // swi
         teardown()
     }
 
-    /// Reconnects hardware without reopening the audio file. Resets
-    /// client-format gating so a post-reconnect device delivering a
-    /// different channel count re-configures the ExtAudioFile client
-    /// format (the AAC output format is unchanged; only the PCM input
-    /// side adapts). Leading silence is NOT re-written: the alignment
-    /// was established on the first buffer of the session.
+    /// Reconnects hardware without reopening the audio file.
+    ///
+    /// Re-queries the new tap's format and updates `tapSampleRate` so
+    /// the ExtAudioFile client format matches the data the new IOProc
+    /// delivers. Only resets the client-format flag (triggering a
+    /// mid-stream `kExtAudioFileProperty_ClientDataFormat` set and AAC
+    /// converter replacement) when the tap's rate or channel count
+    /// actually changed -- avoiding a disruptive converter reset when
+    /// the format is identical.
+    ///
+    /// Leading silence is NOT re-written: alignment was established on
+    /// the first buffer of the session.
     func reconnect() async throws {
         guard capturingFlag.load(ordering: .acquiring) else { return }
         teardownHardware()
 
-        // Allow the first post-reconnect buffer to re-set the client
-        // format, accommodating a new device's channel count.
-        clientFormatConfigured = false
-        clientFormatFailed = false
-
         do {
             try createTapAndAggregate()
+
+            // Query the new tap's format. If the sample rate or channel
+            // count changed, the ExtAudioFile client format must be
+            // updated so the encoder interprets incoming buffers at the
+            // correct rate/layout. A stale tapSampleRate caused the AAC
+            // encoder to misinterpret every buffer's duration, inflating
+            // or deflating the file and producing garbage audio.
+            var formatChanged = false
+            if let newFormat = queryTapFormat() {
+                let oldRate = tapSampleRate
+                tapSampleRate = newFormat.mSampleRate
+                if abs(oldRate - tapSampleRate) > 1 {
+                    logger.info(
+                        "Reconnect: tap sample rate changed \(oldRate) → \(newFormat.mSampleRate)"
+                    )
+                    formatChanged = true
+                }
+                let prevChannels = lastConfiguredChannelCount
+                if newFormat.mChannelsPerFrame != prevChannels {
+                    logger.info(
+                        "Reconnect: tap channel count changed \(prevChannels) → \(newFormat.mChannelsPerFrame)"
+                    )
+                    formatChanged = true
+                }
+            } else {
+                // Can't query -- force reconfigure to be safe.
+                formatChanged = true
+            }
+
+            if formatChanged {
+                clientFormatConfigured = false
+                clientFormatFailed = false
+            }
+
+            #if DEBUG
+                if Self.verboseDiagnostics {
+                    SystemCaptureDiagnostics.logSetupFormats(
+                        tapObjectID: tapObjectID,
+                        aggregateDeviceID: aggregateDeviceID
+                    )
+                }
+            #endif
+
             startWriterThread()
             try startIOProc()
         } catch {
+            // Partial-reconnect cleanup: tear down any hardware and the
+            // writer thread that were created before the throw. Without
+            // this, a failed startIOProc() leaks a running writer
+            // thread and orphaned aggregate/tap, and the capturingFlag
+            // reset below prevents stop() from ever cleaning them up.
+            teardownHardware()
             capturingFlag.store(false, ordering: .releasing)
             throw error
         }
@@ -250,8 +312,12 @@ final class LiveSystemCaptureEngine: CaptureEngine, @unchecked Sendable { // swi
         guard let file = audioFile else { return }
         guard !clientFormatFailed else { return }
 
-        // First buffer: set client format from actual delivered channel
-        // count (ground truth). ExtAudioFile handles N-ch → mono downmix.
+        // First buffer (or first after reconnect): set client format from
+        // actual delivered channel count (ground truth). ExtAudioFile
+        // handles N-ch → mono downmix. On reconnect the flag is cleared
+        // ONLY if the tap's channel count or sample rate actually changed
+        // -- skipping the mid-stream converter replacement when the format
+        // is identical avoids disrupting the AAC encoder's internal state.
         if !clientFormatConfigured {
             if configureClientFormat(
                 channelCount: UInt32(channelCount), file: file
@@ -305,9 +371,15 @@ final class LiveSystemCaptureEngine: CaptureEngine, @unchecked Sendable { // swi
         }
     }
 
-    private func recordWriteError(_ status: OSStatus) {
+    private nonisolated func recordWriteError(_ status: OSStatus) {
         os_unfair_lock_lock(&_lock)
         if _writeError == nil { _writeError = status }
+        os_unfair_lock_unlock(&_lock)
+    }
+
+    private nonisolated func clearWriteError() {
+        os_unfair_lock_lock(&_lock)
+        _writeError = nil
         os_unfair_lock_unlock(&_lock)
     }
 
@@ -492,6 +564,7 @@ extension LiveSystemCaptureEngine {
         tapSampleRate = tapFormat.mSampleRate
         clientFormatConfigured = false
         clientFormatFailed = false
+        lastConfiguredChannelCount = 0
 
         // Create ADTS AAC file. Client format deferred to processEntry()
         // where the actual channel count is known from IOProc data.
@@ -530,6 +603,11 @@ extension LiveSystemCaptureEngine {
     private func configureClientFormat(
         channelCount: UInt32, file: ExtAudioFileRef
     ) -> Bool {
+        let rate = tapSampleRate
+        logger.info(
+            "Configuring client format: rate=\(rate) ch=\(channelCount)"
+        )
+
         let bytesPerFrame = UInt32(MemoryLayout<Float>.size) * channelCount
         var clientASBD = AudioStreamBasicDescription(
             mSampleRate: tapSampleRate,
@@ -558,6 +636,8 @@ extension LiveSystemCaptureEngine {
         if brStatus != noErr {
             logger.warning("applyBitRate returned \(brStatus) — using encoder default")
         }
+
+        lastConfiguredChannelCount = channelCount
         return true
     }
 }


### PR DESCRIPTION
Root cause: reconnect() did not re-query the new process tap's sample rate after tearing down and recreating the tap + aggregate device on an audio route change. The stale tapSampleRate was passed to configureClientFormat(), causing the AAC encoder to misinterpret every post-reconnect buffer's duration — inflating the file with interleaved garbage audio fragments.

The fix:
- Query the new tap's format in reconnect() and update tapSampleRate to match. Only reset the client-format flag (triggering a mid-stream AAC converter replacement) when the tap's sample rate or channel count actually changed, avoiding a disruptive converter reset when the format is identical.
- Fix reconnect() error path: call teardownHardware() before setting capturingFlag = false, preventing leaked writer threads and orphaned Core Audio resources that stop() could never clean up.
- Track lastConfiguredChannelCount to detect channel-count changes across reconnects.
- Add clearWriteError() to reset stale write errors on start(); mark both lock-guarded helpers (recordWriteError, clearWriteError) as nonisolated for consistency under Swift 6 strict concurrency.

Manual test results updated: all ac_* steps re-verified on real Apple-silicon hardware. One pre-existing failure (ac_route_change: mic input device not following default input device change) recorded as-is.