### PR TITLE
Fix flaky meeting detection: mic-only, edge-driven start/stop

### DIFF
--- a/Packages/BiscottiKit/Sources/MeetingDetection/MeetingDetector.swift
+++ b/Packages/BiscottiKit/Sources/MeetingDetection/MeetingDetector.swift
@@ -12,43 +12,46 @@ private let logger = Logger(
 
 private enum CallPhase {
     case idle
-    case pendingStarted(since: ContinuousClock.Instant)
+    /// Mic came up; waiting for it to stay up for `startDebounce` before
+    /// treating this as a real meeting.
+    case pendingStart
+    /// Meeting confirmed — `.started` has been emitted.
     case active
-    case pendingStop(since: ContinuousClock.Instant)
-
-    var isPendingStop: Bool {
-        if case .pendingStop = self { return true }
-        return false
-    }
+    /// Mic went down while active; waiting for sustained silence
+    /// (`stopDebounce`) before treating the meeting as ended.
+    case pendingStop
 }
 
 private struct AppCallState {
     let app: DetectedApp
     var phase: CallPhase = .idle
-    /// Tracks the most recent in-call flag so debounce resolution can
-    /// decide based on current reality, not stale state at entry time.
-    var latestIsInCall: Bool = false
 }
 
-/// Accumulates OR-merged input/output flags across processes sharing a parent.
+/// OR-merges the mic (input) flag across processes sharing a parent app.
+///
+/// Detection keys on the microphone ONLY. Output is intentionally not a
+/// signal: far too many non-meeting apps play audio. A watch-listed app
+/// *holding the mic*, persistently, is the meeting signal.
 private struct MergedFlags {
     let app: DetectedApp
-    var input: Bool
-    var output: Bool
-
-    var isInCall: Bool {
-        input && output
-    }
+    var mic: Bool
 }
 
 // MARK: - MeetingDetector
 
 /// Observes audio process activity and emits debounced detection events
-/// when meeting apps transition between in-call and idle states.
+/// when a watch-listed meeting app starts or stops using the microphone.
 ///
-/// Uses the `MeetingCatalog` watchlist to filter relevant apps, resolves
-/// helper processes to their parent app, and applies a per-app state
-/// machine with configurable debounce to suppress flapping.
+/// Detection is mic-driven and edge-triggered, with no instantaneous
+/// polling: a meeting becomes `.started` once a watch-listed app holds the
+/// mic *continuously* for `startDebounce`, and `.stopped` once the mic
+/// stays released for `stopDebounce`. Any mic-drop during the start window
+/// aborts (so a brief mic probe never notifies); the debounce timers are
+/// cancelled on the opposite edge rather than re-sampled at fire time, so
+/// the outcome never depends on which instant the timer happens to land on.
+///
+/// Uses the `MeetingCatalog` watchlist to filter relevant apps and resolves
+/// helper processes to their parent app.
 @MainActor @Observable
 public final class MeetingDetector {
     // MARK: - Dependencies
@@ -158,7 +161,7 @@ public final class MeetingDetector {
             switch state.phase {
             case .active, .pendingStop:
                 emit(.stopped(app: state.app))
-            case .idle, .pendingStarted:
+            case .idle, .pendingStart:
                 break
             }
         }
@@ -176,8 +179,8 @@ public final class MeetingDetector {
         // Fires .allMicUsersStopped on the >=1 -> 0 transition.
         updateMicUserTracking(snapshot)
 
-        // Step 1 & 2: Filter to watchlist, resolve helpers, OR-merge
-        // raw input/output flags for processes that share a parent.
+        // Step 1 & 2: Filter to watchlist, resolve helpers, OR-merge the
+        // mic flag for processes that share a parent.
         var merged: [String: MergedFlags] = [:]
 
         for process in snapshot {
@@ -190,37 +193,27 @@ public final class MeetingDetector {
             let name = catalog.displayName(forBundleID: parentID) ?? parentID
 
             if var existing = merged[parentID] {
-                existing.input = existing.input || process.isRunningInput
-                existing.output = existing.output || process.isRunningOutput
+                existing.mic = existing.mic || process.isRunningInput
                 merged[parentID] = existing
             } else {
                 let app = DetectedApp(bundleID: parentID, displayName: name)
                 merged[parentID] = MergedFlags(
                     app: app,
-                    input: process.isRunningInput,
-                    output: process.isRunningOutput
+                    mic: process.isRunningInput
                 )
             }
         }
 
-        // Step 3: Feed per-app state machines.
+        // Step 3: Feed per-app state machines (mic signal only).
         for (parentID, flags) in merged {
-            feedStateMachine(
-                parentID: parentID,
-                app: flags.app,
-                isInCall: flags.isInCall
-            )
+            feedStateMachine(parentID: parentID, app: flags.app, mic: flags.mic)
         }
 
         // Step 4: Handle apps that disappeared from the snapshot.
         let presentParentIDs = Set(merged.keys)
         for parentID in appStates.keys where !presentParentIDs.contains(parentID) {
             guard let state = appStates[parentID] else { continue }
-            feedStateMachine(
-                parentID: parentID,
-                app: state.app,
-                isInCall: false
-            )
+            feedStateMachine(parentID: parentID, app: state.app, mic: false)
         }
     }
 
@@ -229,53 +222,59 @@ public final class MeetingDetector {
     private func feedStateMachine(
         parentID: String,
         app: DetectedApp,
-        isInCall: Bool
+        mic: Bool
     ) {
         let state = appStates[parentID] ?? AppCallState(app: app)
 
         switch state.phase {
         case .idle:
-            if isInCall {
-                enterPendingStarted(parentID: parentID, app: app)
+            if mic {
+                enterPendingStart(parentID: parentID, app: app)
             }
 
-        case .pendingStarted:
-            // Track the latest in-call state so the debounce resolution
-            // can decide based on current reality rather than the state
-            // at the moment pendingStarted began. A brief !isInCall flap
-            // no longer aborts detection — the timer checks at resolve.
-            appStates[parentID]?.latestIsInCall = isInCall
-            if !isInCall {
-                logger.debug("Start-window flap for \(app.displayName) — waiting for debounce resolve")
+        case .pendingStart:
+            if !mic {
+                // Mic dropped before it stayed up for `startDebounce`. Abort
+                // back to idle — a meeting requires the mic to come up AND
+                // stay up. A later sustained mic starts a fresh window. The
+                // timer firing therefore *proves* the mic never dropped, so
+                // there is no instantaneous resolve check.
+                cancelDebounce(for: parentID)
+                appStates.removeValue(forKey: parentID)
+                logger.debug(
+                    "Start aborted for \(app.displayName) — mic dropped before sustained"
+                )
             }
 
         case .active:
-            if !isInCall {
+            if !mic {
                 enterPendingStop(parentID: parentID, app: app)
             }
 
         case .pendingStop:
-            if isInCall {
-                // Cancel stop, return to active
+            if mic {
+                // Mic returned before sustained silence elapsed — still in
+                // the meeting. Cancel the stop and return to active.
                 cancelDebounce(for: parentID)
                 appStates[parentID]?.phase = .active
                 logger.debug(
-                    "Stop cancelled for \(app.displayName) — IO resumed"
+                    "Stop cancelled for \(app.displayName) — mic resumed"
                 )
             }
-            // If still !isInCall, the debounce timer handles the transition
+            // If still no mic, the debounce timer handles the transition.
         }
     }
 
     // MARK: - Debounce scheduling
 
-    private func enterPendingStarted(
-        parentID: String,
-        app: DetectedApp
-    ) {
-        let now = ContinuousClock.now
-        appStates[parentID] = AppCallState(app: app, latestIsInCall: true)
-        appStates[parentID]?.phase = .pendingStarted(since: now)
+    /// Mic came up while idle. Enter `pendingStart` and schedule the
+    /// sustained-mic timer. If the mic drops before it fires,
+    /// `feedStateMachine` cancels this task and returns to idle, so the
+    /// timer only ever fires when the mic stayed up the whole window.
+    private func enterPendingStart(parentID: String, app: DetectedApp) {
+        var newState = AppCallState(app: app)
+        newState.phase = .pendingStart
+        appStates[parentID] = newState
 
         let clock = clock
         let debounce = startDebounce
@@ -286,32 +285,25 @@ public final class MeetingDetector {
         }
     }
 
+    /// The sustained-mic timer fired without being cancelled — i.e. the mic
+    /// stayed up for the whole `startDebounce` window — so promote to active
+    /// and emit `.started`. No instantaneous flag check: the
+    /// cancel-on-mic-drop path guarantees the mic never dropped.
     private func resolveStartDebounce(for parentID: String) {
         guard let state = appStates[parentID],
-              case .pendingStarted = state.phase
+              case .pendingStart = state.phase
         else { return }
 
         debounceTasks.removeValue(forKey: parentID)
-
-        if state.latestIsInCall {
-            appStates[parentID]?.phase = .active
-            emit(.started(app: state.app))
-            logger.info(
-                "Meeting detected: \(state.app.displayName) (\(state.app.bundleID))"
-            )
-        } else {
-            // App was not in-call at resolve time — genuine blip, not a meeting
-            appStates.removeValue(forKey: parentID)
-            logger.debug("Start debounce resolved idle for \(state.app.displayName)")
-        }
+        appStates[parentID]?.phase = .active
+        emit(.started(app: state.app))
+        logger.info(
+            "Meeting detected: \(state.app.displayName) (\(state.app.bundleID))"
+        )
     }
 
-    private func enterPendingStop(
-        parentID: String,
-        app _: DetectedApp
-    ) {
-        let now = ContinuousClock.now
-        appStates[parentID]?.phase = .pendingStop(since: now)
+    private func enterPendingStop(parentID: String, app _: DetectedApp) {
+        appStates[parentID]?.phase = .pendingStop
 
         let clock = clock
         let debounce = stopDebounce
@@ -438,7 +430,9 @@ extension MeetingDetector {
         // restored mic users (cancellation is the primary guard, but
         // this is the belt-and-suspenders check).
         guard !hadNonSelfMicUsers else {
-            logger.debug("Mic-stop debounce resolved but non-self mic users reappeared -- suppressing")
+            logger.debug(
+                "Mic-stop debounce resolved but non-self mic users reappeared -- suppressing"
+            )
             return
         }
         emit(.allMicUsersStopped)

--- a/Packages/BiscottiKit/Tests/MeetingDetectionTests/HelperResolutionTests.swift
+++ b/Packages/BiscottiKit/Tests/MeetingDetectionTests/HelperResolutionTests.swift
@@ -136,7 +136,8 @@ struct HelperResolutionTests {
         collector.start(from: detector)
         detector.start()
 
-        // Neither alone has both flags; OR-merge makes isInCall=true
+        // avconferenced supplies the mic; OR-merge across the shared
+        // parent makes the merged mic flag true.
         source.emit([
             makeProcess(
                 bundleID: "com.apple.FaceTime",

--- a/Packages/BiscottiKit/Tests/MeetingDetectionTests/MeetingDetectionTests.swift
+++ b/Packages/BiscottiKit/Tests/MeetingDetectionTests/MeetingDetectionTests.swift
@@ -67,8 +67,8 @@ struct HeuristicTests {
         #expect(collector.events.isEmpty)
     }
 
-    @Test("Input only does not trigger in-call")
-    func inputOnlyNoEvent() async {
+    @Test("Mic (input) alone triggers detection — output is not required")
+    func inputAloneTriggersDetection() async {
         let source = FakeActivitySource()
         let catalog = FakeMeetingCatalog(
             meetingBundleIDs: ["us.zoom.xos"],
@@ -81,17 +81,22 @@ struct HeuristicTests {
         collector.start(from: detector)
         detector.start()
 
+        // Mic on, speaker off: a watch-listed app holding the mic IS the
+        // meeting signal. Output is deliberately not part of the signal.
         source.emit([makeProcess(
             bundleID: "us.zoom.xos",
             isRunningInput: true,
             isRunningOutput: false
         )])
-        await collector.settle()
-        detector.stop()
-        await collector.settle()
-        collector.cancel()
+        await collector.waitForEvents(count: 1)
 
-        #expect(collector.events.isEmpty)
+        #expect(collector.events == [
+            .started(app: DetectedApp(
+                bundleID: "us.zoom.xos", displayName: "Zoom"
+            ))
+        ])
+        detector.stop()
+        collector.cancel()
     }
 
     @Test("No event for non-watchlist app")
@@ -488,80 +493,36 @@ struct MicStopDebounceTests {
     }
 }
 
-// MARK: - Start flap tolerance tests
+// MARK: - Start sustain semantics
 
-@Suite("MeetingDetection — Start Flap Tolerance")
+@Suite("MeetingDetection — Start Sustain")
 @MainActor
-struct StartFlapToleranceTests {
-    @Test("flap during start window then steady in-call emits started")
-    func flapDuringStartWindowThenSteady() async {
+struct StartSustainTests {
+    @Test("Mic must stay up: a drop during the start window aborts (no started)")
+    func micDropDuringStartWindowAborts() async {
         let source = FakeActivitySource()
         let catalog = FakeMeetingCatalog(
             meetingBundleIDs: ["us.zoom.xos"],
             displayNames: ["us.zoom.xos": "Zoom"]
         )
-        // ImmediateClock: debounce fires quickly but not before buffered
-        // snapshots are processed (the for-await loop drains the
-        // buffered snapshots before yielding to the debounce Task).
-        let detector = makeImmediateDetector(
-            catalog: catalog, source: source
-        )
+        // NeverClock: the sustained-mic timer never fires on its own, so a
+        // `.started` could only appear if the engine promoted WITHOUT a
+        // sustained mic. The mid-window mic drop must abort the pending
+        // start back to idle — detection is edge-driven with no
+        // instantaneous resolve check.
+        let detector = makeNeverDetector(catalog: catalog, source: source)
         let collector = EventCollector()
         collector.start(from: detector)
         detector.start()
 
-        // Sequence: in-call -> flap (not in-call) -> back to in-call
-        // Emit all three rapidly so they're buffered before the start
-        // debounce Task resolves.
         source.emit([makeProcess(
             bundleID: "us.zoom.xos",
             isRunningInput: true,
             isRunningOutput: true
         )])
-        source.emit([makeProcess(
-            bundleID: "us.zoom.xos",
-            isRunningInput: false,
-            isRunningOutput: true
-        )])
-        source.emit([makeProcess(
-            bundleID: "us.zoom.xos",
-            isRunningInput: true,
-            isRunningOutput: true
-        )])
-        await collector.waitForEvents(count: 1)
-
-        let zoom = DetectedApp(
-            bundleID: "us.zoom.xos", displayName: "Zoom"
-        )
-        #expect(collector.events == [.started(app: zoom)])
-
-        detector.stop()
         await collector.settle()
-        collector.cancel()
-    }
 
-    @Test("in-call briefly then genuinely idle at resolve does not emit started")
-    func genuinelyIdleAtResolveNoStarted() async {
-        let source = FakeActivitySource()
-        let catalog = FakeMeetingCatalog(
-            meetingBundleIDs: ["us.zoom.xos"],
-            displayNames: ["us.zoom.xos": "Zoom"]
-        )
-        // ImmediateClock so the debounce fires quickly.
-        let detector = makeImmediateDetector(
-            catalog: catalog, source: source
-        )
-        let collector = EventCollector()
-        collector.start(from: detector)
-        detector.start()
-
-        // Brief in-call then immediately idle — debounce should see
-        // latestIsInCall == false and not emit .started.
-        source.emit([makeProcess(
-            bundleID: "us.zoom.xos",
-            isRunningInput: true,
-            isRunningOutput: true
-        )])
+        // Mic drops before the sustained window elapses.
         source.emit([makeProcess(
             bundleID: "us.zoom.xos",
             isRunningInput: false,
@@ -569,15 +530,11 @@ struct StartFlapToleranceTests {
         )])
         await collector.settle()
 
-        // No .started because the app was idle at resolve time
-        let startedEvents = collector.events.filter {
-            if case .started = $0 { return true }; return false
-        }
-        #expect(startedEvents.isEmpty)
-
         detector.stop()
         await collector.settle()
         collector.cancel()
+
+        #expect(collector.events.isEmpty)
     }
 }
 


### PR DESCRIPTION
## Problem

Meeting-detected notifications fired only ~1 in 8 times.

## Root cause

`MeetingDetector`'s start-debounce *resolution* sampled the instantaneous `input && output` flags at the exact 3s resolve instant. CoreAudio's `IsRunningInput` flag for WebKit/Safari meetings is bouncy, so whether detection fired came down to the flag's value at that single moment — a coin flip. Confirmed from on-hardware unified-logging capture: every sustained join scheduled a start timer, but the resolve frequently saw a momentary mic-down and suppressed.

## Fix

Rework the per-app state machine to be **mic-driven and edge-triggered, with no instantaneous polling**:

- **Mic (input) is the only signal.** Output is dropped from the decision — far too many non-meeting apps play audio; a watch-listed app *holding the mic* is the meeting signal.
- **Start** requires the mic to stay up *continuously* for `startDebounce`. Any mic-drop during the window cancels the pending start, so the timer firing *proves* the mic never dropped — there is no resolve-time flag re-check and therefore no race.
- **Stop** mirrors it: the mic must stay released for `stopDebounce`.

The mic-user-tracking path (auto-stop safety net) and the rest of the pipeline are unchanged; logging is trimmed back to the prior light level.

## Verification

Verified on Apple-silicon hardware across multiple Google Meet joins: real (mic-engaged) joins now notify reliably, while brief mic probes — e.g. Meet's pre-join lobby grabbing the mic for the level meter — are correctly ignored.

`make ci` green (lint + test + build); MeetingDetection unit tests updated for the mic-only semantics (mic alone triggers; a deterministic abort-on-drop test replaces the old resolve-time-flap tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
