### PR TITLE
Notes editor: use .fitsContent height behavior (no nested scroll view)

### DIFF
--- a/Packages/BiscottiKit/Package.resolved
+++ b/Packages/BiscottiKit/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "dbf198980fef22140e65c65be2e69229e32193a66f73827fdc45452b20294db6",
+  "originHash" : "caa765d173c93fab204e871417b49f92c4e2dbcb19561e377f321bbf875dd60d",
   "pins" : [
     {
       "identity" : "argmax-oss-swift",
@@ -31,10 +31,9 @@
     {
       "identity" : "swift-markdown-engine",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/nodes-app/swift-markdown-engine",
+      "location" : "https://github.com/scosman/swift-markdown-engine",
       "state" : {
-        "revision" : "301c4a554f87eb473ee649eb588250cca7918125",
-        "version" : "0.7.0"
+        "revision" : "6edaa33637bcfc39272415f635c5f2ed6ff2853b"
       }
     },
     {

--- a/Packages/BiscottiKit/Package.swift
+++ b/Packages/BiscottiKit/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
     dependencies: [
         .package(name: "Transcription", path: "../Transcription"),
         .package(name: "AudioCapture", path: "../AudioCapture"),
-        .package(url: "https://github.com/nodes-app/swift-markdown-engine", exact: "0.7.0")
+        .package(url: "https://github.com/scosman/swift-markdown-engine", revision: "6edaa33637bcfc39272415f635c5f2ed6ff2853b")
     ],
     targets: [
         .target(

--- a/Packages/BiscottiKit/Sources/MarkdownEditorUI/MarkdownEditor.swift
+++ b/Packages/BiscottiKit/Sources/MarkdownEditorUI/MarkdownEditor.swift
@@ -6,16 +6,22 @@ import SwiftUI
 ///
 /// Wraps the third-party `NativeTextViewWrapper` from `MarkdownEngine`
 /// with the F Sage color palette, dimmed markers (hide-on-blur), and
-/// prose-friendly defaults. Callers interact with a plain markdown
-/// `String` binding and never see the engine's configuration object.
+/// prose-friendly defaults. Uses `.fitsContent` height behavior so the
+/// editor grows to fit its content instead of scrolling internally --
+/// the enclosing page scroll view handles overflow.
+///
+/// Callers interact with a plain markdown `String` binding and never
+/// see the engine's configuration object.
 ///
 /// ```swift
-/// MarkdownEditor(
-///     text: $notes,
-///     documentId: meeting.id.uuidString,
-///     placeholder: "Add notes..."
-/// )
-/// .frame(minHeight: 120, maxHeight: 340)
+/// ScrollView {
+///     MarkdownEditor(
+///         text: $notes,
+///         documentId: meeting.id.uuidString,
+///         placeholder: "Add notes..."
+///     )
+///     .frame(minHeight: 120)
+/// }
 /// ```
 public struct MarkdownEditor: View {
     @Binding private var text: String
@@ -85,13 +91,15 @@ public struct MarkdownEditor: View {
         """
 
         var body: some View {
-            MarkdownEditor(
-                text: $text,
-                documentId: "preview",
-                placeholder: "Add notes..."
-            )
-            .frame(minHeight: 200, maxHeight: 400)
-            .padding()
+            ScrollView {
+                MarkdownEditor(
+                    text: $text,
+                    documentId: "preview",
+                    placeholder: "Add notes..."
+                )
+                .frame(minHeight: 120)
+                .padding()
+            }
             .background(Color.paper)
         }
     }

--- a/Packages/BiscottiKit/Sources/MarkdownEditorUI/MarkdownEditorConfiguration+Biscotti.swift
+++ b/Packages/BiscottiKit/Sources/MarkdownEditorUI/MarkdownEditorConfiguration+Biscotti.swift
@@ -16,7 +16,10 @@ public extension MarkdownEditorConfiguration {
     ///   AND a negative kern to collapse layout advance, so setting
     ///   `hiddenMarkerFontSize` to body size causes text overlap.)
     /// - Prose-friendly defaults (auto-close pairs off, list helpers on).
-    /// - Reduced overscroll for a bounded inline editor box.
+    /// - `.fitsContent` height behavior: the editor grows to fit its
+    ///   content instead of scrolling internally, so the enclosing page
+    ///   scroll view handles overflow (no nested scroll region).
+    /// - Minimal overscroll (effectively zero in fitsContent mode).
     /// - No wiki-link, image-embed, syntax-highlight, or LaTeX services.
     ///
     static func biscotti() -> MarkdownEditorConfiguration {
@@ -43,7 +46,8 @@ public extension MarkdownEditorConfiguration {
             lists: ListStyle(helpersEnabled: true, autoClosePairsEnabled: false),
             overscroll: OverscrollPolicy(percent: 0, maxPoints: 8, minPoints: 4),
             textInsets: TextInsets(horizontal: 8, vertical: 8),
-            readingWidth: nil
+            readingWidth: nil,
+            heightBehavior: .fitsContent
         )
     }
 }

--- a/Packages/BiscottiKit/Sources/MeetingDetailUI/MeetingDetailView.swift
+++ b/Packages/BiscottiKit/Sources/MeetingDetailUI/MeetingDetailView.swift
@@ -12,11 +12,11 @@ import TranscriptionService
 /// Layout: while loading, shows a centered spinner. Once loaded, a
 /// single outer `ScrollView` containing a chrome section (header,
 /// calendar card, tab bar) measured via a preference key, and a
-/// tab-content area sized to fill the remaining viewport. The audio
-/// transport bar is pinned to the bottom of the panel via
-/// `safeAreaInset`, staying fixed regardless of scroll position.
-/// The Notes editor scrolls internally; the Transcript tab grows
-/// with content and the outer scroll handles it.
+/// tab-content area. The audio transport bar is pinned to the bottom
+/// of the panel via `safeAreaInset`, staying fixed regardless of
+/// scroll position. Both the Notes editor (via `.fitsContent`) and
+/// the Transcript tab grow with content -- the outer scroll handles
+/// overflow for both.
 public struct MeetingDetailView: View {
     @Bindable private var viewModel: MeetingDetailViewModel
 
@@ -507,9 +507,11 @@ private extension MeetingDetailView {
         }
     }
 
-    /// Notes tab: MarkdownEditor sized to fill the remaining viewport.
-    /// A transparent click-forwarder sits behind the editor so clicking
-    /// empty space below the placeholder focuses the text view.
+    /// Notes tab: MarkdownEditor grows to fit its content (`.fitsContent`
+    /// height behavior). The outer page scroll view handles overflow -- no
+    /// nested scroll region. The min-height fills available viewport space
+    /// (floored at 100pt) so the editor is a large click target even when
+    /// empty, but content taller than the viewport still grows the page.
     func notesTabContent(fill: CGFloat) -> some View {
         MarkdownEditor(
             text: Binding(
@@ -519,12 +521,8 @@ private extension MeetingDetailView {
             documentId: viewModel.meetingID.uuidString,
             placeholder: "Add notes\u{2026}"
         )
-        .frame(height: fill)
+        .frame(minHeight: max(100, fill), alignment: .top)
         .background(TextViewFocusForwarder())
-        .overlay(
-            RoundedRectangle(cornerRadius: Tokens.buttonRadius)
-                .stroke(Color.cardStroke, lineWidth: 0.5)
-        )
     }
 }
 
@@ -693,10 +691,11 @@ private extension View {
 // MARK: - Click-to-focus helper for the MarkdownEditor
 
 /// An `NSViewRepresentable` that catches mouse clicks in the empty area
-/// of the MarkdownEditor's scroll view and makes the `NSTextView` the
+/// below the MarkdownEditor's content and makes the `NSTextView` the
 /// first responder. Placed as a `.background` of the editor so it sits
-/// behind the scroll view and only receives clicks that the text view
-/// itself doesn't consume (i.e. clicks below the text content).
+/// behind the content and only receives clicks that the text view
+/// itself doesn't consume (i.e. clicks in the minHeight region below
+/// the last line of text).
 private struct TextViewFocusForwarder: NSViewRepresentable {
     func makeNSView(context _: Context) -> FocusForwarderView {
         FocusForwarderView()

--- a/Packages/BiscottiKit/Tests/MarkdownEditorUITests/MarkdownEditorConfigurationTests.swift
+++ b/Packages/BiscottiKit/Tests/MarkdownEditorUITests/MarkdownEditorConfigurationTests.swift
@@ -79,17 +79,17 @@ struct MarkdownEditorConfigurationTests {
 
     // MARK: - Overscroll
 
-    @Test("overscroll percent is zero for bounded box")
+    @Test("overscroll percent is zero in fitsContent mode")
     func overscrollPercentZero() {
         #expect(config.overscroll.percent == 0)
     }
 
-    @Test("overscroll maxPoints is small for bounded box")
+    @Test("overscroll maxPoints is small in fitsContent mode")
     func overscrollMaxPointsSmall() {
         #expect(config.overscroll.maxPoints <= 10)
     }
 
-    @Test("overscroll minPoints is small for bounded box")
+    @Test("overscroll minPoints is small in fitsContent mode")
     func overscrollMinPointsSmall() {
         #expect(config.overscroll.minPoints <= 5)
     }
@@ -137,6 +137,13 @@ struct MarkdownEditorConfigurationTests {
                 == defaultSpelling.continuousSpellChecking
         )
         #expect(config.spellChecking.grammarChecking == defaultSpelling.grammarChecking)
+    }
+
+    // MARK: - Height behavior
+
+    @Test("heightBehavior is fitsContent (no nested scroll)")
+    func heightBehaviorFitsContent() {
+        #expect(config.heightBehavior == .fitsContent)
     }
 }
 


### PR DESCRIPTION
Migrate the notes markdown editor to swift-markdown-engine's .fitsContent height behavior so the editor grows to fit its content and the outer page ScrollView handles overflow — eliminating the nested scroll region.

- Add heightBehavior: .fitsContent to the biscotti() editor configuration
- Remove the fixed .frame(height: fill) pin on the notes tab; replace with .frame(minHeight: max(100, fill), alignment: .top) so the editor fills available viewport space (large click target) but grows past it when content is longer
- Drop the outline/stroke overlay on the notes editor (no longer needed without the self-scrolling box)
- Top-align content so placeholder and short notes start at the top
- Update MarkdownEditor doc comments, preview, and test descriptions
- Pin dependency to github.com/scosman/swift-markdown-engine @ 6edaa336