### PR TITLE
Fix AttributeGraph cycle in Meeting Detail height measurement

### DIFF
--- a/Packages/BiscottiKit/Sources/MeetingDetailUI/MeetingDetailView.swift
+++ b/Packages/BiscottiKit/Sources/MeetingDetailUI/MeetingDetailView.swift
@@ -175,8 +175,6 @@ public struct MeetingDetailView: View {
     /// `listRowMaxWidth`, matching the ScrollView path's layout.
     private func transcriptListLayout(geo _: GeometryProxy) -> some View {
         transcriptReadyContent
-            .onPreferenceChange(ChromeHeightKey.self) { chromeHeight = $0 }
-            .onPreferenceChange(TransportHeightKey.self) { transportHeight = $0 }
             .safeAreaInset(edge: .bottom, spacing: Self.transportSpacing) {
                 pinnedTransportBar
             }
@@ -203,8 +201,6 @@ public struct MeetingDetailView: View {
             .frame(maxWidth: Tokens.readableContentMaxWidth, alignment: .leading)
             .frame(maxWidth: .infinity)
         }
-        .onPreferenceChange(ChromeHeightKey.self) { chromeHeight = $0 }
-        .onPreferenceChange(TransportHeightKey.self) { transportHeight = $0 }
         .safeAreaInset(edge: .bottom, spacing: Self.transportSpacing) {
             pinnedTransportBar
         }
@@ -221,8 +217,8 @@ public struct MeetingDetailView: View {
     /// **Layout coupling:** the `verticalOverhead` constant mirrors the
     /// padding and divider in `scrollViewLayout(geo:)`. If you change
     /// the padding values or divider there, update this calculation to
-    /// match. The `transportHeight` is measured via `TransportHeightKey`
-    /// in `pinnedTransportBar` -- it accounts for the bottom
+    /// match. The `transportHeight` is measured via `onGeometryChange`
+    /// on `pinnedTransportBar` -- it accounts for the bottom
     /// `safeAreaInset` that the outer `GeometryReader` does not subtract
     /// from its reported size.
     private func contentFill(viewportHeight: CGFloat) -> CGFloat {
@@ -311,17 +307,11 @@ private extension MeetingDetailView {
             .frame(maxWidth: .infinity)
         }
         .pinnedBarBackground()
-        .background(GeometryReader { transportProxy in
-            Color.clear
-                .preference(
-                    key: TransportHeightKey.self,
-                    value: transportProxy.size.height
-                )
-        })
+        .onGeometryChange(for: CGFloat.self) { $0.size.height } action: { transportHeight = $0 }
     }
 
     /// Header + calendar card + tab bar, measured for the chrome-height
-    /// preference key. AudioTransport is now pinned to the bottom of
+    /// calculation. AudioTransport is now pinned to the bottom of
     /// the panel (see `pinnedTransportBar`), outside this scroll region.
     var chrome: some View {
         VStack(alignment: .leading, spacing: Tokens.spacingMD) {
@@ -340,13 +330,7 @@ private extension MeetingDetailView {
 
             tabBar
         }
-        .background(GeometryReader { chromeProxy in
-            Color.clear
-                .preference(
-                    key: ChromeHeightKey.self,
-                    value: chromeProxy.size.height
-                )
-        })
+        .onGeometryChange(for: CGFloat.self) { $0.size.height } action: { chromeHeight = $0 }
     }
 
     var overflowMenu: some View {
@@ -733,22 +717,6 @@ private extension MeetingDetailView {
             Spacer()
         }
         .frame(maxWidth: .infinity)
-    }
-}
-
-// MARK: - Layout preference keys
-
-private struct ChromeHeightKey: PreferenceKey {
-    static let defaultValue: CGFloat = 0
-    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-        value = max(value, nextValue())
-    }
-}
-
-private struct TransportHeightKey: PreferenceKey {
-    static let defaultValue: CGFloat = 0
-    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-        value = max(value, nextValue())
     }
 }
 


### PR DESCRIPTION
## Problem

The Meeting Detail screen flooded the console with `=== AttributeGraph: cycle detected through attribute … ===` warnings — noticeably worse during AI analysis (rapid status/layout changes: speaker-ID → summary streaming → title → completed). The app kept working (SwiftUI breaks the cycle), but the spam signals a layout-dependency feedback loop.

## Root cause

`MeetingDetailView.swift` measured chrome and transport-bar heights with the classic AttributeGraph-cycle pattern: a `GeometryReader` in a `.background` wrote a `PreferenceKey`, an `.onPreferenceChange` wrote that into `@State`, and that `@State` sized content via `.frame(height:)` — a geometry → state → layout round-trip SwiftUI flags as a cycle. The `.onPreferenceChange` handlers were also **duplicated** across two container levels (`transcriptListLayout` and `scrollViewLayout`), compounding the round-trips.

## Fix

App targets macOS 15+, so the measurement now uses `onGeometryChange(for:action:)`, which reads geometry and writes `@State` directly on the measured view — no preference→state→layout cycle:

- Replace `.background(GeometryReader { … .preference })` on `chrome` and `pinnedTransportBar` with `.onGeometryChange(for: CGFloat.self) { $0.size.height } action: { … }`.
- Remove all four `.onPreferenceChange` handlers (the two duplicated pairs).
- Delete the now-unused `ChromeHeightKey` / `TransportHeightKey` `PreferenceKey` structs.
- Update doc comments that referenced the old mechanism.

`contentFill(viewportHeight:)`, the `@State` vars (`chromeHeight`/`transportHeight`), and all `.frame(height:)` consumers are **unchanged** — only the measurement mechanism changed, so layout is intended to be identical. Confirmed no other `GeometryReader`-in-`.background` + preference patterns remain in the view.

Net diff: **5 insertions, 37 deletions**, single file.

## Checks

- `precommit_checks` green (lint + test — 1,468 tests pass + build)
- App target (`build_app`) builds: Biscotti + ManualTestApp

## ⚠️ On-device verification required (cannot be done by the agent)

This is a runtime layout issue — unit tests can't prove the warnings are gone. A human needs to:
1. Confirm the Meeting Detail layout is visually unchanged (header/cards/tab bar, pinned audio transport at the bottom, tab content fills remaining height, small-window 250pt floor still works).
2. Run the app, open a meeting detail, trigger an AI summary regenerate, and confirm the `AttributeGraph: cycle detected` spam is gone (or drastically reduced) with no layout regression.

The static diagnosis is high-confidence, but the attribute IDs in the original report could not be traced to this loop without running the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)