### PR TITLE
Notification UI: settings, presentation/copy, and Stay-Visible nudge

### DIFF
--- a/App/Sources/BiscottiApp.swift
+++ b/App/Sources/BiscottiApp.swift
@@ -581,11 +581,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate,
         let userInfo = response.notification.request.content.userInfo
 
         // Forward the typed action to NotificationService's actions() stream.
-        // NOTE: Join URL opening is handled HERE in the delegate (below),
-        // not via the actions() stream. AppCore's consumer intentionally
-        // `break`s on .join to stay AppKit-free. If this delegate is ever
-        // refactored to stop opening URLs directly, update AppCore's
-        // .join case to handle it instead.
         let recognized = notificationService?.handleResponseValues(
             categoryID: categoryID,
             actionID: actionID,
@@ -594,21 +589,28 @@ final class AppDelegate: NSObject, NSApplicationDelegate,
 
         // If the action was not a recognized notification category, bail.
         if !recognized { return }
-        if actionID == "biscotti.action.join",
+
+        // Open the call link for Record & Join (button or body-tap on a
+        // link-bearing calendar notification).
+        if categoryID == "biscotti.meeting-starting-with-join",
+           actionID == "biscotti.action.record-and-join"
+           || actionID == UNNotificationDefaultActionIdentifier,
            let urlString = userInfo["biscotti.joinURL"] as? String,
            let url = URL(string: urlString)
         {
             NSWorkspace.shared.open(url)
         }
 
-        // Activate the app for foreground actions.
+        // Foreground Biscotti only for ad-hoc Record and Keep-Recording --
+        // never for calendar notifications (the browser/meeting app is
+        // foregrounded by the link-open instead).
+        let isAdHocRecord = categoryID == "biscotti.ad-hoc-detected"
+            && (actionID == "biscotti.action.record"
+                || actionID == UNNotificationDefaultActionIdentifier)
         let isKeepRecording = actionID == "biscotti.action.keep-recording"
             || (actionID == UNNotificationDefaultActionIdentifier
                 && categoryID == "biscotti.stop-countdown")
-        if actionID == "biscotti.action.open-and-record"
-            || actionID == "biscotti.action.record"
-            || isKeepRecording
-        {
+        if isAdHocRecord || isKeepRecording {
             showMainWindow()
         }
     }

--- a/Packages/BiscottiKit/Sources/AppCore/AppCore.swift
+++ b/Packages/BiscottiKit/Sources/AppCore/AppCore.swift
@@ -35,6 +35,24 @@ public extension Notification.Name {
     static let globalRecordShortcutDidChange = Notification.Name(
         "net.scosman.biscotti.globalRecordShortcutDidChange"
     )
+
+    /// Posted after the "monitor for meetings" setting is toggled.
+    /// AppCore observes this to refresh its cached flag.
+    static let monitorForMeetingsDidChange = Notification.Name(
+        "net.scosman.biscotti.monitorForMeetingsDidChange"
+    )
+
+    /// Posted after the "calendar event notifications" mode is changed.
+    /// AppCore observes this to refresh its cached mode and reschedule timers.
+    static let calendarNotificationModeDidChange = Notification.Name(
+        "net.scosman.biscotti.calendarNotificationModeDidChange"
+    )
+
+    /// Posted after the "stop recording automatically" setting is toggled.
+    /// AppCore observes this to refresh its cached flag.
+    static let stopRecordingAutomaticallyDidChange = Notification.Name(
+        "net.scosman.biscotti.stopRecordingAutomaticallyDidChange"
+    )
 }
 
 // MARK: - Deep-link jump state
@@ -174,6 +192,18 @@ public final class AppCore {
     /// the menu bar shows the detailed "next meeting" text.
     public private(set) var menuBarLeadTime: MenuBarLeadTime = .oneHour
 
+    /// Cached "monitor for meetings" toggle. Gates whether detection
+    /// notifications are presented (the monitor itself always runs).
+    public private(set) var monitorForMeetings = true
+
+    /// Cached calendar notification mode. Gates which calendar events
+    /// trigger pre-meeting notifications.
+    public private(set) var calendarNotificationMode: CalendarNotificationMode = .allMeetings
+
+    /// Cached "stop recording automatically" toggle. Gates whether the
+    /// auto-stop countdown fires when mic users leave.
+    public private(set) var stopRecordingAutomatically = true
+
     // MARK: - Child services (publicly readable for the UI layer)
 
     /// The persistent store.
@@ -240,6 +270,9 @@ public final class AppCore {
 
     /// Observes `.menuBarLeadTimeDidChange` to refresh the cached lead time.
     private var menuBarLeadTimeObserverTask: Task<Void, Never>?
+
+    /// Observes notification setting changes to refresh cached values.
+    private var notificationSettingsObserverTasks: [Task<Void, Never>] = []
 
     /// Auto-stop countdown duration in seconds.
     private let autoStopSeconds = 10
@@ -312,10 +345,12 @@ public final class AppCore {
             let settings = try await store.settings()
             onboardingComplete = settings.onboardingComplete
             loadMenuBarLeadTime(from: settings)
+            loadNotificationSettings(from: settings)
         } catch {
             onboardingComplete = false
         }
         startMenuBarLeadTimeObserver()
+        startNotificationSettingsObservers()
 
         if !onboardingComplete {
             logger.info("onLaunch: routing to onboarding")
@@ -486,35 +521,6 @@ public final class AppCore {
         route = .recording
     }
 
-    /// Routes to the Home screen.
-    public func showHome() {
-        route = .home
-    }
-
-    /// Routes to in-window Settings.
-    public func showSettings() {
-        route = .settings
-    }
-
-    /// Routes to Onboarding (re-run from Settings).
-    public func showOnboardingReplay() {
-        route = .onboarding
-    }
-
-    /// Requests focus on the search field. Increments the focus token
-    /// so `SearchFieldFocuser` (an `NSViewRepresentable` on the toolbar
-    /// `TextField`) detects the change and calls
-    /// `window.makeFirstResponder` on the backing `NSTextField`.
-    /// Called from the Cmd+F menu command.
-    public func focusSearch() {
-        searchFocusToken &+= 1
-    }
-
-    /// Routes to the read-only preview for an upcoming calendar event.
-    public func selectEvent(_ key: String) {
-        route = .event(key)
-    }
-
     /// Marks onboarding complete and transitions to Home.
     public func completeOnboarding() async {
         do {
@@ -587,6 +593,43 @@ public final class AppCore {
             summaries = []
         }
         summariesVersion &+= 1
+    }
+}
+
+// MARK: - Simple route helpers
+
+// Extracted to an extension to keep the main class body within the
+// type_body_length lint limit after adding notification-settings
+// stored properties (which must live in the class body for @Observable).
+
+public extension AppCore {
+    /// Routes to the Home screen.
+    func showHome() {
+        route = .home
+    }
+
+    /// Routes to in-window Settings.
+    func showSettings() {
+        route = .settings
+    }
+
+    /// Routes to Onboarding (re-run from Settings).
+    func showOnboardingReplay() {
+        route = .onboarding
+    }
+
+    /// Requests focus on the search field. Increments the focus token
+    /// so `SearchFieldFocuser` (an `NSViewRepresentable` on the toolbar
+    /// `TextField`) detects the change and calls
+    /// `window.makeFirstResponder` on the backing `NSTextField`.
+    /// Called from the Cmd+F menu command.
+    func focusSearch() {
+        searchFocusToken &+= 1
+    }
+
+    /// Routes to the read-only preview for an upcoming calendar event.
+    func selectEvent(_ key: String) {
+        route = .event(key)
     }
 }
 
@@ -729,6 +772,68 @@ extension AppCore {
                 }
             }
         }
+    }
+}
+
+// MARK: - Notification settings
+
+extension AppCore {
+    /// Updates the cached notification settings from a settings snapshot.
+    func loadNotificationSettings(from settings: AppSettingsData) {
+        monitorForMeetings = settings.monitorForMeetings
+        calendarNotificationMode = settings.calendarNotificationMode
+        stopRecordingAutomatically = settings.stopRecordingAutomatically
+    }
+
+    /// Starts async observers that refresh cached notification settings
+    /// when they are changed from SettingsUI. Cancels any previously
+    /// running observers first.
+    func startNotificationSettingsObservers() {
+        for task in notificationSettingsObserverTasks {
+            task.cancel()
+        }
+        notificationSettingsObserverTasks.removeAll()
+
+        let monitorTask = Task { [weak self] in
+            for await _ in NotificationCenter.default.notifications(
+                named: .monitorForMeetingsDidChange
+            ) {
+                guard let self else { return }
+                let settings = try? await store.settings()
+                if let settings {
+                    monitorForMeetings = settings.monitorForMeetings
+                }
+            }
+        }
+
+        let calendarModeTask = Task { [weak self] in
+            for await _ in NotificationCenter.default.notifications(
+                named: .calendarNotificationModeDidChange
+            ) {
+                guard let self else { return }
+                let settings = try? await store.settings()
+                if let settings {
+                    calendarNotificationMode = settings.calendarNotificationMode
+                    scheduleCalendarTimers()
+                }
+            }
+        }
+
+        let autoStopTask = Task { [weak self] in
+            for await _ in NotificationCenter.default.notifications(
+                named: .stopRecordingAutomaticallyDidChange
+            ) {
+                guard let self else { return }
+                let settings = try? await store.settings()
+                if let settings {
+                    stopRecordingAutomatically = settings.stopRecordingAutomatically
+                }
+            }
+        }
+
+        notificationSettingsObserverTasks = [
+            monitorTask, calendarModeTask, autoStopTask
+        ]
     }
 }
 
@@ -889,6 +994,14 @@ extension AppCore {
             "Received .started for \(app.bundleID)"
         )
 
+        // Suppress if monitor is off
+        guard monitorForMeetings else {
+            detectionLogger.info(
+                "Suppressed: monitorForMeetings is off"
+            )
+            return
+        }
+
         // Suppress if already recording
         if case .recording = runState {
             detectionLogger.info(
@@ -939,6 +1052,7 @@ extension AppCore {
     /// When all non-Biscotti mic users stop (>=1 -> 0 transition),
     /// begin auto-stop countdown regardless of how the recording started.
     private func handleAllMicUsersStopped() {
+        guard stopRecordingAutomatically else { return }
         guard case let .recording(meetingID) = runState else { return }
         beginAutoStopCountdown(meetingID: meetingID)
     }
@@ -1041,6 +1155,18 @@ extension AppCore {
 // MARK: - Calendar-start timers
 
 extension AppCore {
+    /// Filters upcoming events by the calendar notification mode.
+    /// Pure and testable.
+    nonisolated static func eventsToNotify(
+        _ upcoming: [CalendarEvent], mode: CalendarNotificationMode
+    ) -> [CalendarEvent] {
+        switch mode {
+        case .never: []
+        case .allMeetings: upcoming.filter(\.isMeetingLike)
+        case .videoConferencing: upcoming.filter { $0.conferenceURL != nil }
+        }
+    }
+
     private func scheduleCalendarTimers() {
         // Cancel all existing timers
         for (_, task) in calendarTimerTasks {
@@ -1048,7 +1174,7 @@ extension AppCore {
         }
         calendarTimerTasks.removeAll()
 
-        for event in upcoming where event.isMeetingLike {
+        for event in Self.eventsToNotify(upcoming, mode: calendarNotificationMode) {
             let delay = event.start.timeIntervalSinceNow
             guard delay > 0 else { continue } // already started
 
@@ -1061,7 +1187,7 @@ extension AppCore {
                     return // cancelled
                 }
                 guard let self, !Task.isCancelled else { return }
-                await self.handleCalendarTimerFired(event: event)
+                await handleCalendarTimerFired(event: event)
             }
         }
     }
@@ -1069,6 +1195,16 @@ extension AppCore {
     private func handleCalendarTimerFired(
         event: CalendarEvent
     ) async {
+        // Re-check mode in case it changed since the timer was scheduled
+        switch calendarNotificationMode {
+        case .never:
+            return
+        case .videoConferencing where event.conferenceURL == nil:
+            return
+        default:
+            break
+        }
+
         // Suppress if already recording
         guard runState == .idle || runState == .detectedPending
         else { return }

--- a/Packages/BiscottiKit/Sources/AppCore/AppCore.swift
+++ b/Packages/BiscottiKit/Sources/AppCore/AppCore.swift
@@ -607,6 +607,13 @@ public final class AppCore {
 // stored properties (which must live in the class body for @Observable).
 
 public extension AppCore {
+    /// Whether Biscotti's macOS notification style is currently "Banners"
+    /// (auto-dismiss after ~5s). Used by the settings UI to show a
+    /// guidance row nudging the user to switch to "Alerts".
+    func notificationsUseBannerStyle() async -> Bool {
+        await notifications.currentAlertStyle() == .banner
+    }
+
     /// Routes to the Home screen.
     func showHome() {
         route = .home

--- a/Packages/BiscottiKit/Sources/AppCore/AppCore.swift
+++ b/Packages/BiscottiKit/Sources/AppCore/AppCore.swift
@@ -422,6 +422,10 @@ public final class AppCore {
             return
         }
 
+        // Dismiss any lingering meeting-detected banners so they don't
+        // persist on screen during an active recording.
+        await notifications.cancelAdHocDetected()
+
         // Stash the eventKey so retry can re-use it.
         pendingStartupEventKey = eventKey
 
@@ -1131,18 +1135,6 @@ extension AppCore {
             switch action {
             case let .openAndRecord(eventKey):
                 await recordDetectedEvent(eventKey: eventKey)
-
-            case .join:
-                // NOTE: Join URL opening is handled exclusively by the app
-                // target's UNUserNotificationCenterDelegate (AppDelegate),
-                // which reads the URL from userInfo and calls
-                // NSWorkspace.shared.open(url) BEFORE the action reaches
-                // this stream. AppCore intentionally does nothing here to
-                // stay AppKit-free and testable. If the delegate is ever
-                // refactored to only call handleResponseValues (removing
-                // its direct URL open), this case must be updated to open
-                // the URL or forward to a callback.
-                break
 
             case .keepRecording:
                 keepRecording()

--- a/Packages/BiscottiKit/Sources/AppCore/PreviewAppCore.swift
+++ b/Packages/BiscottiKit/Sources/AppCore/PreviewAppCore.swift
@@ -162,5 +162,9 @@
         func removeDeliveredNotifications(withIdentifiers _: [String]) {}
 
         func setCategories(_: Set<UNNotificationCategory>) {}
+
+        func alertStyle() async -> UNAlertStyle {
+            .banner
+        }
     }
 #endif

--- a/Packages/BiscottiKit/Sources/DataStore/DataStore+ReadModels.swift
+++ b/Packages/BiscottiKit/Sources/DataStore/DataStore+ReadModels.swift
@@ -132,6 +132,12 @@ public struct AppSettingsData: Sendable, Equatable {
     /// shows the detailed "next meeting" text. `0` means never show.
     /// Default: 3600 (1 hour before).
     public var menuBarLeadTimeSeconds: Int
+    /// Whether meeting-detected notifications are presented.
+    public var monitorForMeetings: Bool
+    /// Whether recording auto-stops when all mic users leave.
+    public var stopRecordingAutomatically: Bool
+    /// Which calendar events trigger pre-meeting notifications.
+    public var calendarNotificationMode: CalendarNotificationMode
     public var onboardingComplete: Bool
     /// `nil` = all calendars enabled (the default).
     public var enabledCalendarIDs: Set<String>?
@@ -142,6 +148,9 @@ public struct AppSettingsData: Sendable, Equatable {
         exitOnWindowClose: Bool = false,
         globalRecordShortcutEnabled: Bool = true,
         menuBarLeadTimeSeconds: Int = 3600,
+        monitorForMeetings: Bool = true,
+        stopRecordingAutomatically: Bool = true,
+        calendarNotificationMode: CalendarNotificationMode = .allMeetings,
         onboardingComplete: Bool = false,
         enabledCalendarIDs: Set<String>? = nil
     ) {
@@ -150,6 +159,9 @@ public struct AppSettingsData: Sendable, Equatable {
         self.exitOnWindowClose = exitOnWindowClose
         self.globalRecordShortcutEnabled = globalRecordShortcutEnabled
         self.menuBarLeadTimeSeconds = menuBarLeadTimeSeconds
+        self.monitorForMeetings = monitorForMeetings
+        self.stopRecordingAutomatically = stopRecordingAutomatically
+        self.calendarNotificationMode = calendarNotificationMode
         self.onboardingComplete = onboardingComplete
         self.enabledCalendarIDs = enabledCalendarIDs
     }
@@ -396,6 +408,9 @@ public extension DataStore {
                 exitOnWindowClose: existing.exitOnWindowClose,
                 globalRecordShortcutEnabled: existing.globalRecordShortcutEnabled,
                 menuBarLeadTimeSeconds: existing.menuBarLeadTimeSeconds,
+                monitorForMeetings: existing.monitorForMeetings,
+                stopRecordingAutomatically: existing.stopRecordingAutomatically,
+                calendarNotificationMode: CalendarNotificationMode(raw: existing.calendarNotificationModeRaw),
                 onboardingComplete: existing.onboardingComplete,
                 enabledCalendarIDs: existing.enabledCalendarIDs
             )
@@ -425,6 +440,9 @@ public extension DataStore {
             exitOnWindowClose: model.exitOnWindowClose,
             globalRecordShortcutEnabled: model.globalRecordShortcutEnabled,
             menuBarLeadTimeSeconds: model.menuBarLeadTimeSeconds,
+            monitorForMeetings: model.monitorForMeetings,
+            stopRecordingAutomatically: model.stopRecordingAutomatically,
+            calendarNotificationMode: CalendarNotificationMode(raw: model.calendarNotificationModeRaw),
             onboardingComplete: model.onboardingComplete,
             enabledCalendarIDs: model.enabledCalendarIDs
         )
@@ -435,6 +453,9 @@ public extension DataStore {
         model.exitOnWindowClose = dto.exitOnWindowClose
         model.globalRecordShortcutEnabled = dto.globalRecordShortcutEnabled
         model.menuBarLeadTimeSeconds = dto.menuBarLeadTimeSeconds
+        model.monitorForMeetings = dto.monitorForMeetings
+        model.stopRecordingAutomatically = dto.stopRecordingAutomatically
+        model.calendarNotificationModeRaw = dto.calendarNotificationMode.rawValue
         model.onboardingComplete = dto.onboardingComplete
         model.enabledCalendarIDs = dto.enabledCalendarIDs
         try save()

--- a/Packages/BiscottiKit/Sources/DataStore/Models/AppSettings.swift
+++ b/Packages/BiscottiKit/Sources/DataStore/Models/AppSettings.swift
@@ -31,6 +31,16 @@ import SwiftData
     /// Default: 3600 (1 hour before).
     public var menuBarLeadTimeSeconds: Int = 3600
 
+    /// Whether meeting-detected notifications are presented.
+    public var monitorForMeetings: Bool = true
+
+    /// Whether recording auto-stops when all mic users leave.
+    public var stopRecordingAutomatically: Bool = true
+
+    /// Raw string backing for `CalendarNotificationMode`. Stored as a
+    /// String for SwiftData safety (same pattern as other enum-backed fields).
+    public var calendarNotificationModeRaw: String = "allMeetings"
+
     /// Whether the user has completed the onboarding wizard.
     public var onboardingComplete: Bool = false
 
@@ -64,6 +74,9 @@ import SwiftData
         exitOnWindowClose: Bool = false,
         globalRecordShortcutEnabled: Bool = true,
         menuBarLeadTimeSeconds: Int = 3600,
+        monitorForMeetings: Bool = true,
+        stopRecordingAutomatically: Bool = true,
+        calendarNotificationModeRaw: String = "allMeetings",
         onboardingComplete: Bool = false,
         enabledCalendarIDs: Set<String>? = nil
     ) {
@@ -72,6 +85,9 @@ import SwiftData
         self.exitOnWindowClose = exitOnWindowClose
         self.globalRecordShortcutEnabled = globalRecordShortcutEnabled
         self.menuBarLeadTimeSeconds = menuBarLeadTimeSeconds
+        self.monitorForMeetings = monitorForMeetings
+        self.stopRecordingAutomatically = stopRecordingAutomatically
+        self.calendarNotificationModeRaw = calendarNotificationModeRaw
         self.onboardingComplete = onboardingComplete
         if let enabledCalendarIDs {
             enabledCalendarIDsData = (try? JSONEncoder().encode(Array(enabledCalendarIDs).sorted())) ?? Data()

--- a/Packages/BiscottiKit/Sources/DataStore/Models/CalendarNotificationMode.swift
+++ b/Packages/BiscottiKit/Sources/DataStore/Models/CalendarNotificationMode.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// Which calendar events trigger pre-meeting notifications.
+///
+/// Backed by a stored `String` in `AppSettings.calendarNotificationModeRaw`.
+/// Shape mirrors `MenuBarLeadTime` (String rawValue, CaseIterable, Identifiable).
+public enum CalendarNotificationMode: String, CaseIterable, Sendable, Identifiable {
+    case allMeetings
+    case videoConferencing
+    case never
+
+    public var id: String {
+        rawValue
+    }
+
+    /// Human-readable label for the picker.
+    public var displayText: String {
+        switch self {
+        case .allMeetings: "All Meetings"
+        case .videoConferencing: "Meetings with Video Conferencing"
+        case .never: "Never"
+        }
+    }
+
+    /// Stored-string -> enum, defaulting to `.allMeetings` for unknown values.
+    public init(raw: String) {
+        self = Self(rawValue: raw) ?? .allMeetings
+    }
+}

--- a/Packages/BiscottiKit/Sources/Notifications/LiveNotificationCenter.swift
+++ b/Packages/BiscottiKit/Sources/Notifications/LiveNotificationCenter.swift
@@ -49,4 +49,8 @@ public struct LiveNotificationCenter: NotificationCenterProviding, Sendable {
         )
         return settings.authorizationStatus
     }
+
+    public func alertStyle() async -> UNAlertStyle {
+        await UNUserNotificationCenter.current().notificationSettings().alertStyle
+    }
 }

--- a/Packages/BiscottiKit/Sources/Notifications/NotificationAction.swift
+++ b/Packages/BiscottiKit/Sources/Notifications/NotificationAction.swift
@@ -6,9 +6,6 @@ public enum NotificationAction: Sendable, Equatable {
     /// `eventKey` is non-nil for calendar-driven starts, nil for ad-hoc detections.
     case openAndRecord(eventKey: String?)
 
-    /// User tapped Join on a calendar notification with a conference link.
-    case join(URL)
-
     /// User tapped Keep Recording on a stop-countdown notification.
     case keepRecording(meetingID: UUID)
 }

--- a/Packages/BiscottiKit/Sources/Notifications/NotificationAlertStyle.swift
+++ b/Packages/BiscottiKit/Sources/Notifications/NotificationAlertStyle.swift
@@ -1,0 +1,13 @@
+/// The macOS notification alert style for Biscotti, as reported by
+/// `UNNotificationSettings.alertStyle`.
+///
+/// Wraps `UNAlertStyle` as a plain Sendable enum so callers don't
+/// need to import UserNotifications.
+public enum NotificationAlertStyle: Sendable, Equatable {
+    /// Notifications are disabled (style set to "None" in System Settings).
+    case none
+    /// Banners: notifications appear briefly then auto-dismiss (~5 seconds).
+    case banner
+    /// Alerts: notifications stay on screen until the user dismisses them.
+    case alert
+}

--- a/Packages/BiscottiKit/Sources/Notifications/NotificationCenterProviding.swift
+++ b/Packages/BiscottiKit/Sources/Notifications/NotificationCenterProviding.swift
@@ -22,4 +22,7 @@ public protocol NotificationCenterProviding: Sendable {
 
     /// Current authorization status.
     func authorizationStatus() async -> UNAuthorizationStatus
+
+    /// Current on-screen alert style (banner vs. alert vs. none).
+    func alertStyle() async -> UNAlertStyle
 }

--- a/Packages/BiscottiKit/Sources/Notifications/NotificationIdentifiers.swift
+++ b/Packages/BiscottiKit/Sources/Notifications/NotificationIdentifiers.swift
@@ -14,8 +14,7 @@ enum CategoryID {
 
 /// UNNotificationAction identifiers.
 enum ActionID {
-    static let openAndRecord = "biscotti.action.open-and-record"
-    static let join = "biscotti.action.join"
+    static let recordAndJoin = "biscotti.action.record-and-join"
     static let record = "biscotti.action.record"
     static let keepRecording = "biscotti.action.keep-recording"
 }

--- a/Packages/BiscottiKit/Sources/Notifications/NotificationService.swift
+++ b/Packages/BiscottiKit/Sources/Notifications/NotificationService.swift
@@ -22,6 +22,10 @@ public final class NotificationService {
     private var continuation: AsyncStream<NotificationAction>.Continuation?
     private var stream: AsyncStream<NotificationAction>?
 
+    /// Tracks presented ad-hoc notification identifiers so `cancelAdHocDetected()`
+    /// can remove them from both pending and delivered.
+    private var presentedAdHocIDs: Set<String> = []
+
     /// Creates the service, registers categories, and prepares the action stream.
     ///
     /// - Parameter provider: The notification center seam (defaults to the live
@@ -94,6 +98,9 @@ public final class NotificationService {
             logger.info(
                 "present: added \(request.content.categoryIdentifier) request \(request.identifier)"
             )
+            if case .adHocDetected = kind {
+                presentedAdHocIDs.insert(request.identifier)
+            }
         } catch {
             logger.error("Failed to add notification: \(error)")
         }
@@ -105,6 +112,16 @@ public final class NotificationService {
         let identifier = countdownRequestIdentifier(meetingID: meetingID)
         provider.removePendingRequests(withIdentifiers: [identifier])
         provider.removeDeliveredNotifications(withIdentifiers: [identifier])
+    }
+
+    /// Removes any lingering meeting-detected notifications (pending + delivered).
+    /// Called when a recording starts so stale ad-hoc banners don't persist on screen.
+    public func cancelAdHocDetected() async {
+        guard !presentedAdHocIDs.isEmpty else { return }
+        let ids = Array(presentedAdHocIDs)
+        provider.removePendingRequests(withIdentifiers: ids)
+        provider.removeDeliveredNotifications(withIdentifiers: ids)
+        presentedAdHocIDs.removeAll()
     }
 
     // MARK: - Action stream
@@ -180,15 +197,10 @@ public final class NotificationService {
     // MARK: - Private
 
     private func registerCategories() {
-        let openAndRecord = UNNotificationAction(
-            identifier: ActionID.openAndRecord,
-            title: "Open & Record",
-            options: [.foreground]
-        )
-        let join = UNNotificationAction(
-            identifier: ActionID.join,
-            title: "Join",
-            options: [.foreground]
+        let recordAndJoin = UNNotificationAction(
+            identifier: ActionID.recordAndJoin,
+            title: "Record & Join",
+            options: []
         )
         let record = UNNotificationAction(
             identifier: ActionID.record,
@@ -203,12 +215,12 @@ public final class NotificationService {
 
         let meetingStart = UNNotificationCategory(
             identifier: CategoryID.meetingStarting,
-            actions: [openAndRecord],
+            actions: [record],
             intentIdentifiers: []
         )
         let meetingStartWithJoin = UNNotificationCategory(
             identifier: CategoryID.meetingStartingWithJoin,
-            actions: [openAndRecord, join],
+            actions: [recordAndJoin],
             intentIdentifiers: []
         )
         let adHoc = UNNotificationCategory(
@@ -260,8 +272,10 @@ private func makeRequest(for kind: NotificationKind) -> UNNotificationRequest {
         )
 
     case let .adHocDetected(bundleID, appName):
-        content.title = "Meeting detected in \(appName)"
-        content.body = "Tap Record to start capturing."
+        content.title = "Meeting detected"
+        content.subtitle = "App: \(appName)"
+        content.body = ""
+        content.interruptionLevel = .timeSensitive
         content.sound = .default
         content.categoryIdentifier = CategoryID.adHocDetected
         content.userInfo = [
@@ -288,6 +302,7 @@ private func fillMeetingStartContent(
 ) {
     content.title = title
     content.body = ""
+    content.interruptionLevel = .timeSensitive
     content.sound = .default
     content.categoryIdentifier = joinURL != nil
         ? CategoryID.meetingStartingWithJoin

--- a/Packages/BiscottiKit/Sources/Notifications/NotificationService.swift
+++ b/Packages/BiscottiKit/Sources/Notifications/NotificationService.swift
@@ -82,6 +82,19 @@ public final class NotificationService {
         return status == .denied
     }
 
+    // MARK: - Alert style
+
+    /// Returns the current macOS notification alert style for Biscotti,
+    /// mapped to the app's `NotificationAlertStyle` enum.
+    public func currentAlertStyle() async -> NotificationAlertStyle {
+        switch await provider.alertStyle() {
+        case .none: .none
+        case .banner: .banner
+        case .alert: .alert
+        @unknown default: .banner
+        }
+    }
+
     // MARK: - Presentation
 
     /// Posts a notification for the given kind.

--- a/Packages/BiscottiKit/Sources/Notifications/ResponseMapper.swift
+++ b/Packages/BiscottiKit/Sources/Notifications/ResponseMapper.swift
@@ -42,17 +42,10 @@ private func mapMeetingStartResponse(
     let eventKey = userInfo[UserInfoKey.eventKey] as? String
 
     switch actionID {
-    case ActionID.openAndRecord,
+    case ActionID.recordAndJoin,
+         ActionID.record,
          UNNotificationDefaultActionIdentifier:
         return .openAndRecord(eventKey: eventKey)
-
-    case ActionID.join:
-        guard let urlString = userInfo[UserInfoKey.joinURL] as? String,
-              let url = URL(string: urlString)
-        else {
-            return nil
-        }
-        return .join(url)
 
     default:
         return nil

--- a/Packages/BiscottiKit/Sources/SettingsUI/AlertsHelpSheet.swift
+++ b/Packages/BiscottiKit/Sources/SettingsUI/AlertsHelpSheet.swift
@@ -1,0 +1,57 @@
+import DesignSystem
+import SwiftUI
+
+/// Explanatory dialog guiding the user to switch Biscotti's macOS
+/// notification style to "Alerts" in System Settings.
+///
+/// macOS controls notification dwell; there is no API to set it
+/// programmatically. This sheet explains the three manual steps and
+/// offers a deep-link button to open the Notifications settings pane.
+struct AlertsHelpSheet: View {
+    let viewModel: SettingsViewModel
+
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Tokens.spacingMD) {
+            Text("Keep Notifications On Screen")
+                .font(.headline)
+
+            Text(
+                "macOS decides how long notifications stay on screen. To keep Biscotti\u{2019}s notifications visible until you dismiss them, set their style to \u{201C}Alerts\u{201D}."
+            )
+
+            VStack(alignment: .leading, spacing: Tokens.spacingSM) {
+                stepRow(number: 1, text: "Open System Settings \u{2192} Notifications")
+                stepRow(number: 2, text: "Select Biscotti")
+                stepRow(number: 3, text: "Set the alert style to \u{201C}Alerts\u{201D}")
+            }
+
+            HStack {
+                Spacer()
+                Button("Cancel") {
+                    dismiss()
+                }
+                .keyboardShortcut(.cancelAction)
+
+                Button("Open Settings") {
+                    viewModel.openNotificationSettings()
+                    dismiss()
+                }
+                .keyboardShortcut(.defaultAction)
+                .buttonStyle(.borderedProminent)
+                .tint(.sage)
+            }
+        }
+        .padding(Tokens.spacingMD * 1.5)
+        .frame(width: 400)
+    }
+
+    private func stepRow(number: Int, text: String) -> some View {
+        HStack(alignment: .top, spacing: Tokens.spacingSM) {
+            Text("\(number).")
+                .monospacedDigit()
+            Text(text)
+        }
+    }
+}

--- a/Packages/BiscottiKit/Sources/SettingsUI/SettingsView.swift
+++ b/Packages/BiscottiKit/Sources/SettingsUI/SettingsView.swift
@@ -21,6 +21,9 @@ public struct SettingsView: View {
                 // General
                 generalSection
 
+                // Notifications
+                notificationsSection
+
                 // Permissions (above Calendars per user feedback)
                 permissionsSection
 
@@ -249,6 +252,111 @@ public struct SettingsView: View {
             }
         }
     #endif
+}
+
+// MARK: - Notifications section
+
+private extension SettingsView {
+    var notificationsSection: some View {
+        Section("Notifications") {
+            // Row 1: Monitor for Meetings
+            VStack(alignment: .leading, spacing: Tokens.spacingXS) {
+                Toggle(
+                    "Monitor for Meetings",
+                    isOn: monitorForMeetingsBinding
+                )
+                Text(
+                    "Detect when an app starts using your microphone and offer to record. Nothing is recorded or processed unless you start recording."
+                )
+                .font(Tokens.metadataFont)
+                .foregroundStyle(Tokens.secondaryText)
+            }
+
+            // Row 2: Calendar Event Notifications
+            VStack(alignment: .leading, spacing: Tokens.spacingXS) {
+                Picker(
+                    "Calendar Event Notifications",
+                    selection: calendarNotificationModeBinding
+                ) {
+                    ForEach(CalendarNotificationMode.allCases) { mode in
+                        Text(mode.displayText).tag(mode)
+                    }
+                }
+                .disabled(viewModel.calendarNotificationsDisabled)
+
+                if viewModel.calendarNotificationsDisabled {
+                    requiresCalendarAccessBadge
+                }
+
+                Text(
+                    "Show a notification to record and join when a calendar event starts."
+                )
+                .font(Tokens.metadataFont)
+                .foregroundStyle(Tokens.secondaryText)
+            }
+
+            // Row 3: Stop Recording Automatically
+            VStack(alignment: .leading, spacing: Tokens.spacingXS) {
+                Toggle(
+                    "Stop Recording Automatically",
+                    isOn: stopRecordingAutomaticallyBinding
+                )
+                Text("Stop recording when we detect your meeting has ended.")
+                    .font(Tokens.metadataFont)
+                    .foregroundStyle(Tokens.secondaryText)
+            }
+        }
+    }
+
+    var requiresCalendarAccessBadge: some View {
+        HStack(spacing: 4) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.caption2)
+            Text("Requires Calendar Access")
+                .font(.caption)
+        }
+        .foregroundStyle(Tokens.warningChipText)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 3)
+        .background(
+            Capsule().fill(Tokens.warningChipFill)
+        )
+    }
+
+    var monitorForMeetingsBinding: Binding<Bool> {
+        Binding(
+            get: { viewModel.monitorForMeetings },
+            set: { newValue in
+                Task { await viewModel.setMonitorForMeetings(newValue) }
+            }
+        )
+    }
+
+    var calendarNotificationModeBinding: Binding<CalendarNotificationMode> {
+        Binding(
+            get: {
+                viewModel.calendarNotificationsDisabled
+                    ? .never
+                    : viewModel.calendarNotificationMode
+            },
+            set: { newValue in
+                Task {
+                    await viewModel.setCalendarNotificationMode(newValue)
+                }
+            }
+        )
+    }
+
+    var stopRecordingAutomaticallyBinding: Binding<Bool> {
+        Binding(
+            get: { viewModel.stopRecordingAutomatically },
+            set: { newValue in
+                Task {
+                    await viewModel.setStopRecordingAutomatically(newValue)
+                }
+            }
+        )
+    }
 }
 
 // Color(hex:) initializer is in DesignSystem/CalendarContextBlock.swift

--- a/Packages/BiscottiKit/Sources/SettingsUI/SettingsView.swift
+++ b/Packages/BiscottiKit/Sources/SettingsUI/SettingsView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 /// with inline request/grant actions, and calendar include/exclude.
 public struct SettingsView: View {
     @Bindable private var viewModel: SettingsViewModel
+    @State private var showAlertsHelp = false
 
     public init(viewModel: SettingsViewModel) {
         self.viewModel = viewModel
@@ -305,6 +306,40 @@ private extension SettingsView {
                     .font(Tokens.metadataFont)
                     .foregroundStyle(Tokens.secondaryText)
             }
+
+            // Row 4: Notifications Stay Visible (only when alertStyle == .banner)
+            if viewModel.showStayVisibleRow {
+                stayVisibleRow
+            }
+        }
+        .onReceive(
+            NotificationCenter.default.publisher(
+                for: NSApplication.didBecomeActiveNotification
+            )
+        ) { _ in
+            Task { await viewModel.refreshAlertStyle() }
+        }
+        .sheet(isPresented: $showAlertsHelp) {
+            AlertsHelpSheet(viewModel: viewModel)
+        }
+    }
+
+    var stayVisibleRow: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: Tokens.spacingXS) {
+                Text("Notifications Stay Visible")
+                Text(
+                    "Make notifications stay open until clicked or dismissed."
+                )
+                .font(Tokens.metadataFont)
+                .foregroundStyle(Tokens.secondaryText)
+            }
+            Spacer()
+            Button("Enable") {
+                showAlertsHelp = true
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
         }
     }
 

--- a/Packages/BiscottiKit/Sources/SettingsUI/SettingsView.swift
+++ b/Packages/BiscottiKit/Sources/SettingsUI/SettingsView.swift
@@ -69,6 +69,15 @@ public struct SettingsView: View {
                 "Global shortcut to start recording (\u{2318}\u{21E7}R)",
                 isOn: globalRecordShortcutBinding
             )
+            VStack(alignment: .leading, spacing: Tokens.spacingXS) {
+                Toggle(
+                    "Stop Recording Automatically",
+                    isOn: stopRecordingAutomaticallyBinding
+                )
+                Text("Stop recording when we detect your meeting has ended.")
+                    .font(Tokens.metadataFont)
+                    .foregroundStyle(Tokens.secondaryText)
+            }
             Picker(
                 "Show next meeting in menu bar",
                 selection: menuBarLeadTimeBinding
@@ -103,6 +112,17 @@ public struct SettingsView: View {
             get: { viewModel.globalRecordShortcutEnabled },
             set: { newValue in
                 Task { await viewModel.setGlobalRecordShortcut(newValue) }
+            }
+        )
+    }
+
+    private var stopRecordingAutomaticallyBinding: Binding<Bool> {
+        Binding(
+            get: { viewModel.stopRecordingAutomatically },
+            set: { newValue in
+                Task {
+                    await viewModel.setStopRecordingAutomatically(newValue)
+                }
             }
         )
     }
@@ -296,18 +316,7 @@ private extension SettingsView {
                 .foregroundStyle(Tokens.secondaryText)
             }
 
-            // Row 3: Stop Recording Automatically
-            VStack(alignment: .leading, spacing: Tokens.spacingXS) {
-                Toggle(
-                    "Stop Recording Automatically",
-                    isOn: stopRecordingAutomaticallyBinding
-                )
-                Text("Stop recording when we detect your meeting has ended.")
-                    .font(Tokens.metadataFont)
-                    .foregroundStyle(Tokens.secondaryText)
-            }
-
-            // Row 4: Notifications Stay Visible (only when alertStyle == .banner)
+            // Row 3: Notifications Stay Visible (only when alertStyle == .banner)
             if viewModel.showStayVisibleRow {
                 stayVisibleRow
             }
@@ -377,17 +386,6 @@ private extension SettingsView {
             set: { newValue in
                 Task {
                     await viewModel.setCalendarNotificationMode(newValue)
-                }
-            }
-        )
-    }
-
-    var stopRecordingAutomaticallyBinding: Binding<Bool> {
-        Binding(
-            get: { viewModel.stopRecordingAutomatically },
-            set: { newValue in
-                Task {
-                    await viewModel.setStopRecordingAutomatically(newValue)
                 }
             }
         )

--- a/Packages/BiscottiKit/Sources/SettingsUI/SettingsViewModel.swift
+++ b/Packages/BiscottiKit/Sources/SettingsUI/SettingsViewModel.swift
@@ -63,6 +63,12 @@ public final class SettingsViewModel {
     /// Whether recording auto-stops when all mic users leave.
     public private(set) var stopRecordingAutomatically: Bool = true
 
+    /// Whether the "Notifications Stay Visible" row should be shown.
+    /// True only when the macOS alert style is `.banner` (notifications
+    /// are enabled but auto-dismiss). Hidden for `.alert` (goal met)
+    /// and `.none` (notifications disabled entirely).
+    public private(set) var showStayVisibleRow = false
+
     /// Whether the calendar notification picker should be disabled
     /// (calendar access not authorized).
     public var calendarNotificationsDisabled: Bool {
@@ -343,6 +349,8 @@ public final class SettingsViewModel {
         // SMAppService is the source of truth for launch-at-login
         launchAtLogin = readLaunchAtLoginStatus()
 
+        showStayVisibleRow = await core.notificationsUseBannerStyle()
+
         let infos = await core.calendar.calendars()
         calendarGroups = Self.groupCalendars(infos)
     }
@@ -406,6 +414,22 @@ public extension SettingsViewModel {
         } catch {
             calendarNotificationMode = previous
         }
+    }
+
+    /// Re-reads the macOS notification alert style and updates
+    /// `showStayVisibleRow`. Called on `NSApplication.didBecomeActive`
+    /// so the row disappears right after the user switches to Alerts
+    /// in System Settings.
+    func refreshAlertStyle() async {
+        showStayVisibleRow = await core.notificationsUseBannerStyle()
+    }
+
+    /// Opens System Settings to the Notifications pane so the user can
+    /// change Biscotti's notification style to Alerts.
+    func openNotificationSettings() {
+        NSWorkspace.shared.open(
+            core.permissions.settingsURL(for: .notifications)
+        )
     }
 
     /// Toggles the "stop recording automatically" setting. Persists to

--- a/Packages/BiscottiKit/Sources/SettingsUI/SettingsViewModel.swift
+++ b/Packages/BiscottiKit/Sources/SettingsUI/SettingsViewModel.swift
@@ -52,6 +52,23 @@ public final class SettingsViewModel {
     /// How far before a meeting the menu bar shows the detailed text.
     public private(set) var menuBarLeadTime: MenuBarLeadTime = .oneHour
 
+    // MARK: - Notification settings
+
+    /// Whether meeting-detected notifications are presented.
+    public private(set) var monitorForMeetings: Bool = true
+
+    /// Which calendar events trigger pre-meeting notifications.
+    public private(set) var calendarNotificationMode: CalendarNotificationMode = .allMeetings
+
+    /// Whether recording auto-stops when all mic users leave.
+    public private(set) var stopRecordingAutomatically: Bool = true
+
+    /// Whether the calendar notification picker should be disabled
+    /// (calendar access not authorized).
+    public var calendarNotificationsDisabled: Bool {
+        calendarState != .authorized
+    }
+
     // MARK: - Calendar state
 
     /// All calendars grouped by source, for the include/exclude toggles.
@@ -316,6 +333,9 @@ public final class SettingsViewModel {
             menuBarLeadTime = MenuBarLeadTime(
                 seconds: settings.menuBarLeadTimeSeconds
             )
+            monitorForMeetings = settings.monitorForMeetings
+            calendarNotificationMode = settings.calendarNotificationMode
+            stopRecordingAutomatically = settings.stopRecordingAutomatically
         } catch {
             enabledCalendarIDs = nil
         }
@@ -343,5 +363,66 @@ public final class SettingsViewModel {
                     calendars: calendars.sorted { $0.title < $1.title }
                 )
             }
+    }
+}
+
+// MARK: - Notification settings actions
+
+public extension SettingsViewModel {
+    /// Toggles the "monitor for meetings" setting. Persists to the store
+    /// and posts `.monitorForMeetingsDidChange` so AppCore refreshes its
+    /// cached flag.
+    func setMonitorForMeetings(_ enabled: Bool) async {
+        monitorForMeetings = enabled
+        do {
+            try await core.store.updateSettings { settings in
+                settings.monitorForMeetings = enabled
+            }
+            NotificationCenter.default.post(
+                name: .monitorForMeetingsDidChange,
+                object: nil
+            )
+        } catch {
+            monitorForMeetings = !enabled
+        }
+    }
+
+    /// Updates the calendar notification mode. Persists to the store
+    /// and posts `.calendarNotificationModeDidChange` so AppCore
+    /// reschedules timers.
+    func setCalendarNotificationMode(
+        _ mode: CalendarNotificationMode
+    ) async {
+        let previous = calendarNotificationMode
+        calendarNotificationMode = mode
+        do {
+            try await core.store.updateSettings { settings in
+                settings.calendarNotificationMode = mode
+            }
+            NotificationCenter.default.post(
+                name: .calendarNotificationModeDidChange,
+                object: nil
+            )
+        } catch {
+            calendarNotificationMode = previous
+        }
+    }
+
+    /// Toggles the "stop recording automatically" setting. Persists to
+    /// the store and posts `.stopRecordingAutomaticallyDidChange` so
+    /// AppCore refreshes its cached flag.
+    func setStopRecordingAutomatically(_ enabled: Bool) async {
+        stopRecordingAutomatically = enabled
+        do {
+            try await core.store.updateSettings { settings in
+                settings.stopRecordingAutomatically = enabled
+            }
+            NotificationCenter.default.post(
+                name: .stopRecordingAutomaticallyDidChange,
+                object: nil
+            )
+        } catch {
+            stopRecordingAutomatically = !enabled
+        }
     }
 }

--- a/Packages/BiscottiKit/Tests/AppCoreTests/AppCoreBackgroundTests.swift
+++ b/Packages/BiscottiKit/Tests/AppCoreTests/AppCoreBackgroundTests.swift
@@ -675,7 +675,7 @@ struct AppCoreNotificationActionTests {
 
         fix.notificationService.handleResponseValues(
             categoryID: "biscotti.meeting-starting",
-            actionID: "biscotti.action.open-and-record",
+            actionID: "biscotti.action.record",
             userInfo: [
                 "biscotti.kind": "meeting-starting",
                 "biscotti.eventKey": eventKey ?? ""

--- a/Packages/BiscottiKit/Tests/AppCoreTests/NotificationSettingsGatingTests.swift
+++ b/Packages/BiscottiKit/Tests/AppCoreTests/NotificationSettingsGatingTests.swift
@@ -303,3 +303,53 @@ struct NotificationSettingsLoadingTests {
         #expect(fix.core.calendarNotificationMode == .allMeetings)
     }
 }
+
+// MARK: - Cancel ad-hoc on record start
+
+@Suite("AppCore -- cancel ad-hoc on record start")
+struct CancelAdHocOnRecordStartTests {
+    @Test("startRecording dismisses lingering ad-hoc notifications")
+    @MainActor
+    func startRecordingDismissesAdHoc() async throws {
+        let fix = try makeCoreFixture(
+            useFakeScheduler: true,
+            useImmediateDetectorClock: true,
+            testName: "CancelAdHoc"
+        )
+        defer { fix.cleanup() }
+
+        try await fix.store.updateSettings { settings in
+            settings.onboardingComplete = true
+        }
+        await fix.core.onLaunch()
+
+        // Emit audio snapshot so a meeting is detected.
+        fix.fakeActivitySource.emit([
+            makeAudioProcess(
+                bundleID: "us.zoom.xos",
+                input: true, output: true
+            )
+        ])
+        try await pollUntil { fix.core.runState == .detectedPending }
+
+        // An ad-hoc notification should have been presented.
+        let adHocRequests = fix.fakeNotificationCenter.addedRequests.filter {
+            $0.content.categoryIdentifier == "biscotti.ad-hoc-detected"
+        }
+        #expect(!adHocRequests.isEmpty)
+
+        let removedBefore = fix.fakeNotificationCenter.backing.removedPendingIDs.count
+
+        // Start recording -- should cancel the ad-hoc notification.
+        await fix.core.startRecording()
+
+        let removedAfter = fix.fakeNotificationCenter.backing.removedPendingIDs
+        #expect(removedAfter.count > removedBefore)
+
+        // The ad-hoc notification ID should be in the removed list.
+        let adHocID = adHocRequests[0].identifier
+        #expect(removedAfter.contains(adHocID))
+
+        _ = await fix.core.stopRecording()
+    }
+}

--- a/Packages/BiscottiKit/Tests/AppCoreTests/NotificationSettingsGatingTests.swift
+++ b/Packages/BiscottiKit/Tests/AppCoreTests/NotificationSettingsGatingTests.swift
@@ -1,0 +1,305 @@
+import AudioCapture
+import BiscottiTestSupport
+import Calendar
+import DataStore
+import Foundation
+import MeetingDetection
+import Testing
+@testable import AppCore
+
+// MARK: - eventsToNotify (pure filter)
+
+@Suite("AppCore.eventsToNotify")
+struct EventsToNotifyTests {
+    private func makeEvent(
+        id: String = "ev-1",
+        title: String = "Meeting",
+        conferenceURL: URL? = nil,
+        isMeetingLike: Bool = true
+    ) -> CalendarEvent {
+        let now = Date()
+        return CalendarEvent(
+            id: id,
+            title: title,
+            start: now.addingTimeInterval(600),
+            end: now.addingTimeInterval(4200),
+            conferencePlatform: conferenceURL != nil ? "zoom" : nil,
+            conferenceURL: conferenceURL,
+            attendeeCount: 3,
+            calendarTitle: "Work",
+            calendarColorHex: "#0066CC",
+            isMeetingLike: isMeetingLike
+        )
+    }
+
+    @Test(".never returns empty")
+    func neverReturnsEmpty() {
+        let events = [
+            makeEvent(id: "1", conferenceURL: URL(string: "https://zoom.us/j/1")),
+            makeEvent(id: "2")
+        ]
+        let filtered = AppCore.eventsToNotify(events, mode: .never)
+        #expect(filtered.isEmpty)
+    }
+
+    @Test(".allMeetings returns only isMeetingLike events")
+    func allMeetingsFiltersMeetingLike() {
+        let events = [
+            makeEvent(id: "1", isMeetingLike: true),
+            makeEvent(id: "2", isMeetingLike: false),
+            makeEvent(id: "3", isMeetingLike: true)
+        ]
+        let filtered = AppCore.eventsToNotify(events, mode: .allMeetings)
+        #expect(filtered.count == 2)
+        #expect(filtered.map(\.id) == ["1", "3"])
+    }
+
+    @Test(".videoConferencing returns only events with conferenceURL")
+    func videoConferencingFiltersURL() {
+        let zoomURL = URL(string: "https://zoom.us/j/123")
+        let events = [
+            makeEvent(id: "with-link", conferenceURL: zoomURL),
+            makeEvent(id: "no-link", conferenceURL: nil),
+            makeEvent(id: "also-no-link", conferenceURL: nil, isMeetingLike: true)
+        ]
+        let filtered = AppCore.eventsToNotify(events, mode: .videoConferencing)
+        #expect(filtered.count == 1)
+        #expect(filtered[0].id == "with-link")
+    }
+
+    @Test("empty upcoming returns empty for all modes")
+    func emptyUpcoming() {
+        for mode in CalendarNotificationMode.allCases {
+            let filtered = AppCore.eventsToNotify([], mode: mode)
+            #expect(filtered.isEmpty)
+        }
+    }
+}
+
+// MARK: - Detection gating (monitorForMeetings)
+
+@Suite("AppCore -- detection notification gating")
+struct DetectionNotificationGatingTests {
+    @Test("detection suppressed when monitorForMeetings is off")
+    @MainActor
+    func detectionSuppressedWhenMonitorOff() async throws {
+        let fix = try makeCoreFixture(
+            useFakeScheduler: true,
+            useImmediateDetectorClock: true,
+            testName: "MonitorGate"
+        )
+        defer { fix.cleanup() }
+
+        // Set monitorForMeetings = false before launch
+        try await fix.store.updateSettings { settings in
+            settings.onboardingComplete = true
+            settings.monitorForMeetings = false
+        }
+        await fix.core.onLaunch()
+        #expect(fix.core.runState == .idle)
+        #expect(fix.core.monitorForMeetings == false)
+
+        let requestsBefore = fix.fakeNotificationCenter.addedRequests.count
+
+        // Emit audio snapshot with Zoom doing input+output
+        fix.fakeActivitySource.emit([
+            makeAudioProcess(
+                bundleID: "us.zoom.xos",
+                input: true, output: true
+            )
+        ])
+
+        // Give consumer time to process
+        try await Task.sleep(for: .milliseconds(300))
+
+        // Should still be idle (no detectedPending transition)
+        #expect(fix.core.runState == .idle)
+        // No notification should have been presented
+        #expect(fix.fakeNotificationCenter.addedRequests.count == requestsBefore)
+    }
+
+    @Test("detection works when monitorForMeetings is on (default)")
+    @MainActor
+    func detectionWorksWhenMonitorOn() async throws {
+        let fix = try makeCoreFixture(
+            useFakeScheduler: true,
+            useImmediateDetectorClock: true,
+            testName: "MonitorGate"
+        )
+        defer { fix.cleanup() }
+
+        try await fix.store.updateSettings { settings in
+            settings.onboardingComplete = true
+            settings.monitorForMeetings = true
+        }
+        await fix.core.onLaunch()
+        #expect(fix.core.monitorForMeetings == true)
+
+        let requestsBefore = fix.fakeNotificationCenter.addedRequests.count
+
+        fix.fakeActivitySource.emit([
+            makeAudioProcess(
+                bundleID: "us.zoom.xos",
+                input: true, output: true
+            )
+        ])
+
+        try await pollUntil { fix.core.runState == .detectedPending }
+        #expect(fix.core.runState == .detectedPending)
+        #expect(fix.fakeNotificationCenter.addedRequests.count > requestsBefore)
+    }
+}
+
+// MARK: - Auto-stop gating (stopRecordingAutomatically)
+
+@Suite("AppCore -- auto-stop gating")
+struct AutoStopGatingTests {
+    @Test("auto-stop suppressed when stopRecordingAutomatically is off")
+    @MainActor
+    func autoStopSuppressedWhenOff() async throws {
+        let fix = try makeCoreFixture(
+            useFakeScheduler: true,
+            useImmediateDetectorClock: true,
+            testName: "AutoStopGate"
+        )
+        defer { fix.cleanup() }
+
+        guard let fakeScheduler = fix.fakeScheduler else {
+            Issue.record("Expected FakeScheduler")
+            return
+        }
+
+        try await fix.store.updateSettings { settings in
+            settings.onboardingComplete = true
+            settings.stopRecordingAutomatically = false
+        }
+        await fix.core.onLaunch()
+        #expect(fix.core.stopRecordingAutomatically == false)
+
+        // Start recording with Zoom active
+        fix.fakeActivitySource.emit([
+            makeAudioProcess(
+                bundleID: "us.zoom.xos",
+                input: true, output: true
+            )
+        ])
+        try await pollUntil { fix.core.runState == .detectedPending }
+        await fix.core.recordDetectedEvent(eventKey: nil)
+        guard case .recording = fix.core.runState else {
+            Issue.record("Expected recording")
+            return
+        }
+
+        let baselinePending = fakeScheduler.pendingCount
+
+        // Zoom stops -- allMicUsersStopped fires
+        fix.fakeActivitySource.emit([
+            makeAudioProcess(
+                bundleID: "us.zoom.xos",
+                input: false, output: false
+            )
+        ])
+
+        // Give consumer time to process
+        try await Task.sleep(for: .milliseconds(300))
+
+        // No countdown should have started
+        #expect(fakeScheduler.pendingCount == baselinePending)
+        #expect(fix.core.autoStop == nil)
+        #expect(fix.core.recording.state.isRecording == true)
+
+        _ = await fix.core.stopRecording()
+    }
+
+    @Test("auto-stop works when stopRecordingAutomatically is on (default)")
+    @MainActor
+    func autoStopWorksWhenOn() async throws {
+        let fix = try makeCoreFixture(
+            useFakeScheduler: true,
+            useImmediateDetectorClock: true,
+            testName: "AutoStopGate"
+        )
+        defer { fix.cleanup() }
+
+        guard let fakeScheduler = fix.fakeScheduler else {
+            Issue.record("Expected FakeScheduler")
+            return
+        }
+
+        try await fix.store.updateSettings { settings in
+            settings.onboardingComplete = true
+            settings.stopRecordingAutomatically = true
+        }
+        await fix.core.onLaunch()
+        #expect(fix.core.stopRecordingAutomatically == true)
+
+        fix.fakeActivitySource.emit([
+            makeAudioProcess(
+                bundleID: "us.zoom.xos",
+                input: true, output: true
+            )
+        ])
+        try await pollUntil { fix.core.runState == .detectedPending }
+        await fix.core.recordDetectedEvent(eventKey: nil)
+        guard case .recording = fix.core.runState else {
+            Issue.record("Expected recording")
+            return
+        }
+
+        // Zoom stops
+        fix.fakeActivitySource.emit([
+            makeAudioProcess(
+                bundleID: "us.zoom.xos",
+                input: false, output: false
+            )
+        ])
+
+        // Countdown should start
+        try await pollUntil { fakeScheduler.pendingCount > 0 }
+        #expect(fix.core.autoStop != nil)
+
+        _ = await fix.core.stopRecording()
+    }
+}
+
+// MARK: - Notification settings loading
+
+@Suite("AppCore -- notification settings loading")
+struct NotificationSettingsLoadingTests {
+    @Test("onLaunch loads notification settings from store")
+    @MainActor
+    func onLaunchLoadsSettings() async throws {
+        let fix = try makeCoreFixture(testName: "NotifSettingsLoad")
+        defer { fix.cleanup() }
+
+        try await fix.store.updateSettings { settings in
+            settings.onboardingComplete = true
+            settings.monitorForMeetings = false
+            settings.stopRecordingAutomatically = false
+            settings.calendarNotificationMode = .videoConferencing
+        }
+
+        await fix.core.onLaunch()
+
+        #expect(fix.core.monitorForMeetings == false)
+        #expect(fix.core.stopRecordingAutomatically == false)
+        #expect(fix.core.calendarNotificationMode == .videoConferencing)
+    }
+
+    @Test("default values when settings not explicitly set")
+    @MainActor
+    func defaultValues() async throws {
+        let fix = try makeCoreFixture(testName: "NotifSettingsLoad")
+        defer { fix.cleanup() }
+
+        try await fix.store.updateSettings { settings in
+            settings.onboardingComplete = true
+        }
+
+        await fix.core.onLaunch()
+
+        #expect(fix.core.monitorForMeetings == true)
+        #expect(fix.core.stopRecordingAutomatically == true)
+        #expect(fix.core.calendarNotificationMode == .allMeetings)
+    }
+}

--- a/Packages/BiscottiKit/Tests/BiscottiTestSupport/CoreFixture.swift
+++ b/Packages/BiscottiKit/Tests/BiscottiTestSupport/CoreFixture.swift
@@ -205,6 +205,7 @@ public final class FakeTestNotificationCenter: NotificationCenterProviding,
         public var removedPendingIDs: [String] = []
         public var removedDeliveredIDs: [String] = []
         public var registeredCategories: Set<UNNotificationCategory> = []
+        public var scriptedAlertStyle: UNAlertStyle = .banner
     }
 
     public let backing = Backing()
@@ -237,6 +238,10 @@ public final class FakeTestNotificationCenter: NotificationCenterProviding,
         _ categories: Set<UNNotificationCategory>
     ) {
         backing.registeredCategories = categories
+    }
+
+    public func alertStyle() async -> UNAlertStyle {
+        backing.scriptedAlertStyle
     }
 
     /// Convenience accessors

--- a/Packages/BiscottiKit/Tests/DataStoreTests/CalendarNotificationModeTests.swift
+++ b/Packages/BiscottiKit/Tests/DataStoreTests/CalendarNotificationModeTests.swift
@@ -1,0 +1,97 @@
+import DataStore
+import Testing
+
+@Suite("CalendarNotificationMode")
+struct CalendarNotificationModeTests {
+    @Test("rawValue stability")
+    func rawValueStability() {
+        #expect(CalendarNotificationMode.allMeetings.rawValue == "allMeetings")
+        #expect(CalendarNotificationMode.videoConferencing.rawValue == "videoConferencing")
+        #expect(CalendarNotificationMode.never.rawValue == "never")
+    }
+
+    @Test("displayText for each case")
+    func displayText() {
+        #expect(CalendarNotificationMode.allMeetings.displayText == "All Meetings")
+        #expect(CalendarNotificationMode.videoConferencing.displayText == "Meetings with Video Conferencing")
+        #expect(CalendarNotificationMode.never.displayText == "Never")
+    }
+
+    @Test("allCases has three entries")
+    func allCasesCount() {
+        #expect(CalendarNotificationMode.allCases.count == 3)
+    }
+
+    @Test("init(raw:) returns correct case for known values")
+    func initRawKnown() {
+        #expect(CalendarNotificationMode(raw: "allMeetings") == .allMeetings)
+        #expect(CalendarNotificationMode(raw: "videoConferencing") == .videoConferencing)
+        #expect(CalendarNotificationMode(raw: "never") == .never)
+    }
+
+    @Test("init(raw:) defaults to .allMeetings for unknown values")
+    func initRawUnknown() {
+        // This initializer is also the store's defense: settings() uses
+        // CalendarNotificationMode(raw:) to map the SwiftData raw string,
+        // so unknown values gracefully fall back to .allMeetings.
+        #expect(CalendarNotificationMode(raw: "bogus") == .allMeetings)
+        #expect(CalendarNotificationMode(raw: "") == .allMeetings)
+    }
+
+    @Test("id is rawValue")
+    func idIsRawValue() {
+        for mode in CalendarNotificationMode.allCases {
+            #expect(mode.id == mode.rawValue)
+        }
+    }
+}
+
+@Suite("DataStore -- notification settings round-trip")
+struct NotificationSettingsRoundTripTests {
+    @Test("settings defaults include notification fields")
+    func defaultsIncludeNotificationFields() async throws {
+        let store = try DataStore(storage: .inMemory)
+        let settings = try await store.settings()
+        #expect(settings.monitorForMeetings == true)
+        #expect(settings.stopRecordingAutomatically == true)
+        #expect(settings.calendarNotificationMode == .allMeetings)
+    }
+
+    @Test("updateSettings persists notification fields")
+    func updateSettingsPersists() async throws {
+        let store = try DataStore(storage: .inMemory)
+        try await store.updateSettings { settings in
+            settings.monitorForMeetings = false
+            settings.stopRecordingAutomatically = false
+            settings.calendarNotificationMode = .videoConferencing
+        }
+
+        let result = try await store.settings()
+        #expect(result.monitorForMeetings == false)
+        #expect(result.stopRecordingAutomatically == false)
+        #expect(result.calendarNotificationMode == .videoConferencing)
+    }
+
+    @Test("calendarNotificationMode .never round-trips")
+    func calendarModeNeverRoundTrips() async throws {
+        let store = try DataStore(storage: .inMemory)
+        try await store.updateSettings { settings in
+            settings.calendarNotificationMode = .never
+        }
+        let result = try await store.settings()
+        #expect(result.calendarNotificationMode == .never)
+    }
+
+    @Test("store round-trip: write via DTO then read back preserves mode")
+    func storeDTORoundTrip() async throws {
+        let store = try DataStore(storage: .inMemory)
+        // Write each mode through the DTO path and read it back.
+        for mode in CalendarNotificationMode.allCases {
+            try await store.updateSettings { settings in
+                settings.calendarNotificationMode = mode
+            }
+            let result = try await store.settings()
+            #expect(result.calendarNotificationMode == mode)
+        }
+    }
+}

--- a/Packages/BiscottiKit/Tests/NotificationsTests/AlertStyleTests.swift
+++ b/Packages/BiscottiKit/Tests/NotificationsTests/AlertStyleTests.swift
@@ -1,0 +1,37 @@
+import Notifications
+import Testing
+import UserNotifications
+
+@Suite("currentAlertStyle mapping")
+@MainActor
+struct AlertStyleTests {
+    @Test("maps UNAlertStyle.banner to .banner")
+    func mapsBanner() async {
+        let fake = FakeNotificationCenter()
+        fake.scriptedAlertStyle = .banner
+        let service = NotificationService(provider: fake)
+
+        let style = await service.currentAlertStyle()
+        #expect(style == .banner)
+    }
+
+    @Test("maps UNAlertStyle.alert to .alert")
+    func mapsAlert() async {
+        let fake = FakeNotificationCenter()
+        fake.scriptedAlertStyle = .alert
+        let service = NotificationService(provider: fake)
+
+        let style = await service.currentAlertStyle()
+        #expect(style == .alert)
+    }
+
+    @Test("maps UNAlertStyle.none to .none")
+    func mapsNone() async {
+        let fake = FakeNotificationCenter()
+        fake.scriptedAlertStyle = .none
+        let service = NotificationService(provider: fake)
+
+        let style = await service.currentAlertStyle()
+        #expect(style == .none)
+    }
+}

--- a/Packages/BiscottiKit/Tests/NotificationsTests/CancelAdHocTests.swift
+++ b/Packages/BiscottiKit/Tests/NotificationsTests/CancelAdHocTests.swift
@@ -1,0 +1,105 @@
+import Foundation
+import Notifications
+import Testing
+
+@Suite("cancelAdHocDetected")
+struct CancelAdHocTests {
+    @Test("Cancels presented ad-hoc notification identifiers")
+    @MainActor
+    func cancelsAdHocIDs() async {
+        let fake = FakeNotificationCenter()
+        let service = NotificationService(provider: fake)
+        _ = await service.requestAuthorization()
+
+        // Present an ad-hoc detection notification.
+        await service.present(
+            .adHocDetected(bundleID: "us.zoom.xos", appName: "Zoom")
+        )
+
+        #expect(fake.addedRequests.count == 1)
+        let adHocID = fake.addedRequests[0].identifier
+
+        // Cancel should remove the ad-hoc notification.
+        await service.cancelAdHocDetected()
+
+        #expect(fake.removedPendingIDs.count == 1)
+        #expect(fake.removedPendingIDs[0] == [adHocID])
+        #expect(fake.removedDeliveredIDs.count == 1)
+        #expect(fake.removedDeliveredIDs[0] == [adHocID])
+    }
+
+    @Test("Second cancel is a no-op after tracking is cleared")
+    @MainActor
+    func secondCancelIsNoOp() async {
+        let fake = FakeNotificationCenter()
+        let service = NotificationService(provider: fake)
+        _ = await service.requestAuthorization()
+
+        await service.present(
+            .adHocDetected(bundleID: "us.zoom.xos", appName: "Zoom")
+        )
+
+        await service.cancelAdHocDetected()
+        let pendingCountAfterFirst = fake.removedPendingIDs.count
+
+        // Second cancel should not add removal calls.
+        await service.cancelAdHocDetected()
+        #expect(fake.removedPendingIDs.count == pendingCountAfterFirst)
+    }
+
+    @Test("Cancels multiple ad-hoc notifications")
+    @MainActor
+    func cancelsMultipleAdHocIDs() async {
+        let fake = FakeNotificationCenter()
+        let service = NotificationService(provider: fake)
+        _ = await service.requestAuthorization()
+
+        await service.present(
+            .adHocDetected(bundleID: "us.zoom.xos", appName: "Zoom")
+        )
+        await service.present(
+            .adHocDetected(bundleID: "com.google.Chrome", appName: "Chrome")
+        )
+
+        #expect(fake.addedRequests.count == 2)
+
+        await service.cancelAdHocDetected()
+
+        // Both IDs should be in the single removal call.
+        #expect(fake.removedPendingIDs.count == 1)
+        let removedIDs = Set(fake.removedPendingIDs[0])
+        #expect(removedIDs.count == 2)
+        #expect(removedIDs.contains(fake.addedRequests[0].identifier))
+        #expect(removedIDs.contains(fake.addedRequests[1].identifier))
+    }
+
+    @Test("No-op when no ad-hoc notifications were presented")
+    @MainActor
+    func noOpWhenEmpty() async {
+        let fake = FakeNotificationCenter()
+        let service = NotificationService(provider: fake)
+
+        await service.cancelAdHocDetected()
+
+        #expect(fake.removedPendingIDs.isEmpty)
+        #expect(fake.removedDeliveredIDs.isEmpty)
+    }
+
+    @Test("Non-ad-hoc notifications are not tracked for cancellation")
+    @MainActor
+    func nonAdHocNotTracked() async {
+        let fake = FakeNotificationCenter()
+        let service = NotificationService(provider: fake)
+        _ = await service.requestAuthorization()
+
+        // Present a meeting-starting notification (not ad-hoc).
+        await service.present(
+            .meetingStarting(eventKey: "ev-1", title: "Standup", joinURL: nil)
+        )
+
+        await service.cancelAdHocDetected()
+
+        // No removal should happen since only ad-hoc IDs are tracked.
+        #expect(fake.removedPendingIDs.isEmpty)
+    }
+}

--- a/Packages/BiscottiKit/Tests/NotificationsTests/CategoryRegistrationTests.swift
+++ b/Packages/BiscottiKit/Tests/NotificationsTests/CategoryRegistrationTests.swift
@@ -21,7 +21,7 @@ struct CategoryRegistrationTests {
         #expect(ids.contains("biscotti.stop-countdown"))
     }
 
-    @Test("Meeting-starting category has Open & Record action with foreground")
+    @Test("Meeting-starting category has Record action without foreground")
     @MainActor
     func meetingStartingActions() throws {
         let fake = FakeNotificationCenter()
@@ -30,11 +30,12 @@ struct CategoryRegistrationTests {
         let categories = fake.setCategoriesCalls[0]
         let category = try #require(categories.first { $0.identifier == "biscotti.meeting-starting" })
         #expect(category.actions.count == 1)
-        #expect(category.actions[0].identifier == "biscotti.action.open-and-record")
-        #expect(category.actions[0].options.contains(.foreground))
+        #expect(category.actions[0].identifier == "biscotti.action.record")
+        #expect(category.actions[0].title == "Record")
+        #expect(!category.actions[0].options.contains(.foreground))
     }
 
-    @Test("Meeting-starting-with-join has Open & Record and Join actions")
+    @Test("Meeting-starting-with-join has Record & Join action without foreground")
     @MainActor
     func meetingStartingWithJoinActions() throws {
         let fake = FakeNotificationCenter()
@@ -44,16 +45,10 @@ struct CategoryRegistrationTests {
         let category = try #require(categories.first {
             $0.identifier == "biscotti.meeting-starting-with-join"
         })
-        #expect(category.actions.count == 2)
-
-        let actionIDs = category.actions.map(\.identifier)
-        #expect(actionIDs.contains("biscotti.action.open-and-record"))
-        #expect(actionIDs.contains("biscotti.action.join"))
-
-        // Both should have foreground option
-        for action in category.actions {
-            #expect(action.options.contains(.foreground))
-        }
+        #expect(category.actions.count == 1)
+        #expect(category.actions[0].identifier == "biscotti.action.record-and-join")
+        #expect(category.actions[0].title == "Record & Join")
+        #expect(!category.actions[0].options.contains(.foreground))
     }
 
     @Test("Ad-hoc category has Record action without foreground")

--- a/Packages/BiscottiKit/Tests/NotificationsTests/ContentConstructionTests.swift
+++ b/Packages/BiscottiKit/Tests/NotificationsTests/ContentConstructionTests.swift
@@ -4,7 +4,7 @@ import Testing
 
 @Suite("Content construction")
 struct ContentConstructionTests {
-    @Test("Meeting-starting content uses event title")
+    @Test("Meeting-starting content uses event title and timeSensitive")
     @MainActor
     func meetingStartingContentUsesEventTitle() async {
         let fake = FakeNotificationCenter()
@@ -19,12 +19,13 @@ struct ContentConstructionTests {
         let content = fake.addedRequests[0].content
         #expect(content.title == "Standup")
         #expect(content.categoryIdentifier == "biscotti.meeting-starting")
+        #expect(content.interruptionLevel == .timeSensitive)
         #expect(content.sound != nil)
         #expect(content.userInfo["biscotti.eventKey"] as? String == "k")
         #expect(content.userInfo["biscotti.kind"] as? String == "meeting-starting")
     }
 
-    @Test("Meeting-starting with joinURL uses join category")
+    @Test("Meeting-starting with joinURL uses join category and timeSensitive")
     @MainActor
     func meetingStartingWithJoinUsesJoinCategory() async throws {
         let fake = FakeNotificationCenter()
@@ -41,15 +42,16 @@ struct ContentConstructionTests {
         #expect(
             content.categoryIdentifier == "biscotti.meeting-starting-with-join"
         )
+        #expect(content.interruptionLevel == .timeSensitive)
         #expect(
             content.userInfo["biscotti.joinURL"] as? String
                 == "https://zoom.us/j/123"
         )
     }
 
-    @Test("Ad-hoc content names the app")
+    @Test("Ad-hoc content uses new copy format and timeSensitive")
     @MainActor
-    func adHocContentNamesApp() async {
+    func adHocContentUsesNewCopy() async {
         let fake = FakeNotificationCenter()
         let service = NotificationService(provider: fake)
         _ = await service.requestAuthorization()
@@ -60,7 +62,10 @@ struct ContentConstructionTests {
 
         #expect(fake.addedRequests.count == 1)
         let content = fake.addedRequests[0].content
-        #expect(content.title.contains("Zoom"))
+        #expect(content.title == "Meeting detected")
+        #expect(content.subtitle == "App: Zoom")
+        #expect(content.body == "")
+        #expect(content.interruptionLevel == .timeSensitive)
         #expect(content.categoryIdentifier == "biscotti.ad-hoc-detected")
         #expect(content.userInfo["biscotti.bundleID"] as? String == "us.zoom.xos")
     }

--- a/Packages/BiscottiKit/Tests/NotificationsTests/FakeNotificationCenter.swift
+++ b/Packages/BiscottiKit/Tests/NotificationsTests/FakeNotificationCenter.swift
@@ -20,6 +20,7 @@ final class FakeNotificationCenter: NotificationCenterProviding, @unchecked Send
         var authRequestCount = 0
         var authorizationGranted = true
         var currentStatus: UNAuthorizationStatus = .authorized
+        var scriptedAlertStyle: UNAlertStyle = .banner
     }
 
     let backing = Backing()
@@ -51,6 +52,10 @@ final class FakeNotificationCenter: NotificationCenterProviding, @unchecked Send
         backing.currentStatus
     }
 
+    func alertStyle() async -> UNAlertStyle {
+        backing.scriptedAlertStyle
+    }
+
     // MARK: - Test accessors
 
     var setCategoriesCalls: [Set<UNNotificationCategory>] {
@@ -77,5 +82,10 @@ final class FakeNotificationCenter: NotificationCenterProviding, @unchecked Send
     var currentStatus: UNAuthorizationStatus {
         get { backing.currentStatus }
         set { backing.currentStatus = newValue }
+    }
+
+    var scriptedAlertStyle: UNAlertStyle {
+        get { backing.scriptedAlertStyle }
+        set { backing.scriptedAlertStyle = newValue }
     }
 }

--- a/Packages/BiscottiKit/Tests/NotificationsTests/ResponseMappingTests.swift
+++ b/Packages/BiscottiKit/Tests/NotificationsTests/ResponseMappingTests.swift
@@ -5,16 +5,16 @@ import UserNotifications
 
 @Suite("Delegate response mapping")
 struct ResponseMappingTests {
-    @Test("Open & Record on meeting-starting maps to openAndRecord")
+    @Test("Record & Join on meeting-starting-with-join maps to openAndRecord")
     @MainActor
-    func delegateResponseMapsToOpenAndRecord() async {
+    func recordAndJoinMapsToOpenAndRecord() async {
         let fake = FakeNotificationCenter()
         let service = NotificationService(provider: fake)
         let stream = service.actions()
 
         let result = service.handleResponseValues(
-            categoryID: "biscotti.meeting-starting",
-            actionID: "biscotti.action.open-and-record",
+            categoryID: "biscotti.meeting-starting-with-join",
+            actionID: "biscotti.action.record-and-join",
             userInfo: [
                 "biscotti.kind": "meeting-starting",
                 "biscotti.eventKey": "ev-123"
@@ -28,20 +28,19 @@ struct ResponseMappingTests {
         #expect(action == .openAndRecord(eventKey: "ev-123"))
     }
 
-    @Test("Join action maps to join URL")
+    @Test("Record on meeting-starting (no link) maps to openAndRecord")
     @MainActor
-    func joinActionMapsToJoinURL() async throws {
+    func recordOnMeetingStartingMapsToOpenAndRecord() async {
         let fake = FakeNotificationCenter()
         let service = NotificationService(provider: fake)
         let stream = service.actions()
 
-        let url = "https://zoom.us/j/999"
         let result = service.handleResponseValues(
-            categoryID: "biscotti.meeting-starting-with-join",
-            actionID: "biscotti.action.join",
+            categoryID: "biscotti.meeting-starting",
+            actionID: "biscotti.action.record",
             userInfo: [
                 "biscotti.kind": "meeting-starting",
-                "biscotti.joinURL": url
+                "biscotti.eventKey": "ev-456"
             ]
         )
 
@@ -49,7 +48,32 @@ struct ResponseMappingTests {
 
         var iterator = stream.makeAsyncIterator()
         let action = await iterator.next()
-        #expect(try action == .join(#require(URL(string: url))))
+        #expect(action == .openAndRecord(eventKey: "ev-456"))
+    }
+
+    @Test("Record & Join on meeting-starting (no-link) still maps to openAndRecord")
+    @MainActor
+    func recordAndJoinOnNoLinkCategoryMapsToOpenAndRecord() async {
+        let fake = FakeNotificationCenter()
+        let service = NotificationService(provider: fake)
+        let stream = service.actions()
+
+        // recordAndJoin is only registered on the with-join category, but
+        // the mapper accepts it on both -- verify the cross-category case.
+        let result = service.handleResponseValues(
+            categoryID: "biscotti.meeting-starting",
+            actionID: "biscotti.action.record-and-join",
+            userInfo: [
+                "biscotti.kind": "meeting-starting",
+                "biscotti.eventKey": "ev-cross"
+            ]
+        )
+
+        #expect(result == true)
+
+        var iterator = stream.makeAsyncIterator()
+        let action = await iterator.next()
+        #expect(action == .openAndRecord(eventKey: "ev-cross"))
     }
 
     @Test("Ad-hoc record maps to openAndRecord with nil key")
@@ -99,7 +123,7 @@ struct ResponseMappingTests {
         #expect(action == .keepRecording(meetingID: meetingID))
     }
 
-    @Test("Default action on meeting-start maps to openAndRecord")
+    @Test("Default action on meeting-starting maps to openAndRecord")
     @MainActor
     func defaultActionOnMeetingStartMapsToOpenAndRecord() async {
         let fake = FakeNotificationCenter()
@@ -120,6 +144,29 @@ struct ResponseMappingTests {
         var iterator = stream.makeAsyncIterator()
         let action = await iterator.next()
         #expect(action == .openAndRecord(eventKey: "ev-default"))
+    }
+
+    @Test("Default action on meeting-starting-with-join maps to openAndRecord")
+    @MainActor
+    func defaultActionOnMeetingStartWithJoinMapsToOpenAndRecord() async {
+        let fake = FakeNotificationCenter()
+        let service = NotificationService(provider: fake)
+        let stream = service.actions()
+
+        let result = service.handleResponseValues(
+            categoryID: "biscotti.meeting-starting-with-join",
+            actionID: UNNotificationDefaultActionIdentifier,
+            userInfo: [
+                "biscotti.kind": "meeting-starting",
+                "biscotti.eventKey": "ev-join-default"
+            ]
+        )
+
+        #expect(result == true)
+
+        var iterator = stream.makeAsyncIterator()
+        let action = await iterator.next()
+        #expect(action == .openAndRecord(eventKey: "ev-join-default"))
     }
 
     @Test("Default action on ad-hoc maps to openAndRecord with nil key")

--- a/Packages/BiscottiKit/Tests/SettingsUITests/SettingsNotificationSettingsTests.swift
+++ b/Packages/BiscottiKit/Tests/SettingsUITests/SettingsNotificationSettingsTests.swift
@@ -1,0 +1,146 @@
+import AppCore
+import BiscottiTestSupport
+import DataStore
+import Foundation
+import Permissions
+import Testing
+@testable import SettingsUI
+
+@Suite("SettingsViewModel -- notification settings")
+@MainActor
+struct SettingsNotificationSettingsTests {
+    // MARK: - Defaults
+
+    @Test("monitorForMeetings defaults to true")
+    func monitorDefault() throws {
+        let fix = try makeCoreFixture()
+        defer { fix.cleanup() }
+        let viewModel = SettingsViewModel(core: fix.core)
+        #expect(viewModel.monitorForMeetings == true)
+    }
+
+    @Test("stopRecordingAutomatically defaults to true")
+    func stopRecordingDefault() throws {
+        let fix = try makeCoreFixture()
+        defer { fix.cleanup() }
+        let viewModel = SettingsViewModel(core: fix.core)
+        #expect(viewModel.stopRecordingAutomatically == true)
+    }
+
+    @Test("calendarNotificationMode defaults to allMeetings")
+    func calendarModeDefault() throws {
+        let fix = try makeCoreFixture()
+        defer { fix.cleanup() }
+        let viewModel = SettingsViewModel(core: fix.core)
+        #expect(viewModel.calendarNotificationMode == .allMeetings)
+    }
+
+    // MARK: - Load from store
+
+    @Test("load populates notification settings from store")
+    func loadPopulatesSettings() async throws {
+        let fix = try makeCoreFixture()
+        defer { fix.cleanup() }
+
+        try await fix.store.updateSettings { settings in
+            settings.monitorForMeetings = false
+            settings.stopRecordingAutomatically = false
+            settings.calendarNotificationMode = .never
+        }
+
+        let viewModel = SettingsViewModel(core: fix.core)
+        await viewModel.load()
+
+        #expect(viewModel.monitorForMeetings == false)
+        #expect(viewModel.stopRecordingAutomatically == false)
+        #expect(viewModel.calendarNotificationMode == .never)
+    }
+
+    // MARK: - Setters persist and post
+
+    @Test("setMonitorForMeetings persists and posts notification")
+    func setMonitorPersists() async throws {
+        let fix = try makeCoreFixture()
+        defer { fix.cleanup() }
+        let viewModel = SettingsViewModel(core: fix.core)
+
+        var received = false
+        let token = NotificationCenter.default.addObserver(
+            forName: .monitorForMeetingsDidChange,
+            object: nil,
+            queue: .main
+        ) { _ in received = true }
+        defer { NotificationCenter.default.removeObserver(token) }
+
+        await viewModel.setMonitorForMeetings(false)
+        #expect(viewModel.monitorForMeetings == false)
+        #expect(received)
+
+        let settings = try await fix.store.settings()
+        #expect(settings.monitorForMeetings == false)
+    }
+
+    @Test("setCalendarNotificationMode persists and posts notification")
+    func setCalendarModePersists() async throws {
+        let fix = try makeCoreFixture()
+        defer { fix.cleanup() }
+        let viewModel = SettingsViewModel(core: fix.core)
+
+        var received = false
+        let token = NotificationCenter.default.addObserver(
+            forName: .calendarNotificationModeDidChange,
+            object: nil,
+            queue: .main
+        ) { _ in received = true }
+        defer { NotificationCenter.default.removeObserver(token) }
+
+        await viewModel.setCalendarNotificationMode(.videoConferencing)
+        #expect(viewModel.calendarNotificationMode == .videoConferencing)
+        #expect(received)
+
+        let settings = try await fix.store.settings()
+        #expect(settings.calendarNotificationMode == .videoConferencing)
+    }
+
+    @Test("setStopRecordingAutomatically persists and posts notification")
+    func setStopRecordingPersists() async throws {
+        let fix = try makeCoreFixture()
+        defer { fix.cleanup() }
+        let viewModel = SettingsViewModel(core: fix.core)
+
+        var received = false
+        let token = NotificationCenter.default.addObserver(
+            forName: .stopRecordingAutomaticallyDidChange,
+            object: nil,
+            queue: .main
+        ) { _ in received = true }
+        defer { NotificationCenter.default.removeObserver(token) }
+
+        await viewModel.setStopRecordingAutomatically(false)
+        #expect(viewModel.stopRecordingAutomatically == false)
+        #expect(received)
+
+        let settings = try await fix.store.settings()
+        #expect(settings.stopRecordingAutomatically == false)
+    }
+
+    // MARK: - calendarNotificationsDisabled
+
+    @Test("calendarNotificationsDisabled reflects calendar permission state")
+    func calendarNotificationsDisabledReflectsPermission() throws {
+        let fix = try makeCoreFixture()
+        defer { fix.cleanup() }
+        let viewModel = SettingsViewModel(core: fix.core)
+
+        // Default calendarState is .notDetermined -> disabled
+        #expect(viewModel.calendarNotificationsDisabled == true)
+
+        // Authorize calendar
+        fix.permissions.noteCalendar(.authorized)
+        #expect(viewModel.calendarNotificationsDisabled == false)
+
+        // Deny calendar
+        fix.permissions.noteCalendar(.denied)
+        #expect(viewModel.calendarNotificationsDisabled == true)
+    }
+}

--- a/Packages/BiscottiKit/Tests/SettingsUITests/SettingsStayVisibleTests.swift
+++ b/Packages/BiscottiKit/Tests/SettingsUITests/SettingsStayVisibleTests.swift
@@ -1,0 +1,66 @@
+import BiscottiTestSupport
+import Testing
+import UserNotifications
+@testable import SettingsUI
+
+@Suite("SettingsViewModel -- stay-visible row")
+@MainActor
+struct SettingsStayVisibleTests {
+    @Test("showStayVisibleRow defaults to false before load")
+    func defaultsToFalse() throws {
+        let fix = try makeCoreFixture()
+        defer { fix.cleanup() }
+        let viewModel = SettingsViewModel(core: fix.core)
+        #expect(viewModel.showStayVisibleRow == false)
+    }
+
+    @Test("load sets showStayVisibleRow true when alert style is banner")
+    func loadShowsRowForBanner() async throws {
+        let fix = try makeCoreFixture()
+        defer { fix.cleanup() }
+        fix.fakeNotificationCenter.backing.scriptedAlertStyle = .banner
+        let viewModel = SettingsViewModel(core: fix.core)
+        await viewModel.load()
+        #expect(viewModel.showStayVisibleRow == true)
+    }
+
+    @Test("load sets showStayVisibleRow false when alert style is alert")
+    func loadHidesRowForAlert() async throws {
+        let fix = try makeCoreFixture()
+        defer { fix.cleanup() }
+        fix.fakeNotificationCenter.backing.scriptedAlertStyle = .alert
+        let viewModel = SettingsViewModel(core: fix.core)
+        await viewModel.load()
+        #expect(viewModel.showStayVisibleRow == false)
+    }
+
+    @Test("load sets showStayVisibleRow false when alert style is none")
+    func loadHidesRowForNone() async throws {
+        let fix = try makeCoreFixture()
+        defer { fix.cleanup() }
+        fix.fakeNotificationCenter.backing.scriptedAlertStyle = .none
+        let viewModel = SettingsViewModel(core: fix.core)
+        await viewModel.load()
+        #expect(viewModel.showStayVisibleRow == false)
+    }
+
+    @Test("refreshAlertStyle updates showStayVisibleRow")
+    func refreshUpdatesRow() async throws {
+        let fix = try makeCoreFixture()
+        defer { fix.cleanup() }
+        fix.fakeNotificationCenter.backing.scriptedAlertStyle = .banner
+        let viewModel = SettingsViewModel(core: fix.core)
+        await viewModel.load()
+        #expect(viewModel.showStayVisibleRow == true)
+
+        // Simulate user switching to Alerts in System Settings
+        fix.fakeNotificationCenter.backing.scriptedAlertStyle = .alert
+        await viewModel.refreshAlertStyle()
+        #expect(viewModel.showStayVisibleRow == false)
+
+        // Simulate switching back to Banners
+        fix.fakeNotificationCenter.backing.scriptedAlertStyle = .banner
+        await viewModel.refreshAlertStyle()
+        #expect(viewModel.showStayVisibleRow == true)
+    }
+}

--- a/specs/projects/notification_ui/architecture.md
+++ b/specs/projects/notification_ui/architecture.md
@@ -1,0 +1,404 @@
+---
+status: complete
+---
+
+# Architecture: Notification UI
+
+Single-document architecture. Every change is to **existing** components — no new modules. The work spans five layers: `DataStore` (persistence), `Notifications` (content/actions/alert-style), `AppCore` (cached settings + gating), `SettingsUI` (the controls), and the App-target `AppDelegate` (URL-open / window glue).
+
+> **Design note — the monitor always runs.** The audio-activity monitor observes only per-process audio I/O *flags* (`kAudioProcessPropertyIsRunningInput/Output`), never audio content, so there is no privacy reason to stop it. It runs continuously as today; the three settings are pure presentation/behavior gates. No detector start/stop, no lifecycle reconcile.
+
+Concrete anchors are cited as `file:line` from the pre-change tree.
+
+---
+
+## 1. Data model
+
+### 1.1 New enum — `CalendarNotificationMode`
+
+New file `Packages/BiscottiKit/Sources/DataStore/Models/CalendarNotificationMode.swift`, mirroring `MenuBarLeadTime`'s shape:
+
+```swift
+public enum CalendarNotificationMode: String, CaseIterable, Sendable, Identifiable {
+    case allMeetings
+    case videoConferencing
+    case never
+
+    public var id: String { rawValue }
+
+    public var displayText: String {
+        switch self {
+        case .allMeetings: "All Meetings"
+        case .videoConferencing: "Meetings with Video Conferencing"
+        case .never: "Never"
+        }
+    }
+
+    /// Stored-string → enum, defaulting to `.allMeetings` for unknown values.
+    public init(raw: String) { self = Self(rawValue: raw) ?? .allMeetings }
+}
+```
+
+Lives in `DataStore` because both `SettingsUI` and `AppCore` already depend on `DataStore` (same home as `MenuBarLeadTime`).
+
+### 1.2 `AppSettings` (`@Model`) — three new stored properties
+
+In `DataStore/Models/AppSettings.swift` (after `onboardingComplete`, before the calendar-IDs block), add primitives with defaults (store the **raw String** for the mode — SwiftData + String is the safe pattern used throughout this model):
+
+```swift
+public var monitorForMeetings: Bool = true
+public var stopRecordingAutomatically: Bool = true
+public var calendarNotificationModeRaw: String = "allMeetings"   // CalendarNotificationMode.allMeetings.rawValue
+```
+
+Add matching parameters (with the same defaults) to `init(...)` (`AppSettings.swift:61`).
+
+### 1.3 `AppSettingsData` (DTO) — typed fields
+
+In `DataStore+ReadModels.swift:122`, add to the Sendable DTO. The DTO exposes the **typed enum** (cleaner than the menu-bar `Int` pattern, and the enum lives in `DataStore`):
+
+```swift
+public var monitorForMeetings: Bool
+public var stopRecordingAutomatically: Bool
+public var calendarNotificationMode: CalendarNotificationMode
+```
+
+Defaults in the DTO `init`: `true`, `true`, `.allMeetings`.
+
+### 1.4 `DataStore.settings()` / `updateSettings(_:)`
+
+In `DataStore+ReadModels.swift:390` and `:411`, extend the model↔DTO mapping:
+
+- **Read** (`settings()`): `monitorForMeetings: existing.monitorForMeetings`, `stopRecordingAutomatically: existing.stopRecordingAutomatically`, `calendarNotificationMode: CalendarNotificationMode(raw: existing.calendarNotificationModeRaw)`.
+- **Write** (`updateSettings`): build the DTO the same way, then write back `model.monitorForMeetings = dto.monitorForMeetings`, `model.stopRecordingAutomatically = dto.stopRecordingAutomatically`, `model.calendarNotificationModeRaw = dto.calendarNotificationMode.rawValue`.
+
+No migration needed — SwiftData adds the new columns with their declared defaults for existing rows.
+
+---
+
+## 2. Notifications module
+
+### 2.1 Alert-style readback (for the "Notifications Stay Visible" row)
+
+**Provider seam** (`NotificationCenterProviding.swift:7`) — add:
+
+```swift
+/// Current on-screen alert style (banner vs. alert vs. none).
+func alertStyle() async -> UNAlertStyle
+```
+
+**Live impl** (`LiveNotificationCenter.swift`):
+
+```swift
+public func alertStyle() async -> UNAlertStyle {
+    await UNUserNotificationCenter.current().notificationSettings().alertStyle
+}
+```
+
+**New Sendable enum** (new file `Notifications/NotificationAlertStyle.swift`):
+
+```swift
+public enum NotificationAlertStyle: Sendable, Equatable { case none, banner, alert }
+```
+
+**NotificationService** (`NotificationService.swift`) — public mapper:
+
+```swift
+public func currentAlertStyle() async -> NotificationAlertStyle {
+    switch await provider.alertStyle() {
+    case .none: .none
+    case .banner: .banner
+    case .alert: .alert
+    @unknown default: .banner
+    }
+}
+```
+
+### 2.2 Time-sensitive interruption level
+
+In `makeRequest(for:)` (`NotificationService.swift:252`), set `content.interruptionLevel = .timeSensitive` for **`.meetingStarting`** (inside `fillMeetingStartContent`, `:283`) and **`.adHocDetected`** (`:262`). Leave `.stopCountdown` at the default (out of scope). The `com.apple.developer.usernotifications.time-sensitive` entitlement is **not** added here (deferred to Project 9); without it the level degrades to `.active` — harmless.
+
+### 2.3 Meeting-detected copy (`.adHocDetected` case, `:262`)
+
+```swift
+content.title = "Meeting detected"
+content.subtitle = "App: \(appName)"
+content.body = ""
+content.interruptionLevel = .timeSensitive
+content.sound = .default
+content.categoryIdentifier = CategoryID.adHocDetected
+content.userInfo = [UserInfoKey.kind: KindValue.adHoc, UserInfoKey.bundleID: bundleID]
+```
+
+### 2.4 Calendar-notification actions — "Record & Join" / "Record"
+
+**Identifiers** (`NotificationIdentifiers.swift:16`): remove `openAndRecord` and `join`; add `recordAndJoin`; keep `record`, `keepRecording`:
+
+```swift
+enum ActionID {
+    static let recordAndJoin = "biscotti.action.record-and-join"
+    static let record = "biscotti.action.record"
+    static let keepRecording = "biscotti.action.keep-recording"
+}
+```
+
+**Category registration** (`registerCategories()`, `:182`):
+
+| Category | Action(s) | Title(s) | Options |
+|---|---|---|---|
+| `meetingStarting` (no link) | `record` | "Record" | `[]` |
+| `meetingStartingWithJoin` (link) | `recordAndJoin` | "Record & Join" | `[]` |
+| `adHocDetected` | `record` | "Record" | `[]` (category keeps `.customDismissAction`) |
+| `stopCountdown` | `keepRecording` | "Keep Recording" | unchanged |
+
+> Both calendar actions use options `[]` — we do **not** `.foreground` Biscotti. The browser/meeting app is foregrounded by the link-open instead (handled in the delegate, §5).
+
+**`NotificationAction`** (`NotificationAction.swift:4`): remove the `.join(URL)` case. Remaining: `.openAndRecord(eventKey:)`, `.keepRecording(meetingID:)`.
+
+**`ResponseMapper`** (`ResponseMapper.swift`):
+- `mapMeetingStartResponse` (`:38`): for both meeting categories, any of `recordAndJoin` / `record` / `UNNotificationDefaultActionIdentifier` → `.openAndRecord(eventKey:)`; delete the `.join` branch.
+- `mapAdHocResponse` (`:62`): unchanged (`record` / default → `.openAndRecord(eventKey: nil)`).
+
+### 2.5 Dismiss lingering meeting-detected on record start
+
+Track presented ad-hoc identifiers and expose a cancel:
+
+```swift
+private var presentedAdHocIDs: Set<String> = []
+
+// in present(_:), after a successful add for an .adHocDetected kind:
+//   presentedAdHocIDs.insert(request.identifier)
+
+public func cancelAdHocDetected() async {
+    guard !presentedAdHocIDs.isEmpty else { return }
+    let ids = Array(presentedAdHocIDs)
+    provider.removePendingRequests(withIdentifiers: ids)
+    provider.removeDeliveredNotifications(withIdentifiers: ids)
+    presentedAdHocIDs.removeAll()
+}
+```
+
+(Identifier is `biscotti.notif.adhoc.{bundleID}` — `NotificationIdentifiers.swift:53`.)
+
+---
+
+## 3. AppCore — cached settings & gating
+
+### 3.1 New `Notification.Name`s (`AppCore.swift:14`)
+
+`monitorForMeetingsDidChange`, `calendarNotificationModeDidChange`, `stopRecordingAutomaticallyDidChange` — same `net.scosman.biscotti.*` convention as the existing three.
+
+### 3.2 Cached settings + accessor
+
+New stored properties on `AppCore` (defaults match the model):
+
+```swift
+public private(set) var monitorForMeetings = true
+public private(set) var calendarNotificationMode: CalendarNotificationMode = .allMeetings
+public private(set) var stopRecordingAutomatically = true
+```
+
+Loaded in `onLaunch()` from the snapshot already read at `AppCore.swift:309-314` (add a `loadNotificationSettings(from:)` analogous to `loadMenuBarLeadTime(from:)`), and refreshed by observers (§3.3).
+
+Banner-style helper for the settings row:
+
+```swift
+public func notificationsUseBannerStyle() async -> Bool {
+    await notifications.currentAlertStyle() == .banner
+}
+```
+
+### 3.3 Live observers
+
+Add `startNotificationSettingsObservers()` (called next to `startMenuBarLeadTimeObserver()` at `:318`), spawning one task per name (same `for await … NotificationCenter.default.notifications(named:)` pattern as `:720`). On each event, re-read `store.settings()` and update the cached field. Additionally, `calendarNotificationModeDidChange` → `scheduleCalendarTimers()` so already-scheduled timers match the new mode. The monitor / auto-stop observers only refresh their cached flags — the gates (§3.5, §3.6) read those flags live when detection events fire, so nothing else is required.
+
+### 3.4 The monitor keeps running — no lifecycle management
+
+`startBackgroundServices()` (`:357-363`) is **unchanged**: `detector.start()` + the single `consumeDetectorEvents()` task run for the process lifetime, exactly as today. Because the monitor reads only per-process audio I/O flags (not audio content), it stays always-on; this also means auto-stop works regardless of the Monitor toggle. No reconcile, no stop/restart, no truth table.
+
+### 3.5 Gate the detection notification (`handleDetectionStarted`, `:885`)
+
+Add at the very top: `guard monitorForMeetings else { return }`. When Monitor is off, an incoming `.started` event is dropped here — no notification, no `runState = .detectedPending`. The detector keeps emitting; we simply ignore detection starts for presentation. (Reads the live cached `monitorForMeetings`; the existing `.recording` suppression below it is retained.)
+
+### 3.6 Auto-stop gating (`handleAllMicUsersStopped`, `:941`)
+
+```swift
+private func handleAllMicUsersStopped() {
+    guard stopRecordingAutomatically else { return }
+    guard case let .recording(meetingID) = runState else { return }
+    beginAutoStopCountdown(meetingID: meetingID)
+}
+```
+
+### 3.7 Calendar-timer gating (mode-aware)
+
+**Pure filter** (testable):
+
+```swift
+static func eventsToNotify(
+    _ upcoming: [CalendarEvent], mode: CalendarNotificationMode
+) -> [CalendarEvent] {
+    switch mode {
+    case .never: []
+    case .allMeetings: upcoming.filter(\.isMeetingLike)
+    case .videoConferencing: upcoming.filter { $0.conferenceURL != nil }
+    }
+}
+```
+
+- `scheduleCalendarTimers()` (`:1044`): iterate `Self.eventsToNotify(upcoming, mode: calendarNotificationMode)` instead of `upcoming where event.isMeetingLike`. (`.never` ⇒ all existing timers cancelled and none scheduled.)
+- `handleCalendarTimerFired(event:)` (`:1069`): add a re-check guard against the current mode (`mode == .never` ⇒ bail; `mode == .videoConferencing && event.conferenceURL == nil` ⇒ bail), covering the race between a mode change and reschedule.
+- Calendar permission already gates the data (`upcoming` is empty without auth), so no extra permission guard is needed in AppCore; the disabled-UI is cosmetic (§4).
+
+### 3.8 Cancel ad-hoc on record start (`startRecording`, `:384`)
+
+After the `runState` guard (`:386-388`): `await notifications.cancelAdHocDetected()`. Combined with the existing `.recording` suppression in `handleDetectionStarted`, this satisfies functional-spec **B2** (no meeting-detected banner survives into an active recording).
+
+### 3.9 Notification-action consumer (`consumeNotificationActions`, `:1015`)
+
+Remove the `.join` case (the enum case is gone). `.openAndRecord` and `.keepRecording` unchanged.
+
+---
+
+## 4. SettingsUI
+
+### 4.1 `SettingsViewModel` (`SettingsViewModel.swift`)
+
+New observable state:
+
+```swift
+public private(set) var monitorForMeetings = true
+public private(set) var calendarNotificationMode: CalendarNotificationMode = .allMeetings
+public private(set) var stopRecordingAutomatically = true
+public private(set) var showStayVisibleRow = false   // true only when alert style == .banner
+
+public var calendarNotificationsDisabled: Bool { calendarState != .authorized }
+```
+
+Setters (each mirrors `setMenuBarLeadTime`: optimistic set → persist → post Notification.Name → revert on throw):
+- `setMonitorForMeetings(_:)` → posts `.monitorForMeetingsDidChange`
+- `setCalendarNotificationMode(_:)` → posts `.calendarNotificationModeDidChange`
+- `setStopRecordingAutomatically(_:)` → posts `.stopRecordingAutomaticallyDidChange`
+
+`load()` (`:307`): additionally read the three fields from `settings`, and `showStayVisibleRow = await core.notificationsUseBannerStyle()`.
+
+```swift
+public func refreshAlertStyle() async { showStayVisibleRow = await core.notificationsUseBannerStyle() }
+
+public func openNotificationSettings() {
+    NSWorkspace.shared.open(core.permissions.settingsURL(for: .notifications))
+}
+```
+
+(`settingsURL(for: .notifications)` already returns `x-apple.systempreferences:com.apple.Notifications-Settings.extension` — `Permissions.swift:142`.) No new module import needed: `core.notificationsUseBannerStyle()` returns `Bool`, so `SettingsUI` does **not** depend on `Notifications`.
+
+### 4.2 `SettingsView` (`SettingsView.swift`)
+
+Insert `notificationsSection` between `generalSection` and `permissionsSection` (`:22-25`).
+
+- **Rows 1 & 3** (Monitor, Stop Recording): the `VStack { Toggle; Text(subtitle) }` pattern from "Exit app on window close" (`:55-63`), each with a `Binding<Bool>` wrapper (`Task { await viewModel.setX(newValue) }`).
+- **Row 2** (Calendar dropdown): `VStack(alignment:.leading)` with a `Picker("Calendar Event Notifications", selection: calendarNotificationModeBinding)` over `CalendarNotificationMode.allCases` (`Text(mode.displayText).tag(mode)`); the subtitle below. When `viewModel.calendarNotificationsDisabled`:
+  - `.disabled(true)` on the picker and the display binding's getter returns `.never` (stored value untouched — the setter is inert while disabled).
+  - A warning badge between picker and subtitle: a small capsule, `exclamationmark.triangle.fill` + "Requires Calendar Access", `Tokens.warningChipFill` background + `Tokens.warningChipText` foreground (a private `requiresCalendarAccessBadge` view; reuse `StatChip` styling if it fits).
+- **Row 4** (Stay-visible, conditional on `viewModel.showStayVisibleRow`): `HStack { VStack { Text("Notifications Stay Visible"); Text("Make notifications stay open until clicked or dismissed.").metadata }; Spacer(); Button("Enable") { showAlertsHelp = true } .bordered .controlSize(.small) }`.
+- `@State private var showAlertsHelp = false` → `.sheet(isPresented:)` presents `AlertsHelpSheet` (the §4.3 dialog).
+- Re-check style on return from System Settings:
+  `.onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in Task { await viewModel.refreshAlertStyle() } }`.
+
+### 4.3 Alerts help sheet (new private view in `SettingsView.swift` or a sibling file)
+
+A small modal: title "Keep Notifications On Screen", the explanatory paragraph + the 3 numbered steps (per `ui_design.md`), and buttons **Cancel** (dismiss) / **Open Settings** (`viewModel.openNotificationSettings()` then dismiss). Design-system styling; primary button `.sage`.
+
+---
+
+## 5. App target — `AppDelegate` (`BiscottiApp.swift:571`)
+
+The delegate keeps owning AppKit side effects (URL-open, window foreground); AppCore stays AppKit-free. Rewrite the post-`handleResponseValues` block (`:597-613`) — using the same hardcoded ID strings already in use there:
+
+```swift
+// Open the call link for Record & Join (button or body-tap on a link-bearing calendar notif).
+if categoryID == "biscotti.meeting-starting-with-join",
+   actionID == "biscotti.action.record-and-join"
+     || actionID == UNNotificationDefaultActionIdentifier,
+   let s = userInfo["biscotti.joinURL"] as? String, let url = URL(string: s) {
+    NSWorkspace.shared.open(url)
+}
+
+// Foreground Biscotti only for ad-hoc Record and Keep-Recording — never for calendar notifs.
+let isAdHocRecord = categoryID == "biscotti.ad-hoc-detected"
+    && (actionID == "biscotti.action.record" || actionID == UNNotificationDefaultActionIdentifier)
+let isKeepRecording = actionID == "biscotti.action.keep-recording"
+    || (actionID == UNNotificationDefaultActionIdentifier && categoryID == "biscotti.stop-countdown")
+if isAdHocRecord || isKeepRecording { showMainWindow() }
+```
+
+Removed: the old `biscotti.action.join` URL block and the `open-and-record` window-foreground. The stale code comment about `.join` (AppCore `:1021-1030`, delegate `:584-588`) is deleted with the case.
+
+`willPresent` (`:617`) and `foregroundPresentationOptions` (`NotificationService.swift:171`) are unchanged (`[.banner, .sound]`).
+
+---
+
+## 6. Error handling
+
+Consistent with existing patterns: settings setters revert optimistic UI on a thrown store write; `cancelAdHocDetected()` / detector `start`/`stop` are fire-and-forget (no throw); `currentAlertStyle()` defaults to `.banner` on `@unknown`; URL opens are best-effort (`NSWorkspace.open`). No new fatal paths. Logging via the existing `os.Logger` categories (`Notifications`, AppCore's `detectionLogger`).
+
+---
+
+## 7. Testing strategy
+
+Swift Testing, fakes via existing seams. New/updated unit tests (all runnable under `make test`):
+
+**DataStore**
+- `AppSettings`/DTO round-trip for the three new fields, including defaults on a fresh store and `CalendarNotificationMode(raw:)` fallback for an unknown stored string.
+- `CalendarNotificationMode`: `displayText`, `rawValue` stability, `allCases` order.
+
+**Notifications**
+- `ResponseMapper`: `recordAndJoin` / `record` / default on both meeting categories → `.openAndRecord(eventKey)`; ad-hoc unchanged; dismiss → nil; (no `.join`).
+- `NotificationService` (fake provider capturing requests/categories):
+  - `present(.meetingStarting…)` and `present(.adHocDetected…)` set `interruptionLevel == .timeSensitive`; ad-hoc sets `title == "Meeting detected"`, `subtitle == "App: …"`.
+  - Registered categories carry the new action ids/titles ("Record & Join", "Record").
+  - `cancelAdHocDetected()` removes exactly the presented ad-hoc identifiers (pending + delivered) and clears tracking.
+  - `currentAlertStyle()` maps each `UNAlertStyle` (fake scripts the value).
+
+**AppCore**
+- `eventsToNotify(_:mode:)` — `.never` ⇒ empty; `.videoConferencing` ⇒ only `conferenceURL != nil`; `.allMeetings` ⇒ `isMeetingLike`.
+- Detection-notification gating: `handleDetectionStarted` no-ops (no present, no `detectedPending`) when `monitorForMeetings == false`; presents when true (drive via the existing AppCore test harness / fake detector stream + a notifications spy).
+- Auto-stop gating: `handleAllMicUsersStopped` no-ops when `stopRecordingAutomatically == false`; fires when true + recording.
+- `startRecording` calls `notifications.cancelAdHocDetected()` (spy on the notifications seam).
+- Live-toggle wiring: posting each `Notification.Name` updates the cached field; `calendarNotificationModeDidChange` reschedules timers (assert via the pure helper + a scheduler spy).
+
+**SettingsUI**
+- `SettingsViewModel` setters persist + post the right `Notification.Name` and revert on a failing store seam.
+- `load()` populates the three fields; `showStayVisibleRow` reflects a scripted banner/alert/none style; `calendarNotificationsDisabled` reflects `calendarState`.
+
+**App target / manual.** The `AppDelegate` URL-open / window-foreground branch is thin AppKit glue (its decision logic is covered by `ResponseMapper` tests). Notification *presentation* (dwell, time-sensitive prominence, the alert-style row self-hiding, deep link) is not unit-testable → cover in a manual hardware smoke test.
+
+**Manual-test gate.** This project does **not** modify `Packages/AudioCapture` or `Packages/Transcription`, so the `ac_*`/`tx_*` manual-test results and the `manual-tests-check` gate are **untouched** (no `not-run` marking needed). Detection/notification behavior should still be smoke-tested on hardware before sign-off, but it is outside that gate.
+
+---
+
+## 8. File-change summary
+
+| File | Change |
+|---|---|
+| `DataStore/Models/CalendarNotificationMode.swift` | **new** enum |
+| `DataStore/Models/AppSettings.swift` | +3 stored props + init params |
+| `DataStore/DataStore+ReadModels.swift` | DTO +3 fields; read/write mapping |
+| `Notifications/NotificationAlertStyle.swift` | **new** enum |
+| `Notifications/NotificationCenterProviding.swift` | + `alertStyle()` |
+| `Notifications/LiveNotificationCenter.swift` | impl `alertStyle()` |
+| `Notifications/NotificationService.swift` | `currentAlertStyle()`; `.timeSensitive`; ad-hoc copy; categories; `cancelAdHocDetected()` + tracking |
+| `Notifications/NotificationIdentifiers.swift` | `ActionID`: −openAndRecord/−join, +recordAndJoin |
+| `Notifications/NotificationAction.swift` | remove `.join` |
+| `Notifications/ResponseMapper.swift` | meeting-start mapping; drop `.join` |
+| `AppCore/AppCore.swift` | 3 Notification.Names; cached settings + loader; observers (calendar-mode reschedules); `notificationsUseBannerStyle()`; `handleDetectionStarted` monitor guard; auto-stop guard; `eventsToNotify` + timer gating; `cancelAdHocDetected` on start; drop `.join` consumer case |
+| `SettingsUI/SettingsViewModel.swift` | new props/setters; `load()`; `refreshAlertStyle()`; `openNotificationSettings()` |
+| `SettingsUI/SettingsView.swift` | `notificationsSection`; badge; stay-visible row; help sheet; active-refresh |
+| `App/Sources/BiscottiApp.swift` | delegate URL-open / window-foreground rewrite |
+| `…/Tests/**` | tests per §7 |
+
+---
+
+## 9. Out of scope (reaffirmed)
+
+Time-sensitive **entitlement** (Project 9); stop-countdown copy/behavior; notification-permission request flow; capture/recording internals; onboarding changes; localization.

--- a/specs/projects/notification_ui/architecture.md
+++ b/specs/projects/notification_ui/architecture.md
@@ -296,11 +296,12 @@ public func openNotificationSettings() {
 
 Insert `notificationsSection` between `generalSection` and `permissionsSection` (`:22-25`).
 
-- **Rows 1 & 3** (Monitor, Stop Recording): the `VStack { Toggle; Text(subtitle) }` pattern from "Exit app on window close" (`:55-63`), each with a `Binding<Bool>` wrapper (`Task { await viewModel.setX(newValue) }`).
+- **Row 1** (Monitor for Meetings): the `VStack { Toggle; Text(subtitle) }` pattern from "Exit app on window close" (`:55-63`), with a `Binding<Bool>` wrapper (`Task { await viewModel.setX(newValue) }`).
 - **Row 2** (Calendar dropdown): `VStack(alignment:.leading)` with a `Picker("Calendar Event Notifications", selection: calendarNotificationModeBinding)` over `CalendarNotificationMode.allCases` (`Text(mode.displayText).tag(mode)`); the subtitle below. When `viewModel.calendarNotificationsDisabled`:
   - `.disabled(true)` on the picker and the display binding's getter returns `.never` (stored value untouched — the setter is inert while disabled).
   - A warning badge between picker and subtitle: a small capsule, `exclamationmark.triangle.fill` + "Requires Calendar Access", `Tokens.warningChipFill` background + `Tokens.warningChipText` foreground (a private `requiresCalendarAccessBadge` view; reuse `StatChip` styling if it fits).
-- **Row 4** (Stay-visible, conditional on `viewModel.showStayVisibleRow`): `HStack { VStack { Text("Notifications Stay Visible"); Text("Make notifications stay open until clicked or dismissed.").metadata }; Spacer(); Button("Enable") { showAlertsHelp = true } .bordered .controlSize(.small) }`.
+- **Row 3** (Stay-visible, conditional on `viewModel.showStayVisibleRow`): `HStack { VStack { Text("Notifications Stay Visible"); Text("Make notifications stay open until clicked or dismissed.").metadata }; Spacer(); Button("Enable") { showAlertsHelp = true } .bordered .controlSize(.small) }`.
+- **Stop Recording Automatically** lives in the **General** section (not Notifications) — same `VStack { Toggle; Text(subtitle) }` pattern, placed after the global-shortcut toggle.
 - `@State private var showAlertsHelp = false` → `.sheet(isPresented:)` presents `AlertsHelpSheet` (the §4.3 dialog).
 - Re-check style on return from System Settings:
   `.onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in Task { await viewModel.refreshAlertStyle() } }`.

--- a/specs/projects/notification_ui/functional_spec.md
+++ b/specs/projects/notification_ui/functional_spec.md
@@ -1,0 +1,147 @@
+---
+status: complete
+---
+
+# Functional Spec: Notification UI
+
+## Scope
+
+Two coupled changes to Biscotti's notification experience:
+
+1. **Notification settings** — three new user-facing controls on the Settings page (two toggles + one dropdown), each wired to live app behavior.
+2. **Notification presentation & copy** — fix dwell/persistence, simplify copy, and correct the click/button behavior for the two foreground-flow notifications: the **calendar-event** notification and the **meeting-detected** notification.
+
+The auto-stop **countdown** notification and the notification-permission request flow are unchanged except where noted.
+
+---
+
+## Part A — Notification Settings
+
+All three settings live in a new **"Notifications"** section on the Settings page (placement/ordering is a UI-design detail). Each persists to the existing SwiftData `AppSettings` store and takes effect **live** (no app restart), following the established pattern: ViewModel setter writes the store and posts a `Notification.Name` that `AppCore` observes to start/stop the relevant service.
+
+### A1. Monitor for Meetings
+
+- **Control:** Toggle. **Default: on.**
+- **Title:** "Monitor for Meetings"
+- **Subtitle:** "Detect when an app starts using your microphone and offer to record. Nothing is recorded or processed unless you start recording."
+- **Behavior when ON:** When an app starts using audio I/O (a meeting), Biscotti posts a **meeting-detected** notification offering to record.
+- **Behavior when OFF:** No meeting-detected notifications are posted (and no "detected-pending" state transition). The lightweight audio-activity monitor itself **keeps running** — it only observes *which apps have audio input/output active* (boolean flags from Core Audio process listeners), never any audio content, so there's no privacy reason to stop it and dependent features (e.g. auto-stop) keep working. "Off" simply silences the detection prompts.
+- **Interaction with auto-stop (A3):** Fully independent. The monitor always runs, so A3 works regardless of A1. A1 gates only the detection *notification*; A3 gates only the auto-stop.
+- **Permission dependency:** None. No badge.
+
+### A2. Calendar Event Notifications
+
+- **Control:** **Dropdown / Picker** (3 options). **Default: "All Meetings."**
+  - **All Meetings** — notify before any *meeting-like* calendar event starts. "Meeting-like" = not all-day, not a birthday, and (has a detected video-call link **OR** has 2+ attendees).
+  - **Meetings with Video Conferencing** — notify only for events where a video-call/conference link was detected.
+  - **Never** — never post calendar-event notifications.
+- **Title:** "Calendar Event Notifications"
+- **Subtitle:** "Show a notification to record and join when a calendar event starts."
+- **Disabled / no-permission state:** When calendar access is **not** authorized, the dropdown is **disabled**, **renders as "Never,"** and shows a yellow **"[Requires Calendar Access]"** badge (warning-ochre chip, reusing the design-system warning tokens). The stored value is preserved and restored once access is granted; while unauthorized the effective behavior is "Never" regardless of stored value.
+- **Permission dependency:** Calendar (EventKit) authorization, read from the existing observable permission state.
+
+### A3. Stop Recording Automatically
+
+- **Control:** Toggle. **Default: on.**
+- **Title:** "Stop Recording Automatically"
+- **Subtitle:** "Stop recording when we detect your meeting has ended."
+- **Behavior when ON:** Current behavior — when all non-Biscotti microphone users stop during an active recording, begin the auto-stop countdown (with its "Keep Recording" notification) and stop if not cancelled.
+- **Behavior when OFF:** Never auto-stop; never post the countdown notification. Recording stops only on explicit user action.
+
+---
+
+## Part B — Notification Presentation & Copy
+
+### B0. Persistence (applies to B1 and B2)
+
+**Constraint (validated against macOS docs):** there is **no public API** to set a notification's on-screen dwell time or force "stay until dismissed." On-screen persistence is governed by the user's per-app **Alerts vs. Banners** style in System Settings → Notifications (Banners auto-dismiss after ~5s; Alerts persist until dismissed). `interruptionLevel` controls prominence/Focus-breakthrough, **not** dwell. Notifications *with action buttons* render in the more persistent alert presentation. The "hide after exactly 1 minute" goal is not achievable; the accepted fallback is "stay until dismissed," which requires Alerts style.
+
+**Approach (chosen):**
+1. Set `interruptionLevel = .timeSensitive` on the calendar-event and meeting-detected notifications (more prominent; breaks through Focus when permitted). The `com.apple.developer.usernotifications.time-sensitive` **entitlement is deferred to the signing project (Project 9)**; until it's added, `.timeSensitive` degrades harmlessly to `.active`.
+2. Keep/relabel **action buttons** on both notifications (alert-style presentation).
+3. Add a **self-hiding Settings row** guiding the user to set Biscotti's notification style to **"Alerts"** (for true stay-until-dismissed). See **B3**.
+
+Both notifications already remain in **Notification Center** until dismissed — that part is unchanged.
+
+### B1. Calendar-event notification
+
+Two variants, selected by whether a video-call link was detected on the event:
+
+**Variant 1 — event has a video-call link:**
+- **Title:** event title (unchanged).
+- **Subtitle/body:** unchanged from today (no new copy requested).
+- **Single action button:** **"Record & Join."** (Label says "Join"; behavior = start recording **and** open the call link.)
+- **Default action (tap the notification body):** same as the button — start recording **and** open the call link.
+- **Foreground behavior:** opening the link brings the meeting app/browser to the front. Biscotti's own main window is **not** forced to the foreground (recording runs in the menu-bar background). Differs from today, which foregrounded Biscotti. *(Confirmed.)*
+- Replaces today's two-button design ("Open & Record" + "Join"); the single "Record & Join" covers both. There is **no** separate "Join-only" button — intentionally removed. A user who wants to join *without* recording can use macOS Calendar's own event notification. *(Confirmed.)*
+
+**Variant 2 — event has no video-call link** (only reachable when the dropdown is "All Meetings"):
+- **Title:** event title.
+- **Single action button:** **"Record"** (record only — there is no link to open).
+- **Default action:** start recording. Background record; Biscotti window not forced foreground.
+
+### B2. Meeting-detected notification
+
+- **Title:** "Meeting detected" (was "Meeting detected in {App}").
+- **Subtitle:** "App: {AppName}" — e.g. "App: Safari" (uses the notification `subtitle` field; body cleared).
+- **Action button:** "Record" (unchanged) — records the detected app's meeting.
+- **Suppression — must not appear during an active recording:**
+  1. Keep the existing guard that suppresses *posting* when a recording is in progress.
+  2. **Additionally**, when any recording **starts**, remove any already-delivered/pending meeting-detected notification(s) so a banner that arrived microseconds before "Record" doesn't linger on screen during recording.
+  3. **Investigate root cause** of the reported "appeared while already recording" case and fix it (likely a race between detection-event delivery and recording start, or a stale already-delivered notification — points 1–2 should cover both, but confirm).
+  - The existing calendar-notification suppression window (don't post meeting-detected shortly after a calendar notification) is retained.
+- **Persistence:** per B0.
+
+### B3. "Notifications Stay Visible" row (the Alerts-style guidance)
+
+A **self-hiding row** in the Settings → Notifications section that guides the user to switch Biscotti's macOS notification style to **Alerts** (the only way to get stay-until-dismissed). No onboarding step, no popup, no just-in-time nag.
+
+- **Row title:** "Notifications Stay Visible"
+- **Subtitle:** "Make notifications stay open until clicked or dismissed."
+- **Button:** "Enable."
+- **Button action:** opens an **explanatory dialog** (sheet/alert) — macOS controls notification dwell, so we can't flip it for the user; the dialog explains how and offers a button to **open System Settings → Notifications** (deep-link; best-effort target of Biscotti, with a one-line "find Biscotti, choose Alerts" instruction since macOS may not pre-select the app). The dialog does not itself change any setting.
+- **Visibility rule (self-hiding):** read the current `UNNotificationSettings.alertStyle`.
+  - `.banner` → **show** the row (notifications are on but transient — this is who we're helping).
+  - `.alert` → **hide** entirely (goal already met).
+  - `.none` → **hide** (notifications are off; the existing Notifications permission row handles that case).
+  - Re-evaluate when the app/Settings becomes active again, so the row disappears right after the user switches to Alerts.
+
+---
+
+## Part C — Behavior Wiring (what each setting gates)
+
+| Setting | Gates |
+|---|---|
+| **Monitor for Meetings** (A1) | Whether **meeting-detected notifications** are presented (and the detected-pending transition happens). The audio-activity monitor always runs regardless. |
+| **Calendar Event Notifications** (A2) | Whether calendar-start notifications are scheduled/posted, and for which events: *All Meetings* → all meeting-like events; *Meetings with Video Conferencing* → link-only; *Never* → none. |
+| **Stop Recording Automatically** (A3) | Whether the auto-stop countdown + stop fires when a meeting's mic activity ends during a recording. |
+
+**No monitor lifecycle management.** The audio-activity monitor runs continuously (as today) — it reads only per-process audio I/O flags, not audio content, so there is no privacy reason to stop it. A1 and A3 are pure presentation/behavior gates, checked when their respective detection events fire; toggling them takes effect live with no starting/stopping of the monitor.
+
+---
+
+## Edge Cases
+
+- **Calendar permission revoked while dropdown is "All Meetings"/"Video":** dropdown becomes disabled, renders "Never," shows the badge; no calendar notifications fire (calendar fetch already requires auth). Stored mode is preserved and restored on re-grant.
+- **Calendar permission granted while app running:** dropdown re-enables and restores the stored mode; badge disappears. (Relies on the existing observable permission refresh.)
+- **Notification permission not granted:** no notifications post (existing behavior); the Alerts-style nudge (B0.3) is only meaningful once notifications are authorized.
+- **Monitor off + recording started manually + auto-stop on:** auto-stop still works — the monitor always runs; A1 only suppressed the detection *notification*, not the monitor.
+- **Meeting detected for the same app that's already being recorded:** suppressed (covered by B2 suppression).
+- **Event with a link but the link fails to open:** recording still starts; link-open failure is logged, not surfaced as an error (best-effort, matches current `NSWorkspace.open` behavior).
+- **Dropdown = "Never" but Monitor on:** ad-hoc meeting-detected notifications still fire; only calendar notifications are suppressed. (The two are independent surfaces.)
+
+---
+
+## Out of Scope
+
+- The auto-stop **countdown** notification's copy/behavior (only gated on/off by A3).
+- The notification-permission **request** flow and its UI.
+- Adding the time-sensitive **entitlement** (deferred to the signing project, Project 9).
+- Any change to *which* audio is captured, recording quality, or the detector's debounce tuning.
+- Localization of the new copy.
+
+---
+
+## Open Items for Review
+
+_All major behavior decisions resolved. Remaining details (exact section ordering, dialog copy, badge styling) are handled in the UI-design step._

--- a/specs/projects/notification_ui/functional_spec.md
+++ b/specs/projects/notification_ui/functional_spec.md
@@ -17,7 +17,7 @@ The auto-stop **countdown** notification and the notification-permission request
 
 ## Part A — Notification Settings
 
-All three settings live in a new **"Notifications"** section on the Settings page (placement/ordering is a UI-design detail). Each persists to the existing SwiftData `AppSettings` store and takes effect **live** (no app restart), following the established pattern: ViewModel setter writes the store and posts a `Notification.Name` that `AppCore` observes to start/stop the relevant service.
+Two of the three settings live in a new **"Notifications"** section on the Settings page; "Stop Recording Automatically" lives in the General section (see `ui_design.md`). Each persists to the existing SwiftData `AppSettings` store and takes effect **live** (no app restart), following the established pattern: ViewModel setter writes the store and posts a `Notification.Name` that `AppCore` observes to start/stop the relevant service.
 
 ### A1. Monitor for Meetings
 

--- a/specs/projects/notification_ui/implementation_plan.md
+++ b/specs/projects/notification_ui/implementation_plan.md
@@ -15,7 +15,7 @@ Three phases, each a coherent, independently reviewable unit. Details live in `f
   - `SettingsUI`: `SettingsViewModel` props/setters/`load`; `SettingsView` "Notifications" section — two toggles + the calendar-mode `Picker` with the disabled/"Requires Calendar Access" badge (arch §4.1–4.2, ui_design §Rows 1–3).
   - Tests: `DataStore` round-trip + enum; `eventsToNotify`; detection-notification + auto-stop gating; live-toggle wiring; ViewModel setters/load (arch §7).
 
-- [ ] **Phase 2 — Notification presentation & copy.**
+- [x] **Phase 2 — Notification presentation & copy.**
   The meeting-detected and calendar-event notifications themselves.
   - `Notifications`: meeting-detected copy → "Meeting detected" / "App: {name}"; `.timeSensitive` on both kinds; "Record & Join"/"Record" action rework (`ActionID`, categories, `NotificationAction` drop `.join`, `ResponseMapper`); `cancelAdHocDetected()` + presented-ID tracking (arch §2.2–2.5).
   - `AppCore`: call `cancelAdHocDetected()` at the top of `startRecording`; drop the `.join` consumer case (arch §3.8–3.9).

--- a/specs/projects/notification_ui/implementation_plan.md
+++ b/specs/projects/notification_ui/implementation_plan.md
@@ -12,7 +12,7 @@ Three phases, each a coherent, independently reviewable unit. Details live in `f
   The three settings end-to-end, including the behavior they gate.
   - `DataStore`: new `CalendarNotificationMode` enum; `AppSettings` + `AppSettingsData` + read/write mapping (arch §1).
   - `AppCore`: 3 `Notification.Name`s, cached settings + loader, live observers (arch §3.1–3.3); the three gates — monitor guard in `handleDetectionStarted`, auto-stop guard in `handleAllMicUsersStopped`, `eventsToNotify(_:mode:)` + calendar-timer gating/re-check (arch §3.5–3.7).
-  - `SettingsUI`: `SettingsViewModel` props/setters/`load`; `SettingsView` "Notifications" section — two toggles + the calendar-mode `Picker` with the disabled/"Requires Calendar Access" badge (arch §4.1–4.2, ui_design §Rows 1–3).
+  - `SettingsUI`: `SettingsViewModel` props/setters/`load`; `SettingsView` "Notifications" section — Monitor for Meetings toggle + the calendar-mode `Picker` with the disabled/"Requires Calendar Access" badge; "Stop Recording Automatically" toggle in the General section (arch §4.1–4.2, ui_design).
   - Tests: `DataStore` round-trip + enum; `eventsToNotify`; detection-notification + auto-stop gating; live-toggle wiring; ViewModel setters/load (arch §7).
 
 - [x] **Phase 2 — Notification presentation & copy.**
@@ -26,7 +26,7 @@ Three phases, each a coherent, independently reviewable unit. Details live in `f
   The self-hiding Alerts-style nudge.
   - `Notifications`: `NotificationAlertStyle`; provider `alertStyle()`; `NotificationService.currentAlertStyle()` (arch §2.1).
   - `AppCore`: `notificationsUseBannerStyle()` (arch §3.2).
-  - `SettingsUI`: `showStayVisibleRow` + `refreshAlertStyle()` + `openNotificationSettings()`; the conditional row, the help sheet, and the `didBecomeActive` re-check (arch §4.1–4.3, ui_design §Row 4 + dialog).
+  - `SettingsUI`: `showStayVisibleRow` + `refreshAlertStyle()` + `openNotificationSettings()`; the conditional row, the help sheet, and the `didBecomeActive` re-check (arch §4.1–4.3, ui_design §Row 3 + dialog).
   - Tests: `currentAlertStyle()` mapping; ViewModel `showStayVisibleRow` per scripted style (arch §7).
 
 ## Notes

--- a/specs/projects/notification_ui/implementation_plan.md
+++ b/specs/projects/notification_ui/implementation_plan.md
@@ -1,0 +1,36 @@
+---
+status: complete
+---
+
+# Implementation Plan: Notification UI
+
+Three phases, each a coherent, independently reviewable unit. Details live in `functional_spec.md`, `ui_design.md`, and `architecture.md` (referenced by section).
+
+## Phases
+
+- [x] **Phase 1 — Settings: persistence, wiring, UI, and gating.**
+  The three settings end-to-end, including the behavior they gate.
+  - `DataStore`: new `CalendarNotificationMode` enum; `AppSettings` + `AppSettingsData` + read/write mapping (arch §1).
+  - `AppCore`: 3 `Notification.Name`s, cached settings + loader, live observers (arch §3.1–3.3); the three gates — monitor guard in `handleDetectionStarted`, auto-stop guard in `handleAllMicUsersStopped`, `eventsToNotify(_:mode:)` + calendar-timer gating/re-check (arch §3.5–3.7).
+  - `SettingsUI`: `SettingsViewModel` props/setters/`load`; `SettingsView` "Notifications" section — two toggles + the calendar-mode `Picker` with the disabled/"Requires Calendar Access" badge (arch §4.1–4.2, ui_design §Rows 1–3).
+  - Tests: `DataStore` round-trip + enum; `eventsToNotify`; detection-notification + auto-stop gating; live-toggle wiring; ViewModel setters/load (arch §7).
+
+- [ ] **Phase 2 — Notification presentation & copy.**
+  The meeting-detected and calendar-event notifications themselves.
+  - `Notifications`: meeting-detected copy → "Meeting detected" / "App: {name}"; `.timeSensitive` on both kinds; "Record & Join"/"Record" action rework (`ActionID`, categories, `NotificationAction` drop `.join`, `ResponseMapper`); `cancelAdHocDetected()` + presented-ID tracking (arch §2.2–2.5).
+  - `AppCore`: call `cancelAdHocDetected()` at the top of `startRecording`; drop the `.join` consumer case (arch §3.8–3.9).
+  - App target: `AppDelegate` URL-open / window-foreground rewrite (arch §5).
+  - Tests: `ResponseMapper`; `NotificationService` (copy, interruption level, categories, `cancelAdHocDetected`) (arch §7).
+
+- [ ] **Phase 3 — "Notifications Stay Visible" row.**
+  The self-hiding Alerts-style nudge.
+  - `Notifications`: `NotificationAlertStyle`; provider `alertStyle()`; `NotificationService.currentAlertStyle()` (arch §2.1).
+  - `AppCore`: `notificationsUseBannerStyle()` (arch §3.2).
+  - `SettingsUI`: `showStayVisibleRow` + `refreshAlertStyle()` + `openNotificationSettings()`; the conditional row, the help sheet, and the `didBecomeActive` re-check (arch §4.1–4.3, ui_design §Row 4 + dialog).
+  - Tests: `currentAlertStyle()` mapping; ViewModel `showStayVisibleRow` per scripted style (arch §7).
+
+## Notes
+
+- No `Packages/AudioCapture` or `Packages/Transcription` changes — the `manual-tests-check` gate stays untouched.
+- Notification *presentation* (dwell, prominence, deep link, the row self-hiding) needs a manual hardware smoke test before sign-off (arch §7).
+- Time-sensitive **entitlement** is deferred to Project 9; `.timeSensitive` degrades harmlessly until then.

--- a/specs/projects/notification_ui/implementation_plan.md
+++ b/specs/projects/notification_ui/implementation_plan.md
@@ -22,7 +22,7 @@ Three phases, each a coherent, independently reviewable unit. Details live in `f
   - App target: `AppDelegate` URL-open / window-foreground rewrite (arch §5).
   - Tests: `ResponseMapper`; `NotificationService` (copy, interruption level, categories, `cancelAdHocDetected`) (arch §7).
 
-- [ ] **Phase 3 — "Notifications Stay Visible" row.**
+- [x] **Phase 3 — "Notifications Stay Visible" row.**
   The self-hiding Alerts-style nudge.
   - `Notifications`: `NotificationAlertStyle`; provider `alertStyle()`; `NotificationService.currentAlertStyle()` (arch §2.1).
   - `AppCore`: `notificationsUseBannerStyle()` (arch §3.2).

--- a/specs/projects/notification_ui/phase_plans/phase_1.md
+++ b/specs/projects/notification_ui/phase_plans/phase_1.md
@@ -1,0 +1,47 @@
+---
+status: complete
+---
+
+# Phase 1: Settings -- persistence, wiring, UI, and gating
+
+## Overview
+
+Adds three notification settings end-to-end: persistence in DataStore, cached settings + live observers + behavior gating in AppCore, and the SettingsUI section with two toggles, a picker, and a disabled/badge state.
+
+## Steps
+
+### DataStore
+
+1. Create `DataStore/Models/CalendarNotificationMode.swift` with enum mirroring `MenuBarLeadTime` shape (String rawValue, CaseIterable, Sendable, Identifiable, displayText, init(raw:) fallback).
+2. Add three stored properties to `AppSettings.swift`: `monitorForMeetings: Bool = true`, `stopRecordingAutomatically: Bool = true`, `calendarNotificationModeRaw: String = "allMeetings"`. Add matching init parameters.
+3. Add three fields to `AppSettingsData` DTO in `DataStore+ReadModels.swift`: `monitorForMeetings`, `stopRecordingAutomatically`, `calendarNotificationMode: CalendarNotificationMode`. Update `settings()` read mapping and `updateSettings` write mapping.
+
+### AppCore
+
+4. Add three `Notification.Name`s: `monitorForMeetingsDidChange`, `calendarNotificationModeDidChange`, `stopRecordingAutomaticallyDidChange`.
+5. Add cached properties: `monitorForMeetings`, `calendarNotificationMode`, `stopRecordingAutomatically`. Load in `onLaunch()` via `loadNotificationSettings(from:)`.
+6. Add `startNotificationSettingsObservers()` (three tasks mirroring `startMenuBarLeadTimeObserver`). Calendar mode observer also calls `scheduleCalendarTimers()`.
+7. Add monitor guard at top of `handleDetectionStarted`: `guard monitorForMeetings else { return }`.
+8. Add auto-stop guard at top of `handleAllMicUsersStopped`: `guard stopRecordingAutomatically else { return }`.
+9. Add `eventsToNotify(_:mode:)` static filter. Update `scheduleCalendarTimers()` to use it. Add re-check guard in `handleCalendarTimerFired`.
+
+### SettingsUI
+
+10. Add `monitorForMeetings`, `calendarNotificationMode`, `stopRecordingAutomatically` properties + `calendarNotificationsDisabled` computed on `SettingsViewModel`. Add three setters (persist + post Notification.Name + revert on failure). Update `load()`.
+11. Add `notificationsSection` to `SettingsView` between General and Permissions: Monitor toggle (Row 1), Calendar picker with disabled/badge state (Row 2), Stop Recording toggle (Row 3).
+
+## Tests
+
+### DataStore
+- `CalendarNotificationMode` rawValue stability, displayText, allCases count, init(raw:) fallback
+- `AppSettings`/DTO round-trip for the three new fields with defaults and explicit values
+
+### AppCore
+- `eventsToNotify` -- `.never` returns empty; `.videoConferencing` filters to conferenceURL-bearing events; `.allMeetings` filters to isMeetingLike
+- Detection gating: `handleDetectionStarted` no-ops when `monitorForMeetings == false` (no notification, no detectedPending)
+- Auto-stop gating: `handleAllMicUsersStopped` no-ops when `stopRecordingAutomatically == false`
+
+### SettingsUI
+- SettingsViewModel setters persist and post correct Notification.Name
+- SettingsViewModel `load()` populates the three fields from store
+- `calendarNotificationsDisabled` reflects `calendarState`

--- a/specs/projects/notification_ui/phase_plans/phase_2.md
+++ b/specs/projects/notification_ui/phase_plans/phase_2.md
@@ -1,0 +1,57 @@
+---
+status: complete
+---
+
+# Phase 2: Notification presentation & copy
+
+## Overview
+
+Reworks the notification content, categories, and actions for meeting-detected and calendar-event notifications. Updates meeting-detected copy to "Meeting detected" / "App: {name}"; sets `.timeSensitive` on both notification types; replaces the two-button calendar flow (Open & Record + Join) with a single "Record & Join" / "Record" action; removes the `.join` action/enum case entirely; adds `cancelAdHocDetected()` to dismiss lingering meeting-detected banners on record start; and rewrites the AppDelegate URL-open / window-foreground logic.
+
+## Steps
+
+### Notifications module
+
+1. **NotificationIdentifiers.swift** -- Remove `ActionID.openAndRecord` and `ActionID.join`; add `ActionID.recordAndJoin`. Keep `record` and `keepRecording` unchanged.
+
+2. **NotificationAction.swift** -- Remove the `.join(URL)` case. Only `.openAndRecord(eventKey:)` and `.keepRecording(meetingID:)` remain.
+
+3. **NotificationService.swift -- categories** -- Rewrite `registerCategories()`:
+   - `meetingStarting` (no link): single `record` action, title "Record", options `[]`.
+   - `meetingStartingWithJoin` (link): single `recordAndJoin` action, title "Record & Join", options `[]`.
+   - `adHocDetected`: `record` action unchanged, keeps `.customDismissAction`.
+   - `stopCountdown`: `keepRecording` unchanged.
+
+4. **NotificationService.swift -- ad-hoc content** -- In `makeRequest(for:)`, change `.adHocDetected` case: title = "Meeting detected", subtitle = "App: {appName}", body = "", interruptionLevel = `.timeSensitive`.
+
+5. **NotificationService.swift -- meeting-start content** -- In `fillMeetingStartContent`, set `content.interruptionLevel = .timeSensitive`.
+
+6. **NotificationService.swift -- cancelAdHocDetected()** -- Add `presentedAdHocIDs: Set<String>` tracking. In `present(_:)`, after successful add for `.adHocDetected`, insert the request identifier. Add `public func cancelAdHocDetected() async` that removes pending+delivered and clears tracking.
+
+7. **ResponseMapper.swift** -- Rewrite `mapMeetingStartResponse`: for both meeting categories, `recordAndJoin` / `record` / `UNNotificationDefaultActionIdentifier` all map to `.openAndRecord(eventKey:)`. Remove the `.join` branch entirely.
+
+### AppCore
+
+8. **AppCore.swift -- startRecording** -- After the runState guard, call `await notifications.cancelAdHocDetected()`.
+
+9. **AppCore.swift -- consumeNotificationActions** -- Remove the `.join` case (enum case is gone).
+
+### App target
+
+10. **BiscottiApp.swift -- didReceive delegate** -- Rewrite the post-handleResponseValues block:
+    - Open the call link for Record & Join: if category is `meetingStartingWithJoin` and action is `recordAndJoin` or default, open the joinURL.
+    - Foreground Biscotti only for ad-hoc Record and Keep-Recording, never for calendar notifications.
+    - Remove the old `biscotti.action.join` URL block and the `open-and-record` window-foreground.
+
+## Tests
+
+### Notifications
+
+- **ResponseMapper**: `recordAndJoin` / `record` / default on both meeting categories map to `.openAndRecord(eventKey:)`. Ad-hoc unchanged. No `.join` test. Dismiss returns nil.
+- **CategoryRegistration**: Update meeting-starting to expect `record` (title "Record"), no foreground. Update meeting-starting-with-join to expect single `recordAndJoin` (title "Record & Join"), no foreground. Ad-hoc and countdown unchanged.
+- **ContentConstruction**: Ad-hoc sets title = "Meeting detected", subtitle = "App: {name}", body = "". Both meeting-start and ad-hoc set `.timeSensitive`. (Update existing tests + add new assertions.)
+- **cancelAdHocDetected**: Present an ad-hoc, then cancel -- asserts removed pending+delivered IDs match the ad-hoc identifier; clears tracking on second cancel (no-op).
+
+### AppCore
+
+- **startRecording calls cancelAdHocDetected**: Drive through the fixture; present an ad-hoc detection, then startRecording; assert the ad-hoc identifiers appear in removedPendingIDs/removedDeliveredIDs.

--- a/specs/projects/notification_ui/phase_plans/phase_3.md
+++ b/specs/projects/notification_ui/phase_plans/phase_3.md
@@ -1,0 +1,48 @@
+---
+status: complete
+---
+
+# Phase 3: "Notifications Stay Visible" row
+
+## Overview
+
+Adds the self-hiding "Notifications Stay Visible" settings row that guides users to switch Biscotti's macOS notification style to Alerts. This requires: a new `NotificationAlertStyle` enum and `alertStyle()` provider method in the Notifications module, a `currentAlertStyle()` mapper on `NotificationService`, a `notificationsUseBannerStyle()` helper on `AppCore`, and the conditional row + explanatory help sheet in `SettingsUI` (with `showStayVisibleRow`, `refreshAlertStyle()`, `openNotificationSettings()`, and a `didBecomeActive` re-check).
+
+## Steps
+
+### Notifications module
+
+1. **New file `Notifications/NotificationAlertStyle.swift`** -- Public Sendable enum with cases `.none`, `.banner`, `.alert`.
+
+2. **`NotificationCenterProviding.swift`** -- Add `func alertStyle() async -> UNAlertStyle` to the protocol.
+
+3. **`LiveNotificationCenter.swift`** -- Implement `alertStyle()`: return `await UNUserNotificationCenter.current().notificationSettings().alertStyle`.
+
+4. **`NotificationService.swift`** -- Add `public func currentAlertStyle() async -> NotificationAlertStyle` that maps the provider's `UNAlertStyle` to the app's enum (`.none` -> `.none`, `.banner` -> `.banner`, `.alert` -> `.alert`, `@unknown default` -> `.banner`).
+
+### FakeNotificationCenter (test support)
+
+5. **`FakeNotificationCenter.swift`** (in NotificationsTests) -- Add `var scriptedAlertStyle: UNAlertStyle = .banner` to Backing and implement `alertStyle()`.
+
+6. **`CoreFixture.swift`** (in BiscottiTestSupport) -- Add `var scriptedAlertStyle: UNAlertStyle = .banner` to `FakeTestNotificationCenter.Backing` and implement `alertStyle()`.
+
+### AppCore
+
+7. **`AppCore.swift`** -- Add `public func notificationsUseBannerStyle() async -> Bool` returning `await notifications.currentAlertStyle() == .banner`.
+
+### SettingsUI
+
+8. **`SettingsViewModel.swift`** -- Add `public private(set) var showStayVisibleRow = false`. In `load()`, set `showStayVisibleRow = await core.notificationsUseBannerStyle()`. Add `public func refreshAlertStyle() async` and `public func openNotificationSettings()`.
+
+9. **`SettingsView.swift`** -- Add Row 4 (conditional on `viewModel.showStayVisibleRow`) inside `notificationsSection`: HStack with title/subtitle VStack + "Enable" button. Add `@State private var showAlertsHelp = false` and `.sheet(isPresented:)` presenting `AlertsHelpSheet`. Add `.onReceive(NSApplication.didBecomeActiveNotification)` to call `refreshAlertStyle()`.
+
+10. **`AlertsHelpSheet` view** (new private view in a sibling file or same file) -- Modal sheet with title "Keep Notifications On Screen", explanatory text, 3 numbered steps, Cancel + Open Settings buttons.
+
+## Tests
+
+### Notifications
+- `currentAlertStyle()` maps each `UNAlertStyle` value (`.none`, `.banner`, `.alert`) to the correct `NotificationAlertStyle` case. Uses the existing FakeNotificationCenter with a scriptable `alertStyle`.
+
+### SettingsUI
+- `SettingsViewModel.showStayVisibleRow` is `true` when alert style is `.banner`, `false` when `.alert` or `.none`.
+- `refreshAlertStyle()` updates `showStayVisibleRow` to reflect a changed scripted style.

--- a/specs/projects/notification_ui/project_overview.md
+++ b/specs/projects/notification_ui/project_overview.md
@@ -1,0 +1,26 @@
+---
+status: complete
+---
+
+# Notification UI
+
+A project to update Biscotti's in-app notifications — both the notifications themselves (presentation + copy + behavior) and the notification-related settings.
+
+## Notification Settings
+
+Add these three settings to the Settings page, and wire them up:
+
+- **"Monitor for Meetings"** — "Detect when an app starts using your microphone and offer to record. Nothing is recorded or processed unless you start recording." A toggle. Default **on**. When off, don't monitor audio for sending [notifications].
+- **"Calendar Event Notifications"** — "Show a \"Record & Join\" notification when a calendar event with a video call link is about to start." Toggle, default **on**. Disabled and renders as off if no calendar permissions, and add a yellow "[Requires Calendar Access]" badge when disabled because no calendar permissions.
+- **"Stop Recording Automatically"** — "Stop recording when we detect your meeting has ended." Toggle, default **on**.
+
+## Notification presentation and copy
+
+- **Notification for calendar event**
+  - Only appeared for a second; should stay visible 1 min ideally then hide (but still be in the list). If we can't "hide after 1 min," prefer stay open until dismissed (check macOS notification docs/options).
+  - Clicking the notification started recording, but didn't open the link. The default action should be **"Record & Open"**.
+  - Ideally there would be a button on it that says **"Record & Open"**.
+- **"Meeting detected" notification**
+  - Text: simplify the notification to **"Meeting detected"**, and subtitle to **"App: Safari"**. It was too wordy today.
+  - Shown when already recording — should have been filtered, and not appear if recording is in progress.
+  - Only appeared for a second; should stay visible 1 min+ (same as above).

--- a/specs/projects/notification_ui/ui_design.md
+++ b/specs/projects/notification_ui/ui_design.md
@@ -19,6 +19,10 @@ Calendars
 
 Rationale: these are behavioral preferences (siblings of General), and grouping all notification controls together keeps them discoverable. The "Notifications" permission row stays in Permissions as today.
 
+### "Stop Recording Automatically" in General
+
+The "Stop Recording Automatically" toggle + subtitle lives in the **General** section (after the global-shortcut toggle, before the menu-bar lead-time picker). It is a general recording behavior, not a notification setting.
+
 ## "Notifications" section layout
 
 ```
@@ -31,9 +35,6 @@ Rationale: these are behavioral preferences (siblings of General), and grouping 
 │ Calendar Event Notifications        [ All Meetings    ▾ ]    │
 │ Show a notification to record and join when a calendar       │
 │ event starts.                                                │
-│                                                              │
-│ Stop Recording Automatically                      [ ●  ]     │
-│ Stop recording when we detect your meeting has ended.        │
 │                                                              │
 │ Notifications Stay Visible                       [ Enable ]  │  ← only when alertStyle == .banner
 │ Make notifications stay open until clicked or dismissed.     │
@@ -58,10 +59,7 @@ Rationale: these are behavioral preferences (siblings of General), and grouping 
     ```
   - Badge = small capsule, `exclamationmark.triangle.fill` + "Requires Calendar Access", using `Tokens.warningChipFill` background + `Tokens.warningChipText` foreground (warning-ochre). Reuse/adapt the existing `StatChip`-style capsule; architecture decides reuse vs. a small inline helper.
 
-### Row 3 — Stop Recording Automatically
-Same shape as Row 1: `Toggle` + subtitle.
-
-### Row 4 — Notifications Stay Visible (conditional helper)
+### Row 3 — Notifications Stay Visible (conditional helper)
 Only rendered when `viewModel.alertStyle == .banner` (hidden for `.alert` and `.none`). Layout like a settings row with a trailing action button:
 - Leading `VStack`: title **"Notifications Stay Visible"** + subtitle **"Make notifications stay open until clicked or dismissed."**
 - Trailing: `Button("Enable")`, `.buttonStyle(.bordered)`, `.controlSize(.small)` (matches the permission action buttons).
@@ -91,12 +89,12 @@ A modal **sheet** (preferred over `.alert` so the numbered steps read cleanly), 
 - **Open Settings** → deep-links to the macOS Notifications settings pane (best-effort; macOS may not pre-select Biscotti, hence the explicit step 2). Then dismisses the sheet.
 - **Cancel** → dismisses.
 - Styling follows the design system (ivory background, system fonts, `.sage` for the primary button to match existing accents).
-- On return to the app, `alertStyle` is re-read; if now `.alert`, Row 4 disappears.
+- On return to the app, `alertStyle` is re-read; if now `.alert`, Row 3 disappears.
 
 ## Interaction / state notes
 
 - All three controls write through the `SettingsViewModel` (new properties + setters) following the existing `Binding` wrapper pattern; changes apply live.
-- The picker's disabled/badge state and Row 4's visibility derive from observable state already (or newly) exposed on the view model: `calendarState` (exists) and `alertStyle` (new).
+- The picker's disabled/badge state and Row 3's visibility derive from observable state already (or newly) exposed on the view model: `calendarState` (exists) and `alertStyle` (new).
 - No empty/loading states beyond what `SettingsView.task { load() }` already provides.
 
 ## Out of scope (UI)

--- a/specs/projects/notification_ui/ui_design.md
+++ b/specs/projects/notification_ui/ui_design.md
@@ -1,0 +1,105 @@
+---
+status: complete
+---
+
+# UI Design: Notification UI
+
+All new UI lives in the in-window **Settings** screen (`SettingsView`), plus one explanatory dialog. No new windows, no navigation changes. Everything reuses existing `SettingsView` idioms: grouped `Form` sections, the `VStack { control; Text(subtitle) }` row pattern (see "Exit app on window close"), default `Toggle`/`Picker`, and the design-system warning tokens.
+
+## Section placement
+
+A new **"Notifications"** `Section`, inserted between **General** and **Permissions**:
+
+```
+General
+Notifications        ← new
+Permissions
+Calendars
+```
+
+Rationale: these are behavioral preferences (siblings of General), and grouping all notification controls together keeps them discoverable. The "Notifications" permission row stays in Permissions as today.
+
+## "Notifications" section layout
+
+```
+┌─ Notifications ─────────────────────────────────────────────┐
+│ Monitor for Meetings                              [ ●  ]     │
+│ Detect when an app starts using your microphone and offer    │
+│ to record. Nothing is recorded or processed unless you       │
+│ start recording.                                             │
+│                                                              │
+│ Calendar Event Notifications        [ All Meetings    ▾ ]    │
+│ Show a notification to record and join when a calendar       │
+│ event starts.                                                │
+│                                                              │
+│ Stop Recording Automatically                      [ ●  ]     │
+│ Stop recording when we detect your meeting has ended.        │
+│                                                              │
+│ Notifications Stay Visible                       [ Enable ]  │  ← only when alertStyle == .banner
+│ Make notifications stay open until clicked or dismissed.     │
+└──────────────────────────────────────────────────────────────┘
+```
+
+### Row 1 — Monitor for Meetings
+`VStack(alignment:.leading)` containing a `Toggle("Monitor for Meetings", isOn:)` and a subtitle `Text` (`Tokens.metadataFont` / `Tokens.secondaryText`). Mirrors the "Exit app on window close" row.
+
+### Row 2 — Calendar Event Notifications (`Picker`)
+`VStack(alignment:.leading)`:
+- `Picker("Calendar Event Notifications", selection:)` with three tagged options, display text: **"All Meetings"**, **"Meetings with Video Conferencing"**, **"Never"**.
+- Subtitle `Text` below.
+- **No-calendar-permission state** (`calendarState != .authorized`):
+  - Picker is `.disabled(true)` and displays **"Never"** (display binding pins to `.never`; the stored value is untouched and restored when access returns).
+  - A **warning badge** renders on its own line between the picker and the subtitle:
+
+    ```
+    Calendar Event Notifications              [ Never ▾ ]  (dimmed)
+    ⚠ Requires Calendar Access
+    Show a notification to record and join when a calendar event starts.
+    ```
+  - Badge = small capsule, `exclamationmark.triangle.fill` + "Requires Calendar Access", using `Tokens.warningChipFill` background + `Tokens.warningChipText` foreground (warning-ochre). Reuse/adapt the existing `StatChip`-style capsule; architecture decides reuse vs. a small inline helper.
+
+### Row 3 — Stop Recording Automatically
+Same shape as Row 1: `Toggle` + subtitle.
+
+### Row 4 — Notifications Stay Visible (conditional helper)
+Only rendered when `viewModel.alertStyle == .banner` (hidden for `.alert` and `.none`). Layout like a settings row with a trailing action button:
+- Leading `VStack`: title **"Notifications Stay Visible"** + subtitle **"Make notifications stay open until clicked or dismissed."**
+- Trailing: `Button("Enable")`, `.buttonStyle(.bordered)`, `.controlSize(.small)` (matches the permission action buttons).
+- Tapping **Enable** presents the explanatory dialog (below). It does **not** itself change any setting — macOS doesn't allow that.
+
+## Explanatory dialog ("Enable" → how-to)
+
+A modal **sheet** (preferred over `.alert` so the numbered steps read cleanly), presented over Settings:
+
+```
+┌──────────────────────────────────────────────┐
+│  Keep Notifications On Screen                  │
+│                                                │
+│  macOS decides how long notifications stay     │
+│  on screen. To keep Biscotti's notifications   │
+│  visible until you dismiss them, set their     │
+│  style to “Alerts”.                            │
+│                                                │
+│   1.  Open System Settings → Notifications     │
+│   2.  Select Biscotti                          │
+│   3.  Set the alert style to “Alerts”          │
+│                                                │
+│            [ Cancel ]   [ Open Settings ]      │
+└──────────────────────────────────────────────┘
+```
+
+- **Open Settings** → deep-links to the macOS Notifications settings pane (best-effort; macOS may not pre-select Biscotti, hence the explicit step 2). Then dismisses the sheet.
+- **Cancel** → dismisses.
+- Styling follows the design system (ivory background, system fonts, `.sage` for the primary button to match existing accents).
+- On return to the app, `alertStyle` is re-read; if now `.alert`, Row 4 disappears.
+
+## Interaction / state notes
+
+- All three controls write through the `SettingsViewModel` (new properties + setters) following the existing `Binding` wrapper pattern; changes apply live.
+- The picker's disabled/badge state and Row 4's visibility derive from observable state already (or newly) exposed on the view model: `calendarState` (exists) and `alertStyle` (new).
+- No empty/loading states beyond what `SettingsView.task { load() }` already provides.
+
+## Out of scope (UI)
+
+- Notification banners themselves are rendered by macOS; we only control content/buttons/`interruptionLevel` (covered in the functional spec, not a UI surface here).
+- No changes to onboarding, menu bar, or the record screen.


### PR DESCRIPTION
## Summary

Implements the **Notification UI** project (spec: `specs/projects/notification_ui/`) — three phases plus a follow-up tweak — and merges `main`.

### Phase 1 — Settings: persistence, wiring, and gating
- New `CalendarNotificationMode` enum (All meetings / Video conferencing only / Never) + three settings persisted on `AppSettings`/`AppSettingsData`.
- `AppCore` caches the settings at launch, observes live changes, and enforces three behavior gates: detection-notification guard, auto-stop guard, and an `eventsToNotify` calendar filter (with a fire-time re-check).
- New Settings **"Notifications"** section: **Monitor for Meetings** toggle + **Calendar Event Notifications** picker (disabled with a "Requires Calendar Access" badge when calendar permission isn't granted).

### Phase 2 — Notification presentation & copy
- Meeting-detected copy → **"Meeting detected" / "App: {name}"**; `.timeSensitive` interruption level on both calendar-event and meeting-detected notifications.
- Action rework: single **Record & Join** / **Record** action (replaces the old Open & Record + Join two-button flow); new `ActionID`s/categories, rewritten `ResponseMapper`, `.join` enum case removed.
- `cancelAdHocDetected()` dismisses lingering ad-hoc banners when a recording starts.
- `AppDelegate` rewritten so calendar notifications open the meeting link **without** foregrounding the app; foregrounding only for ad-hoc Record / Keep-Recording.

### Phase 3 — "Notifications Stay Visible" row
- Self-hiding Settings row nudging users to switch macOS notification style to **Alerts** (stay-until-dismissed). Hides automatically once on Alerts or when notifications are off; re-checks on app activation.
- `AlertsHelpSheet` explains the 3 manual steps and deep-links to System Settings → Notifications.
- `NotificationAlertStyle` + provider/service plumbing; `AppCore.notificationsUseBannerStyle()`.

### Follow-up
- Moved **"Stop Recording Automatically"** from the Notifications section into **General** (it's a general recording behavior, not a notification setting). Spec docs updated to match.

### Merge
- Merged `main` (the `system_audio_capture_and_permissions` work — System Audio permission row, probe-tone playback, onboarding step). One conflict in `SettingsView.swift` resolved by keeping main's internal `viewModel` (needed by the `SettingsSystemAudioRow` cross-file extension) plus this branch's `showAlertsHelp` state.

## Testing
- `make build`, `make test`, `make lint` all green post-merge (1471 package tests).
- Note: the `MeetingDetection` "mic-stop debounce" suite has a pre-existing timing-sensitive flake (passes on re-run) — unrelated to this branch.

## Follow-ups / notes
- **Manual hardware smoke test still required before sign-off** for notification *presentation* (dwell, prominence, `.timeSensitive` behavior, deep link, the row self-hiding) — can't be unit-tested.
- The `.timeSensitive` **entitlement** is deferred to Project 9; it degrades harmlessly until then.
- No `AudioCapture`/`Transcription` changes from the notification work itself, so the `manual-tests-check` gate status is unaffected by these phases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
