### PR TITLE
Small-LLM model selection + onboarding two-model download

### DIFF
--- a/ManualTestApp/Results/manual_test_results.json
+++ b/ManualTestApp/Results/manual_test_results.json
@@ -71,92 +71,115 @@
     "timestamp" : "2026-06-19T16:18:54Z"
   },
   "llm_action_items_quality" : {
-    "status" : "not-run",
-    "stepID" : "llm_action_items_quality"
+    "status" : "pass",
+    "stepID" : "llm_action_items_quality",
+    "timestamp" : "2026-06-23T18:42:01Z"
   },
   "llm_action_items_run" : {
-    "status" : "not-run",
-    "stepID" : "llm_action_items_run"
+    "status" : "pass",
+    "stepID" : "llm_action_items_run",
+    "timestamp" : "2026-06-23T18:41:59Z"
   },
   "llm_ai_tests_passed" : {
-    "status" : "not-run",
-    "stepID" : "llm_ai_tests_passed"
+    "status" : "pass",
+    "stepID" : "llm_ai_tests_passed",
+    "timestamp" : "2026-06-23T18:41:20Z"
   },
   "llm_chat_system" : {
-    "status" : "not-run",
-    "stepID" : "llm_chat_system"
+    "status" : "pass",
+    "stepID" : "llm_chat_system",
+    "timestamp" : "2026-06-23T18:41:34Z"
   },
   "llm_chat_system_quality" : {
-    "status" : "not-run",
-    "stepID" : "llm_chat_system_quality"
+    "status" : "pass",
+    "stepID" : "llm_chat_system_quality",
+    "timestamp" : "2026-06-23T18:41:36Z"
   },
   "llm_e2b_download" : {
-    "status" : "not-run",
-    "stepID" : "llm_e2b_download"
+    "status" : "pass",
+    "stepID" : "llm_e2b_download",
+    "timestamp" : "2026-06-23T18:10:28Z"
   },
   "llm_e2b_kv_reuse" : {
-    "status" : "not-run",
-    "stepID" : "llm_e2b_kv_reuse"
+    "status" : "pass",
+    "stepID" : "llm_e2b_kv_reuse",
+    "timestamp" : "2026-06-23T19:18:57Z"
   },
   "llm_e2b_kv_reuse_quality" : {
-    "status" : "not-run",
-    "stepID" : "llm_e2b_kv_reuse_quality"
+    "status" : "pass",
+    "stepID" : "llm_e2b_kv_reuse_quality",
+    "timestamp" : "2026-06-23T19:19:01Z"
   },
   "llm_kv_reuse" : {
-    "status" : "not-run",
-    "stepID" : "llm_kv_reuse"
+    "status" : "pass",
+    "stepID" : "llm_kv_reuse",
+    "timestamp" : "2026-06-23T19:18:44Z"
   },
   "llm_kv_reuse_quality" : {
-    "status" : "not-run",
-    "stepID" : "llm_kv_reuse_quality"
+    "status" : "pass",
+    "stepID" : "llm_kv_reuse_quality",
+    "timestamp" : "2026-06-23T19:18:51Z"
   },
   "llm_model_disk" : {
-    "status" : "not-run",
-    "stepID" : "llm_model_disk"
+    "status" : "pass",
+    "stepID" : "llm_model_disk",
+    "timestamp" : "2026-06-23T17:57:50Z"
   },
   "llm_model_download" : {
-    "status" : "not-run",
-    "stepID" : "llm_model_download"
+    "status" : "pass",
+    "stepID" : "llm_model_download",
+    "timestamp" : "2026-06-23T18:30:01Z"
   },
   "llm_reclamation" : {
-    "status" : "not-run",
-    "stepID" : "llm_reclamation"
+    "note" : "No BiscottiLLM service process found (reclaimed)",
+    "status" : "pass",
+    "stepID" : "llm_reclamation",
+    "timestamp" : "2026-06-23T19:19:05Z"
   },
   "llm_speaker_names_quality" : {
-    "status" : "not-run",
-    "stepID" : "llm_speaker_names_quality"
+    "status" : "pass",
+    "stepID" : "llm_speaker_names_quality",
+    "timestamp" : "2026-06-23T18:42:16Z"
   },
   "llm_speaker_names_run" : {
-    "status" : "not-run",
-    "stepID" : "llm_speaker_names_run"
+    "status" : "pass",
+    "stepID" : "llm_speaker_names_run",
+    "timestamp" : "2026-06-23T18:42:13Z"
   },
   "llm_streaming_channels" : {
-    "status" : "not-run",
-    "stepID" : "llm_streaming_channels"
+    "status" : "pass",
+    "stepID" : "llm_streaming_channels",
+    "timestamp" : "2026-06-23T19:17:23Z"
   },
   "llm_streaming_run" : {
-    "status" : "not-run",
-    "stepID" : "llm_streaming_run"
+    "status" : "pass",
+    "stepID" : "llm_streaming_run",
+    "timestamp" : "2026-06-23T19:17:40Z"
   },
   "llm_summarize_quality" : {
-    "status" : "not-run",
-    "stepID" : "llm_summarize_quality"
+    "status" : "pass",
+    "stepID" : "llm_summarize_quality",
+    "timestamp" : "2026-06-23T18:41:48Z"
   },
   "llm_summarize_run" : {
-    "status" : "not-run",
-    "stepID" : "llm_summarize_run"
+    "status" : "pass",
+    "stepID" : "llm_summarize_run",
+    "timestamp" : "2026-06-23T18:41:46Z"
   },
   "llm_thinking_mode" : {
-    "status" : "not-run",
-    "stepID" : "llm_thinking_mode"
+    "status" : "pass",
+    "stepID" : "llm_thinking_mode",
+    "timestamp" : "2026-06-23T19:17:13Z"
   },
   "llm_thinking_run" : {
-    "status" : "not-run",
-    "stepID" : "llm_thinking_run"
+    "status" : "pass",
+    "stepID" : "llm_thinking_run",
+    "timestamp" : "2026-06-23T18:42:58Z"
   },
   "llm_xpc_inference" : {
-    "status" : "not-run",
-    "stepID" : "llm_xpc_inference"
+    "status" : "pass",
+    "stepID" : "llm_xpc_inference",
+    "timestamp" : "2026-06-23T18:41:29Z"
   },
   "tx_ai_test_passed" : {
     "status" : "not-run",

--- a/ManualTestApp/Results/manual_test_results.json
+++ b/ManualTestApp/Results/manual_test_results.json
@@ -71,100 +71,92 @@
     "timestamp" : "2026-06-19T16:18:54Z"
   },
   "llm_action_items_quality" : {
-    "status" : "pass",
-    "stepID" : "llm_action_items_quality",
-    "timestamp" : "2026-06-22T23:45:01Z"
+    "status" : "not-run",
+    "stepID" : "llm_action_items_quality"
   },
   "llm_action_items_run" : {
-    "status" : "pass",
-    "stepID" : "llm_action_items_run",
-    "timestamp" : "2026-06-22T23:44:58Z"
+    "status" : "not-run",
+    "stepID" : "llm_action_items_run"
   },
   "llm_ai_tests_passed" : {
-    "status" : "pass",
-    "stepID" : "llm_ai_tests_passed",
-    "timestamp" : "2026-06-22T23:43:48Z"
+    "status" : "not-run",
+    "stepID" : "llm_ai_tests_passed"
   },
   "llm_chat_system" : {
-    "status" : "pass",
-    "stepID" : "llm_chat_system",
-    "timestamp" : "2026-06-22T23:44:20Z"
+    "status" : "not-run",
+    "stepID" : "llm_chat_system"
   },
   "llm_chat_system_quality" : {
-    "status" : "pass",
-    "stepID" : "llm_chat_system_quality",
-    "timestamp" : "2026-06-22T23:44:26Z"
+    "status" : "not-run",
+    "stepID" : "llm_chat_system_quality"
+  },
+  "llm_e2b_download" : {
+    "status" : "not-run",
+    "stepID" : "llm_e2b_download"
+  },
+  "llm_e2b_kv_reuse" : {
+    "status" : "not-run",
+    "stepID" : "llm_e2b_kv_reuse"
+  },
+  "llm_e2b_kv_reuse_quality" : {
+    "status" : "not-run",
+    "stepID" : "llm_e2b_kv_reuse_quality"
   },
   "llm_kv_reuse" : {
-    "status" : "pass",
-    "stepID" : "llm_kv_reuse",
-    "timestamp" : "2026-06-22T23:46:52Z"
+    "status" : "not-run",
+    "stepID" : "llm_kv_reuse"
   },
   "llm_kv_reuse_quality" : {
-    "status" : "pass",
-    "stepID" : "llm_kv_reuse_quality",
-    "timestamp" : "2026-06-22T23:47:12Z"
+    "status" : "not-run",
+    "stepID" : "llm_kv_reuse_quality"
   },
   "llm_model_disk" : {
-    "status" : "pass",
-    "stepID" : "llm_model_disk",
-    "timestamp" : "2026-06-22T23:43:37Z"
+    "status" : "not-run",
+    "stepID" : "llm_model_disk"
   },
   "llm_model_download" : {
-    "status" : "pass",
-    "stepID" : "llm_model_download",
-    "timestamp" : "2026-06-22T23:43:35Z"
+    "status" : "not-run",
+    "stepID" : "llm_model_download"
   },
   "llm_reclamation" : {
-    "note" : "No BiscottiLLM service process found (reclaimed)",
-    "status" : "pass",
-    "stepID" : "llm_reclamation",
-    "timestamp" : "2026-06-22T23:47:16Z"
+    "status" : "not-run",
+    "stepID" : "llm_reclamation"
   },
   "llm_speaker_names_quality" : {
-    "status" : "pass",
-    "stepID" : "llm_speaker_names_quality",
-    "timestamp" : "2026-06-22T23:45:19Z"
+    "status" : "not-run",
+    "stepID" : "llm_speaker_names_quality"
   },
   "llm_speaker_names_run" : {
-    "status" : "pass",
-    "stepID" : "llm_speaker_names_run",
-    "timestamp" : "2026-06-22T23:45:14Z"
+    "status" : "not-run",
+    "stepID" : "llm_speaker_names_run"
   },
   "llm_streaming_channels" : {
-    "status" : "pass",
-    "stepID" : "llm_streaming_channels",
-    "timestamp" : "2026-06-22T23:46:33Z"
+    "status" : "not-run",
+    "stepID" : "llm_streaming_channels"
   },
   "llm_streaming_run" : {
-    "status" : "pass",
-    "stepID" : "llm_streaming_run",
-    "timestamp" : "2026-06-22T23:46:35Z"
+    "status" : "not-run",
+    "stepID" : "llm_streaming_run"
   },
   "llm_summarize_quality" : {
-    "status" : "pass",
-    "stepID" : "llm_summarize_quality",
-    "timestamp" : "2026-06-22T23:44:46Z"
+    "status" : "not-run",
+    "stepID" : "llm_summarize_quality"
   },
   "llm_summarize_run" : {
-    "status" : "pass",
-    "stepID" : "llm_summarize_run",
-    "timestamp" : "2026-06-22T23:44:40Z"
+    "status" : "not-run",
+    "stepID" : "llm_summarize_run"
   },
   "llm_thinking_mode" : {
-    "status" : "pass",
-    "stepID" : "llm_thinking_mode",
-    "timestamp" : "2026-06-22T23:46:09Z"
+    "status" : "not-run",
+    "stepID" : "llm_thinking_mode"
   },
   "llm_thinking_run" : {
-    "status" : "pass",
-    "stepID" : "llm_thinking_run",
-    "timestamp" : "2026-06-22T23:46:06Z"
+    "status" : "not-run",
+    "stepID" : "llm_thinking_run"
   },
   "llm_xpc_inference" : {
-    "status" : "pass",
-    "stepID" : "llm_xpc_inference",
-    "timestamp" : "2026-06-22T23:43:58Z"
+    "status" : "not-run",
+    "stepID" : "llm_xpc_inference"
   },
   "tx_ai_test_passed" : {
     "status" : "pass",

--- a/ManualTestApp/Results/manual_test_results.json
+++ b/ManualTestApp/Results/manual_test_results.json
@@ -159,23 +159,19 @@
     "stepID" : "llm_xpc_inference"
   },
   "tx_ai_test_passed" : {
-    "status" : "pass",
-    "stepID" : "tx_ai_test_passed",
-    "timestamp" : "2026-06-10T21:27:45Z"
+    "status" : "not-run",
+    "stepID" : "tx_ai_test_passed"
   },
   "tx_clear_cache" : {
-    "status" : "pass",
-    "stepID" : "tx_clear_cache",
-    "timestamp" : "2026-06-10T21:23:54Z"
+    "status" : "not-run",
+    "stepID" : "tx_clear_cache"
   },
   "tx_model_disk" : {
-    "status" : "pass",
-    "stepID" : "tx_model_disk",
-    "timestamp" : "2026-06-10T21:24:22Z"
+    "status" : "not-run",
+    "stepID" : "tx_model_disk"
   },
   "tx_model_download" : {
-    "status" : "pass",
-    "stepID" : "tx_model_download",
-    "timestamp" : "2026-06-10T21:24:20Z"
+    "status" : "not-run",
+    "stepID" : "tx_model_download"
   }
 }

--- a/ManualTestApp/Sources/WiredScripts.swift
+++ b/ManualTestApp/Sources/WiredScripts.swift
@@ -409,6 +409,96 @@ enum WiredScripts {
                         }
                     }
 
+                case "llm_e2b_download":
+                    return .action(id: id, label: label) { status in
+                        let e2b = LLMModelCatalog.model(id: "gemma-4-e2b")!
+                        let downloader = ModelDownloader(cacheDirectory: cache)
+                        _ = try await downloader.download(
+                            from: e2b.downloadURL
+                        ) { bytes, total in
+                            if let total {
+                                let mb = Double(bytes) / 1_000_000
+                                let totalMB = Double(total) / 1_000_000
+                                let pct = Double(bytes) / Double(total) * 100
+                                status(String(
+                                    format: "Downloading E2B: %.0f / %.0f MB (%.0f%%)",
+                                    mb, totalMB, pct
+                                ))
+                            } else {
+                                let mb = Double(bytes) / 1_000_000
+                                status(String(
+                                    format: "Downloading E2B: %.0f MB", mb
+                                ))
+                            }
+                        }
+                        status("E2B download complete")
+                    }
+
+                case "llm_e2b_kv_reuse":
+                    return .action(id: id, label: label) { status in
+                        let e2b = LLMModelCatalog.model(id: "gemma-4-e2b")!
+                        let inventory = ModelInventory(cacheDirectory: cache)
+                        let model = inventory.path(for: e2b)
+                        try requireModelDownloaded(model)
+                        status("Connecting to BiscottiLLM.xpc with E2B model...")
+                        try await LLMService.withConnection(
+                            model: model,
+                            backend: .hosted(serviceName: llmServiceName)
+                        ) { conn in
+                            let options = GenerationOptions(maxTokens: 128, temperature: 0)
+
+                            let systemMsg = LLMMessage.system(
+                                "You are a meeting analyst. Answer precisely."
+                            )
+                            let userMsg = LLMMessage.user(
+                                "Summarize this meeting transcript in one sentence:\n\n"
+                                    + TestScript.sampleMeetingTranscript
+                            )
+
+                            status("E2B Turn 1: Generating with fresh cache...")
+                            let result1 = try await conn.generate(
+                                messages: [systemMsg, userMsg],
+                                options: options
+                            )
+                            let prefillMs1 = String(
+                                format: "%.0f", result1.promptEvalDuration * 1000
+                            )
+                            status(
+                                "E2B Turn 1 done.\n"
+                                    + "  cached=\(result1.cachedPromptTokenCount) "
+                                    + "prompt=\(result1.promptTokenCount) tokens\n"
+                                    + "  prefill=\(prefillMs1)ms\n"
+                                    + "  response: \(result1.text.prefix(200))\n\n"
+                                    + "E2B Turn 2: Extending conversation (should reuse prefix)..."
+                            )
+
+                            let result2 = try await conn.generate(
+                                messages: [
+                                    systemMsg,
+                                    userMsg,
+                                    .assistant(result1.text),
+                                    .user("List the action items from the transcript.")
+                                ],
+                                options: options
+                            )
+                            let prefillMs2 = String(
+                                format: "%.0f", result2.promptEvalDuration * 1000
+                            )
+                            status(
+                                "E2B Turn 1:\n"
+                                    + "  cached=\(result1.cachedPromptTokenCount) "
+                                    + "prompt=\(result1.promptTokenCount) "
+                                    + "prefill=\(prefillMs1)ms\n"
+                                    + "  \(result1.text.prefix(200))\n\n"
+                                    + "E2B Turn 2:\n"
+                                    + "  cached=\(result2.cachedPromptTokenCount) "
+                                    + "prompt=\(result2.promptTokenCount) "
+                                    + "prefill=\(prefillMs2)ms\n"
+                                    + "  \(result2.text.prefix(200))"
+                            )
+                        }
+                    }
+
                 case "llm_streaming_run":
                     return .action(id: id, label: label) { status in
                         let model = ModelDownloader(cacheDirectory: cache).modelPath

--- a/Packages/BiscottiKit/Package.swift
+++ b/Packages/BiscottiKit/Package.swift
@@ -413,8 +413,11 @@ let package = Package(
                 "Calendar",
                 "DataStore",
                 "DesignSystem",
+                "Intelligence",
+                "ModelManagementUI",
                 "Permissions",
-                "TranscriptionService"
+                "TranscriptionService",
+                .product(name: "LocalLLM", package: "LocalLLM")
             ],
             swiftSettings: warningsAsErrors
         ),
@@ -426,11 +429,13 @@ let package = Package(
                 "BiscottiTestSupport",
                 "Calendar",
                 "DataStore",
+                "Intelligence",
                 "MeetingCatalog",
                 "Permissions",
                 "Recording",
                 "TranscriptionService",
                 .product(name: "AudioCapture", package: "AudioCapture"),
+                .product(name: "LocalLLM", package: "LocalLLM"),
                 .product(name: "Transcription", package: "Transcription")
             ],
             swiftSettings: warningsAsErrors

--- a/Packages/BiscottiKit/Package.swift
+++ b/Packages/BiscottiKit/Package.swift
@@ -26,7 +26,8 @@ let package = Package(
         .library(name: "OnboardingUI", targets: ["OnboardingUI"]),
         .library(name: "ManualTestKit", targets: ["ManualTestKit"]),
         .library(name: "MarkdownEditorUI", targets: ["MarkdownEditorUI"]),
-        .library(name: "Intelligence", targets: ["Intelligence"])
+        .library(name: "Intelligence", targets: ["Intelligence"]),
+        .library(name: "ModelManagementUI", targets: ["ModelManagementUI"])
     ],
     dependencies: [
         .package(name: "Transcription", path: "../Transcription"),
@@ -351,6 +352,7 @@ let package = Package(
                 "DesignSystem",
                 "Intelligence",
                 "LocalLLM",
+                "ModelManagementUI",
                 "Permissions"
             ],
             swiftSettings: warningsAsErrors
@@ -505,6 +507,27 @@ let package = Package(
                 "DataStore",
                 .product(name: "LocalLLM", package: "LocalLLM"),
                 .product(name: "Transcription", package: "Transcription")
+            ],
+            swiftSettings: warningsAsErrors
+        ),
+        .target(
+            name: "ModelManagementUI",
+            dependencies: [
+                "AppCore",
+                "DesignSystem",
+                "Intelligence",
+                .product(name: "LocalLLM", package: "LocalLLM")
+            ],
+            swiftSettings: warningsAsErrors
+        ),
+        .testTarget(
+            name: "ModelManagementUITests",
+            dependencies: [
+                "ModelManagementUI",
+                "AppCore",
+                "BiscottiTestSupport",
+                "Intelligence",
+                .product(name: "LocalLLM", package: "LocalLLM")
             ],
             swiftSettings: warningsAsErrors
         ),

--- a/Packages/BiscottiKit/Package.swift
+++ b/Packages/BiscottiKit/Package.swift
@@ -350,6 +350,7 @@ let package = Package(
                 "DataStore",
                 "DesignSystem",
                 "Intelligence",
+                "LocalLLM",
                 "Permissions"
             ],
             swiftSettings: warningsAsErrors

--- a/Packages/BiscottiKit/Package.swift
+++ b/Packages/BiscottiKit/Package.swift
@@ -259,6 +259,7 @@ let package = Package(
                 "Recording",
                 "TranscriptionService",
                 .product(name: "AudioCapture", package: "AudioCapture"),
+                .product(name: "LocalLLM", package: "LocalLLM"),
                 .product(name: "Transcription", package: "Transcription")
             ],
             swiftSettings: warningsAsErrors
@@ -501,6 +502,7 @@ let package = Package(
             dependencies: [
                 "Intelligence",
                 "DataStore",
+                .product(name: "LocalLLM", package: "LocalLLM"),
                 .product(name: "Transcription", package: "Transcription")
             ],
             swiftSettings: warningsAsErrors

--- a/Packages/BiscottiKit/Sources/AppCore/AppCore+Live.swift
+++ b/Packages/BiscottiKit/Sources/AppCore/AppCore+Live.swift
@@ -53,8 +53,7 @@ public extension AppCore {
 
         logger.info("AppCore.live: TranscriptionService init")
         let transcriber = Transcriber(backend: .hosted(serviceName: transcriberServiceName))
-        let engine = LiveTranscriberAdapter(transcriber: transcriber)
-        let transcription = TranscriptionService(store: store, engine: engine)
+        let transcription = TranscriptionService(store: store, engine: LiveTranscriberAdapter(transcriber: transcriber))
 
         logger.info("AppCore.live: CalendarService init")
         let catalog = BundledMeetingCatalog()
@@ -66,16 +65,16 @@ public extension AppCore {
         logger.info("AppCore.live: NotificationService init")
         let notifications = NotificationService()
 
-        // Wire the live notification authorizer into Permissions so
-        // that requestNotifications() actually calls
-        // UNUserNotificationCenter.requestAuthorization(options:).
+        // Wire live notification authorizer so requestNotifications() works.
         let notifAuth = LiveNotificationAuthorizerAdapter(
             service: notifications
         )
         permissions.setNotificationAuthorizer(notifAuth)
 
-        logger.info("AppCore.live: Intelligence init")
-        let intelligence = buildIntelligence(store: store)
+        logger.info("AppCore.live: ModelManager + Intelligence init")
+        let (modelManager, intelligence) = buildModelAndIntelligence(
+            store: store
+        )
 
         logger.info("AppCore.live: constructing AppCore")
         let core = AppCore(
@@ -86,24 +85,32 @@ public extension AppCore {
             calendar: calendar,
             detector: detector,
             notifications: notifications,
-            intelligence: intelligence
+            intelligence: intelligence,
+            modelManager: modelManager
         )
         logger.info("AppCore.live: done")
         return core
     }
 
-    /// Builds the live `Intelligence` service with real LocalLLM-backed
+    /// Builds the live `ModelManager` + `Intelligence` with real LocalLLM-backed
     /// implementations. Extracted to keep `live(storageRoot:…)` under
     /// the function body length lint limit.
-    private static func buildIntelligence(
+    @MainActor
+    private static func buildModelAndIntelligence(
         store: DataStore
-    ) -> Intelligence {
+    ) -> (ModelManager, Intelligence) {
         let modelProvider = LiveModelProvider()
-        let llmRunner = LiveLLMRunner(modelProvider: modelProvider)
-        return Intelligence(
+        let hardwareProbe = LiveHardwareProbe()
+        let modelManager = ModelManager(
+            store: store,
+            models: modelProvider,
+            hardware: hardwareProbe
+        )
+        let llmRunner = LiveLLMRunner()
+        let intelligence = Intelligence(
             store: store,
             llm: llmRunner,
-            models: modelProvider,
+            modelManager: modelManager,
             settings: { [store] in
                 let settings = try? await store.settings()
                 return AISettings(
@@ -111,6 +118,7 @@ public extension AppCore {
                 )
             }
         )
+        return (modelManager, intelligence)
     }
 }
 

--- a/Packages/BiscottiKit/Sources/AppCore/AppCore+Live.swift
+++ b/Packages/BiscottiKit/Sources/AppCore/AppCore+Live.swift
@@ -220,6 +220,10 @@ private struct LiveTranscriberAdapter: Transcribing {
         )
     }
 
+    func modelsPresent() async -> Bool {
+        await transcriber.modelsPresent()
+    }
+
     func shutdown() async {
         await transcriber.shutdown()
     }

--- a/Packages/BiscottiKit/Sources/AppCore/AppCore.swift
+++ b/Packages/BiscottiKit/Sources/AppCore/AppCore.swift
@@ -228,8 +228,11 @@ public final class AppCore {
     /// System notification presenter and action stream.
     public let notifications: NotificationService
 
-    /// In-process LLM orchestration (speaker-ID, summarization, model download).
+    /// In-process LLM orchestration (speaker-ID, summarization).
     public let intelligence: Intelligence
+
+    /// Model state owner (selection, downloads, suitability).
+    public let modelManager: ModelManager
 
     // MARK: - Private
 
@@ -264,9 +267,7 @@ public final class AppCore {
     /// Task that mirrors calendar.upcoming into self.upcoming.
     private var upcomingMirrorTask: Task<Void, Never>?
 
-    /// Task that fires at each clock-minute boundary to refresh
-    /// `minuteTick`, driving displayed-upcoming filtering and
-    /// relative-time label recomputation.
+    /// Fires at each clock-minute boundary to refresh `minuteTick`.
     private var minuteTickTask: Task<Void, Never>?
 
     /// The fire-and-forget transcription task spawned by `stopRecording()`.
@@ -289,15 +290,8 @@ public final class AppCore {
     /// `.task` modifier) while the same AppCore instance persists.
     private var hasLaunched = false
 
-    private let logger = Logger(
-        subsystem: "net.scosman.biscotti",
-        category: "AppCore"
-    )
-
-    private let detectionLogger = Logger(
-        subsystem: "net.scosman.biscotti",
-        category: "Detection"
-    )
+    private let logger = Logger(subsystem: "net.scosman.biscotti", category: "AppCore")
+    private let detectionLogger = Logger(subsystem: "net.scosman.biscotti", category: "Detection")
 
     // MARK: - Init
 
@@ -312,6 +306,7 @@ public final class AppCore {
         detector: MeetingDetector,
         notifications: NotificationService,
         intelligence: Intelligence,
+        modelManager: ModelManager,
         scheduler: any AppScheduler = LiveAppScheduler()
     ) {
         self.store = store
@@ -322,6 +317,7 @@ public final class AppCore {
         self.detector = detector
         self.notifications = notifications
         self.intelligence = intelligence
+        self.modelManager = modelManager
         self.scheduler = scheduler
     }
 
@@ -343,6 +339,11 @@ public final class AppCore {
         logger.info("onLaunch: recoverOrphans starting")
         await recording.recoverOrphans()
         logger.info("onLaunch: recoverOrphans done")
+
+        // Resolve model selection (migration write-back for existing users)
+        logger.info("onLaunch: modelManager.refresh starting")
+        await modelManager.refresh()
+        logger.info("onLaunch: modelManager.refresh done")
 
         // Check onboarding gate and load cached settings
         logger.info("onLaunch: reading settings")

--- a/Packages/BiscottiKit/Sources/AppCore/PreviewAppCore.swift
+++ b/Packages/BiscottiKit/Sources/AppCore/PreviewAppCore.swift
@@ -55,10 +55,16 @@
                 provider: PreviewNotificationCenter()
             )
 
+            let modelManager = ModelManager(
+                store: store,
+                models: PreviewModelProvider(),
+                hardware: PreviewHardwareProbe()
+            )
+
             let intelligence = Intelligence(
                 store: store,
                 llm: PreviewLLMRunner(),
-                models: PreviewModelProvider(),
+                modelManager: modelManager,
                 settings: { AISettings(enabled: true) }
             )
 
@@ -70,7 +76,8 @@
                 calendar: calendar,
                 detector: detector,
                 notifications: notifications,
-                intelligence: intelligence
+                intelligence: intelligence,
+                modelManager: modelManager
             )
         }
     }
@@ -189,6 +196,7 @@
     /// No-op LLM runner for previews.
     private struct PreviewLLMRunner: LLMRunning {
         func withSession<T: Sendable>(
+            model _: URL,
             config _: LocalLLM.EngineConfig,
             _ body: @Sendable (any LLMSession) async throws -> T
         ) async throws -> T {
@@ -221,15 +229,40 @@
         }
     }
 
-    /// No-op model provider for previews (model not downloaded).
+    /// No-op model provider for previews (no models downloaded).
     private struct PreviewModelProvider: ModelProviding {
-        let modelURL = URL(fileURLWithPath: "/preview/model.gguf")
-        func isDownloaded() -> Bool {
+        let catalog: [LLMModel] = LLMModelCatalog.all
+
+        func url(for id: String) -> URL? {
+            LLMModelCatalog.model(id: id).map {
+                URL(fileURLWithPath: "/preview/\($0.fileName)")
+            }
+        }
+
+        func isDownloaded(_: String) -> Bool {
             false
         }
 
+        func downloadedModelIDs() -> [String] {
+            []
+        }
+
         func download(
+            _: String,
             progress _: @Sendable @escaping (Int64, Int64?) -> Void
         ) async throws {}
+
+        func delete(_: String) throws {}
+    }
+
+    /// Fake hardware probe for previews (32 GB RAM, plenty of disk).
+    private struct PreviewHardwareProbe: HardwareProbing {
+        var physicalMemoryBytes: UInt64 {
+            32_000_000_000
+        }
+
+        func availableDiskBytes(at _: URL) -> Int64? {
+            100_000_000_000
+        }
     }
 #endif

--- a/Packages/BiscottiKit/Sources/AppCore/PreviewAppCore.swift
+++ b/Packages/BiscottiKit/Sources/AppCore/PreviewAppCore.swift
@@ -120,6 +120,10 @@
 
     private struct PreviewTranscriber: Transcribing {
         func ensureModelsDownloaded(status _: (@Sendable (String) -> Void)?) async throws {}
+        func modelsPresent() async -> Bool {
+            false
+        }
+
         func processAudio(
             mic _: URL,
             system _: URL,

--- a/Packages/BiscottiKit/Sources/DataStore/DataStore+ReadModels.swift
+++ b/Packages/BiscottiKit/Sources/DataStore/DataStore+ReadModels.swift
@@ -181,6 +181,9 @@ public struct AppSettingsData: Sendable, Equatable {
     /// Whether AI analysis (summary + speaker inference) runs automatically
     /// after transcription completes. Default: on.
     public var aiAnalysisEnabled: Bool
+    /// The stable ID of the user's chosen LLM model (e.g. "gemma-4-12b").
+    /// Empty string means no explicit choice yet (drives migration/fallback).
+    public var selectedModelID: String
 
     public init(
         customVocabulary: [String] = [],
@@ -193,7 +196,8 @@ public struct AppSettingsData: Sendable, Equatable {
         calendarNotificationMode: CalendarNotificationMode = .allMeetings,
         onboardingComplete: Bool = false,
         enabledCalendarIDs: Set<String>? = nil,
-        aiAnalysisEnabled: Bool = true
+        aiAnalysisEnabled: Bool = true,
+        selectedModelID: String = ""
     ) {
         self.customVocabulary = customVocabulary
         self.launchAtLogin = launchAtLogin
@@ -206,6 +210,7 @@ public struct AppSettingsData: Sendable, Equatable {
         self.onboardingComplete = onboardingComplete
         self.enabledCalendarIDs = enabledCalendarIDs
         self.aiAnalysisEnabled = aiAnalysisEnabled
+        self.selectedModelID = selectedModelID
     }
 }
 
@@ -458,7 +463,8 @@ public extension DataStore {
                 calendarNotificationMode: CalendarNotificationMode(raw: existing.calendarNotificationModeRaw),
                 onboardingComplete: existing.onboardingComplete,
                 enabledCalendarIDs: existing.enabledCalendarIDs,
-                aiAnalysisEnabled: existing.aiAnalysisEnabled
+                aiAnalysisEnabled: existing.aiAnalysisEnabled,
+                selectedModelID: existing.selectedModelID
             )
         }
         // Create the singleton with defaults
@@ -491,7 +497,8 @@ public extension DataStore {
             calendarNotificationMode: CalendarNotificationMode(raw: model.calendarNotificationModeRaw),
             onboardingComplete: model.onboardingComplete,
             enabledCalendarIDs: model.enabledCalendarIDs,
-            aiAnalysisEnabled: model.aiAnalysisEnabled
+            aiAnalysisEnabled: model.aiAnalysisEnabled,
+            selectedModelID: model.selectedModelID
         )
         mutate(&dto)
 
@@ -506,6 +513,7 @@ public extension DataStore {
         model.onboardingComplete = dto.onboardingComplete
         model.enabledCalendarIDs = dto.enabledCalendarIDs
         model.aiAnalysisEnabled = dto.aiAnalysisEnabled
+        model.selectedModelID = dto.selectedModelID
         try save()
     }
 

--- a/Packages/BiscottiKit/Sources/DataStore/Models/AppSettings.swift
+++ b/Packages/BiscottiKit/Sources/DataStore/Models/AppSettings.swift
@@ -48,6 +48,10 @@ import SwiftData
     /// after transcription completes. Default: on.
     public var aiAnalysisEnabled: Bool = true
 
+    /// The stable ID of the user's chosen LLM model (e.g. "gemma-4-12b").
+    /// Empty string means no explicit choice yet (drives migration/fallback).
+    public var selectedModelID: String = ""
+
     /// JSON-encoded backing store for `enabledCalendarIDs`. Uses the same
     /// Data-backed pattern as `customVocabularyData` to avoid SwiftData's
     /// `[String]` materialization issues in SPM modules.
@@ -83,7 +87,8 @@ import SwiftData
         calendarNotificationModeRaw: String = "allMeetings",
         onboardingComplete: Bool = false,
         enabledCalendarIDs: Set<String>? = nil,
-        aiAnalysisEnabled: Bool = true
+        aiAnalysisEnabled: Bool = true,
+        selectedModelID: String = ""
     ) {
         customVocabularyData = (try? JSONEncoder().encode(customVocabulary)) ?? Data()
         self.launchAtLogin = launchAtLogin
@@ -98,5 +103,6 @@ import SwiftData
             enabledCalendarIDsData = (try? JSONEncoder().encode(Array(enabledCalendarIDs).sorted())) ?? Data()
         }
         self.aiAnalysisEnabled = aiAnalysisEnabled
+        self.selectedModelID = selectedModelID
     }
 }

--- a/Packages/BiscottiKit/Sources/Intelligence/HardwareProbing.swift
+++ b/Packages/BiscottiKit/Sources/Intelligence/HardwareProbing.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// Abstracts hardware queries (RAM, free disk) so suitability logic is
+/// fully unit-testable with fake values. Only two reads are needed --
+/// physical RAM and free disk space on a given volume.
+public protocol HardwareProbing: Sendable {
+    /// Total physical RAM in bytes.
+    var physicalMemoryBytes: UInt64 { get }
+
+    /// Free disk space in bytes on the volume containing `url`, or `nil`
+    /// if the capacity could not be determined.
+    func availableDiskBytes(at url: URL) -> Int64?
+}
+
+/// Production probe: reads real hardware via Foundation APIs.
+public struct LiveHardwareProbe: HardwareProbing {
+    public init() {}
+
+    public var physicalMemoryBytes: UInt64 {
+        ProcessInfo.processInfo.physicalMemory
+    }
+
+    public func availableDiskBytes(at url: URL) -> Int64? {
+        let values = try? url.resourceValues(
+            forKeys: [.volumeAvailableCapacityForImportantUsageKey]
+        )
+        return values?.volumeAvailableCapacityForImportantUsage
+    }
+}

--- a/Packages/BiscottiKit/Sources/Intelligence/Intelligence.swift
+++ b/Packages/BiscottiKit/Sources/Intelligence/Intelligence.swift
@@ -5,8 +5,8 @@ import LocalLLM
 /// The in-process owner of all Biscotti LLM scenario logic.
 ///
 /// Parallels `TranscriptionService`: holds observable per-meeting status the UI
-/// watches, plus model-download state. Depends on injected abstractions
-/// (`LLMRunning`, `ModelProviding`) so it unit-tests without a model.
+/// watches. Model management (download, selection, suitability) is delegated to
+/// `ModelManager`; this class owns the analysis orchestration.
 @MainActor @Observable
 public final class Intelligence {
     // MARK: - Observable state
@@ -19,14 +19,11 @@ public final class Intelligence {
     /// meeting ID. Cleared when generation completes or fails.
     public package(set) var streamingSummary: [UUID: String] = [:]
 
-    /// Model download lifecycle state, observed by Settings.
-    public package(set) var download: ModelDownloadState = .unknown
-
     // MARK: - Dependencies
 
     private let store: DataStore
     private let llm: any LLMRunning
-    private let models: any ModelProviding
+    private let modelManager: ModelManager
     private let settingsProvider: @Sendable () async -> AISettings
 
     // MARK: - In-flight guard
@@ -42,19 +39,18 @@ public final class Intelligence {
     /// - Parameters:
     ///   - store: The DataStore for reading/writing meeting data.
     ///   - llm: The LLM session provider (real or fake).
-    ///   - models: The model presence/download provider (real or fake).
+    ///   - modelManager: The model state owner (selection, downloads, suitability).
     ///   - settings: Closure that reads the current AI settings from DataStore.
     public init(
         store: DataStore,
         llm: any LLMRunning,
-        models: any ModelProviding,
+        modelManager: ModelManager,
         settings: @Sendable @escaping () async -> AISettings
     ) {
         self.store = store
         self.llm = llm
-        self.models = models
+        self.modelManager = modelManager
         settingsProvider = settings
-        refreshModelState()
     }
 
     // MARK: - Auto-run orchestration
@@ -76,7 +72,7 @@ public final class Intelligence {
             jobs.removeValue(forKey: meetingID)
             return
         }
-        guard models.isDownloaded() else {
+        guard let modelURL = modelManager.activeModelURL() else {
             jobs.removeValue(forKey: meetingID)
             return
         }
@@ -92,7 +88,8 @@ public final class Intelligence {
             try await runAnalysisSession(
                 meetingID: meetingID,
                 detail: detail, transcript: transcript,
-                doSummary: !detail.editedSummary
+                doSummary: !detail.editedSummary,
+                modelURL: modelURL
             )
             jobs[meetingID] = .completed
         } catch is CancellationError {
@@ -118,7 +115,7 @@ public final class Intelligence {
             inFlightMeetingID = nil
         }
 
-        guard models.isDownloaded() else { return }
+        guard let modelURL = modelManager.activeModelURL() else { return }
 
         // Set preparing SYNCHRONOUSLY before any await.
         jobs[meetingID] = .preparing
@@ -137,7 +134,8 @@ public final class Intelligence {
             try await runAnalysisSession(
                 meetingID: meetingID,
                 detail: detail, transcript: transcript,
-                doSummary: doSummary
+                doSummary: doSummary,
+                modelURL: modelURL
             )
             jobs[meetingID] = .completed
         } catch is CancellationError {
@@ -156,7 +154,8 @@ public final class Intelligence {
         meetingID: UUID,
         detail: MeetingDetailData,
         transcript: TranscriptData,
-        doSummary: Bool
+        doSummary: Bool,
+        modelURL: URL
     ) async throws {
         let human = await (try? store.humanSetSpeakerMappings(
             for: transcript.id
@@ -183,7 +182,7 @@ public final class Intelligence {
             doTitle: doTitle
         )
 
-        try await llm.withSession(config: .modelOnly) { session in
+        try await llm.withSession(model: modelURL, config: .modelOnly) { session in
             let contextSize = try await ContextSizing.contextSizeForAnalysis(
                 firstUser: firstUser,
                 system: IntelligencePrompts.analysisSystem,
@@ -263,44 +262,6 @@ public final class Intelligence {
         }
     }
 
-    // MARK: - Model management
-
-    /// Whether the model file exists on disk.
-    public var isModelDownloaded: Bool {
-        models.isDownloaded()
-    }
-
-    /// Recompute `download` state from disk presence. Called at init and when
-    /// the Settings screen appears.
-    public func refreshModelState() {
-        download = models.isDownloaded() ? .downloaded : .notDownloaded
-    }
-
-    /// Download the default model, driving `download` through the state machine.
-    public func downloadModel() async {
-        download = .downloading(fraction: nil)
-
-        // Track the last reported fraction to throttle progress updates.
-        // URLSession can fire thousands of callbacks for a multi-GB download;
-        // we only dispatch a MainActor task when the fraction moves by >= 1%.
-        let lastFraction = LastFraction()
-
-        do {
-            try await models.download { [weak self] bytes, total in
-                let fraction = total.map { Double(bytes) / Double($0) }
-                guard lastFraction.shouldUpdate(to: fraction) else { return }
-                Task { @MainActor [weak self] in
-                    self?.download = .downloading(fraction: fraction)
-                }
-            }
-            download = .downloaded
-        } catch is CancellationError {
-            download = .notDownloaded
-        } catch {
-            download = .failed(message: shortDescription(error))
-        }
-    }
-
     // MARK: - Private helpers
 
     private func shortDescription(_ error: some Error) -> String {
@@ -308,36 +269,5 @@ public final class Intelligence {
             return llmError.localizedDescription
         }
         return error.localizedDescription
-    }
-}
-
-// MARK: - Download progress throttle
-
-/// Tracks the last reported download fraction to avoid dispatching thousands
-/// of MainActor tasks during a multi-GB download. Only reports when the
-/// fraction changes by >= 1% or transitions to/from nil.
-///
-/// Marked `@unchecked Sendable` because it is only mutated from the
-/// `ModelProviding.download` progress callback (single call site).
-private final class LastFraction: @unchecked Sendable {
-    private var value: Double?
-
-    /// Returns `true` if the caller should dispatch a UI update for this fraction.
-    func shouldUpdate(to newFraction: Double?) -> Bool {
-        guard let newFraction else {
-            // nil fraction (unknown total): report only the first time
-            if value == nil { return false }
-            value = nil
-            return true
-        }
-        guard let previous = value else {
-            value = newFraction
-            return true
-        }
-        if newFraction - previous >= 0.01 || newFraction >= 1.0 {
-            value = newFraction
-            return true
-        }
-        return false
     }
 }

--- a/Packages/BiscottiKit/Sources/Intelligence/IntelligencePrompts.swift
+++ b/Packages/BiscottiKit/Sources/Intelligence/IntelligencePrompts.swift
@@ -87,12 +87,21 @@ public enum IntelligencePrompts {
     are already correctly assigned -- do not change them. Only assign the \
     currently unassigned speakers.
 
-    Output format -- one line per newly identified speaker, nothing else:
-    <speakerIndex> | <Full Name> | <email-or-blank>
+    Output ONLY one line per newly identified speaker and nothing else -- no \
+    preamble, no commentary, no markdown table, no numbering, no surrounding \
+    text. Each line MUST follow this EXACT format, using " | " (space pipe \
+    space) to separate exactly three fields:
 
-    Example:
+    ```
+    <speakerIndex> | <Full Name> | <email-or-blank>
+    ```
+
+    For example, your entire response must look exactly like this:
+
+    ```
     0 | Daniel Lee | daniel@acme.com
     1 | Priya Patel |
+    ```
     """
 
     /// Instructions for the summary task.
@@ -101,8 +110,11 @@ public enum IntelligencePrompts {
     key decisions, discussion topics, and outcomes. At the end, include a \
     "## Action Items" section as a checklist using `- [ ]` format, with owners \
     noted when clear from the transcript. You may reference the speaker names \
-    identified earlier. Output markdown only -- no preamble, no commentary, and \
-    do not invent content that is not in the transcript.
+    identified earlier, but do NOT repeat or restate the speaker mapping/list. \
+    Your response must contain ONLY a summary of the meeting and nothing else: \
+    no speaker mapping, no preamble, no commentary, and no content that is not \
+    in the transcript. Output markdown only, and begin your response directly \
+    with the summary.
     """
 
     // MARK: - User Turn Builders

--- a/Packages/BiscottiKit/Sources/Intelligence/LLMRunning.swift
+++ b/Packages/BiscottiKit/Sources/Intelligence/LLMRunning.swift
@@ -1,9 +1,11 @@
+import Foundation
 import LocalLLM
 
 /// A single loaded-model session that supports N sequential generation calls.
 /// Real impl wraps `LLMService.withConnection`; fakes in tests.
 public protocol LLMRunning: Sendable {
     func withSession<T: Sendable>(
+        model: URL,
         config: EngineConfig,
         _ body: @Sendable (any LLMSession) async throws -> T
     ) async throws -> T

--- a/Packages/BiscottiKit/Sources/Intelligence/LiveLLMRunning.swift
+++ b/Packages/BiscottiKit/Sources/Intelligence/LiveLLMRunning.swift
@@ -5,21 +5,18 @@ import LocalLLM
 /// hosted (XPC) backend. Each `withSession` call opens a connection, loads the
 /// model, runs the closure, and closes the connection.
 public struct LiveLLMRunner: LLMRunning {
-    private let modelProvider: any ModelProviding
-
     /// The XPC service bundle identifier for BiscottiLLM.
     static let serviceName = "net.scosman.biscotti.BiscottiLLM"
 
-    public init(modelProvider: any ModelProviding) {
-        self.modelProvider = modelProvider
-    }
+    public init() {}
 
     public func withSession<T: Sendable>(
+        model: URL,
         config: EngineConfig,
         _ body: @Sendable (any LLMSession) async throws -> T
     ) async throws -> T {
         try await LLMService.withConnection(
-            model: modelProvider.modelURL,
+            model: model,
             backend: .hosted(serviceName: Self.serviceName),
             config: config
         ) { connection in

--- a/Packages/BiscottiKit/Sources/Intelligence/LiveModelProvider.swift
+++ b/Packages/BiscottiKit/Sources/Intelligence/LiveModelProvider.swift
@@ -1,26 +1,45 @@
 import Foundation
 import LocalLLM
 
-/// Production `ModelProviding` backed by `ModelDownloader` + `LocalLLMPaths`.
+/// Production `ModelProviding` backed by `LLMModelCatalog` + `ModelInventory`
+/// + `ModelDownloader`, all sharing `LocalLLMPaths.defaultModelCacheDir`.
 public struct LiveModelProvider: ModelProviding {
+    private let inventory: ModelInventory
     private let downloader: ModelDownloader
 
-    public let modelURL: URL
+    public let catalog: [LLMModel]
 
     public init() {
         let cacheDir = LocalLLMPaths.defaultModelCacheDir
-        let modelDownloader = ModelDownloader(cacheDirectory: cacheDir)
-        downloader = modelDownloader
-        modelURL = modelDownloader.modelPath
+        catalog = LLMModelCatalog.all
+        inventory = ModelInventory(cacheDirectory: cacheDir)
+        downloader = ModelDownloader(cacheDirectory: cacheDir)
     }
 
-    public func isDownloaded() -> Bool {
-        ModelDownloader.fileExistsAndNonEmpty(at: modelURL)
+    public func url(for id: String) -> URL? {
+        guard let model = LLMModelCatalog.model(id: id) else { return nil }
+        return inventory.path(for: model)
+    }
+
+    public func isDownloaded(_ id: String) -> Bool {
+        guard let model = LLMModelCatalog.model(id: id) else { return false }
+        return inventory.isDownloaded(model)
+    }
+
+    public func downloadedModelIDs() -> [String] {
+        inventory.downloadedModels(in: catalog).map(\.id)
     }
 
     public func download(
+        _ id: String,
         progress: @Sendable @escaping (Int64, Int64?) -> Void
     ) async throws {
-        _ = try await downloader.download(progress: progress)
+        guard let model = LLMModelCatalog.model(id: id) else { return }
+        _ = try await downloader.download(from: model.downloadURL, progress: progress)
+    }
+
+    public func delete(_ id: String) throws {
+        guard let model = LLMModelCatalog.model(id: id) else { return }
+        try inventory.delete(model)
     }
 }

--- a/Packages/BiscottiKit/Sources/Intelligence/MeetingAnalyzer.swift
+++ b/Packages/BiscottiKit/Sources/Intelligence/MeetingAnalyzer.swift
@@ -1,6 +1,9 @@
 import DataStore
 import Foundation
 import LocalLLM
+#if DEBUG
+    import os
+#endif
 
 /// The multi-turn conversation orchestrator that replaced the separate
 /// `SpeakerIdentifier` and `Summarizer`. Handles four cases:
@@ -19,6 +22,15 @@ enum MeetingAnalyzer {
     static let titleOptions = GenerationOptions(
         maxTokens: 32, temperature: 0.3, thinking: .off
     )
+
+    #if DEBUG
+        /// DEBUG-only diagnostics logger. Used to capture the raw speaker-ID
+        /// turn output so we can harden the parser/prompt against weaker
+        /// models (e.g. E2B). Not compiled into release builds.
+        private static let debugLog = Logger(
+            subsystem: "net.scosman.biscotti", category: "MeetingAnalyzer"
+        )
+    #endif
 
     /// Groups all parameters for an analysis run, keeping function
     /// signatures within the lint threshold.
@@ -91,6 +103,12 @@ enum MeetingAnalyzer {
         let raw = try await session.generate(
             messages: messages, options: speakerOptions
         )
+
+        #if DEBUG
+            debugLog.info(
+                "Speaker-ID turn raw response:\n\(raw, privacy: .public)"
+            )
+        #endif
 
         try await persistSpeakers(raw, ctx)
 

--- a/Packages/BiscottiKit/Sources/Intelligence/ModelManager.swift
+++ b/Packages/BiscottiKit/Sources/Intelligence/ModelManager.swift
@@ -1,0 +1,339 @@
+import DataStore
+import Foundation
+import LocalLLM
+import os
+
+// MARK: - ModelChoice & ModelBlockedReason
+
+/// Why a model row is blocked (cannot be downloaded or selected).
+public enum ModelBlockedReason: Sendable, Equatable {
+    /// The Mac does not have enough RAM to run this model.
+    case cannotRun
+    /// Not enough free disk space to download this model.
+    case insufficientDisk
+}
+
+/// A per-model view value assembled for the Manage Models sheet.
+/// Not persisted; recomputed each time the sheet appears.
+public struct ModelChoice: Sendable, Identifiable, Equatable {
+    public let model: LLMModel
+    public let description: String
+    public let isRecommended: Bool
+    public let runnable: Bool
+    public let hasEnoughDiskToDownload: Bool
+    public let isDownloaded: Bool
+    public let isSelected: Bool
+    public let downloadState: ModelDownloadState
+    public var id: String {
+        model.id
+    }
+
+    /// The reason this model is blocked, if any.
+    public var blockedReason: ModelBlockedReason? {
+        if !runnable { return .cannotRun }
+        if !isDownloaded, !hasEnoughDiskToDownload { return .insufficientDisk }
+        return nil
+    }
+}
+
+// MARK: - ModelManager
+
+/// The in-process owner of all model state: per-model download status,
+/// selection, suitability, and the `modelChoices` matrix for the UI.
+///
+/// Replaces `Intelligence`'s former `download`, `downloadModel`,
+/// `refreshModelState`, `isModelDownloaded`, and single-model coupling.
+/// Observed by Settings (parallels how `Intelligence.download` was observed).
+@MainActor @Observable
+public final class ModelManager {
+    // MARK: - Observable state
+
+    /// Per-model download lifecycle state, keyed by model id.
+    public package(set) var downloads: [String: ModelDownloadState] = [:]
+
+    /// Cached mirror of the persisted `selectedModelID` setting.
+    /// Updated by `refresh()` and `selectModel(id:)`.
+    public private(set) var selectedModelID: String = ""
+
+    // MARK: - Dependencies
+
+    private let store: DataStore
+    private let models: any ModelProviding
+    private let hardware: any HardwareProbing
+
+    private let logger = Logger(
+        subsystem: "net.scosman.biscotti",
+        category: "ModelManager"
+    )
+
+    // MARK: - Init
+
+    public init(
+        store: DataStore,
+        models: any ModelProviding,
+        hardware: any HardwareProbing
+    ) {
+        self.store = store
+        self.models = models
+        self.hardware = hardware
+    }
+
+    // MARK: - Derived reads
+
+    /// Whether any model is available for AI analysis (active model exists).
+    public var isModelAvailable: Bool {
+        activeModelID != nil
+    }
+
+    /// The active model id resolved from downloads + selection.
+    ///
+    /// 1. If `selectedModelID` names a downloaded catalog model, that id.
+    /// 2. Else the first downloaded model in catalog order.
+    /// 3. Else `nil`.
+    public var activeModelID: String? {
+        let sel = selectedModelID
+        if !sel.isEmpty,
+           downloads[sel] == .downloaded
+        {
+            return sel
+        }
+        // Fallback: first downloaded in catalog order
+        for model in models.catalog where downloads[model.id] == .downloaded {
+            return model.id
+        }
+        return nil
+    }
+
+    /// The on-disk URL for the active model, or `nil` if none.
+    public func activeModelURL() -> URL? {
+        guard let id = activeModelID else { return nil }
+        return models.url(for: id)
+    }
+
+    /// The recommended model id for this hardware, delegating to
+    /// `ModelSuitability` with the injected hardware probe's RAM.
+    public func recommendedModelID() -> String? {
+        ModelSuitability.recommendedModelID(
+            catalog: models.catalog, ram: hardware.physicalMemoryBytes
+        )
+    }
+
+    /// Assembles the per-model choice matrix for the Manage Models sheet.
+    public func modelChoices() -> [ModelChoice] {
+        let ram = hardware.physicalMemoryBytes
+        // Assumes all models share one cache directory; uses the first
+        // model's URL to query available disk space.
+        let cacheDir = models.url(for: models.catalog.first?.id ?? "")
+        let freeBytes: Int64? = if let cacheDir {
+            hardware.availableDiskBytes(at: cacheDir)
+        } else {
+            nil
+        }
+        let recommendedID = ModelSuitability.recommendedModelID(
+            catalog: models.catalog, ram: ram
+        )
+        let activeID = activeModelID
+
+        return models.catalog.map { model in
+            let downloaded = downloads[model.id] == .downloaded
+            let runnable = ModelSuitability.canRun(model, ram: ram)
+            let enoughDisk = ModelSuitability.hasEnoughDisk(model, freeBytes: freeBytes)
+            let state = downloads[model.id] ?? .notDownloaded
+
+            return ModelChoice(
+                model: model,
+                description: ModelPolicy.description(id: model.id),
+                isRecommended: model.id == recommendedID,
+                runnable: runnable,
+                hasEnoughDiskToDownload: enoughDisk,
+                isDownloaded: downloaded,
+                isSelected: model.id == activeID,
+                downloadState: state
+            )
+        }
+    }
+
+    // MARK: - Lifecycle / actions
+
+    /// Recomputes downloads from disk and loads/migrates the persisted selection.
+    ///
+    /// Called at app startup and when Settings appear. **Migration:** if the
+    /// loaded selection is empty or names a non-downloaded model but a downloaded
+    /// model is found, persists that id as the selection. This provides seamless
+    /// migration for existing 12B users.
+    public func refresh() async {
+        // Rebuild download states from disk truth
+        for model in models.catalog {
+            if models.isDownloaded(model.id) {
+                downloads[model.id] = .downloaded
+            } else if case .downloading = downloads[model.id] {
+                // Keep in-flight download state
+            } else {
+                downloads[model.id] = .notDownloaded
+            }
+        }
+
+        // Load persisted selection
+        let settings = try? await store.settings()
+        selectedModelID = settings?.selectedModelID ?? ""
+
+        // Migration: if the selection is empty or stale, persist the resolved active
+        if let resolved = activeModelID, resolved != selectedModelID {
+            selectedModelID = resolved
+            try? await store.updateSettings { settings in
+                settings.selectedModelID = resolved
+            }
+        }
+    }
+
+    /// Download the model with the given id.
+    ///
+    /// Guards: the model must be runnable, have enough disk, and no other
+    /// download can be in flight (one-at-a-time). On success, auto-selects
+    /// the model if no valid selection exists.
+    public func downloadModel(id: String) async {
+        guard canStartDownload(id: id) else { return }
+
+        downloads[id] = .downloading(fraction: nil)
+
+        let lastFraction = LastFraction()
+
+        do {
+            try await models.download(id) { [weak self] bytes, total in
+                let fraction = total.map { Double(bytes) / Double($0) }
+                guard lastFraction.shouldUpdate(to: fraction) else { return }
+                // Note: this Task may dispatch after the outer method sets
+                // .downloaded, briefly reverting state. Acceptable: the next
+                // refresh() corrects it, and the visual glitch is imperceptible.
+                Task { @MainActor [weak self] in
+                    self?.downloads[id] = .downloading(fraction: fraction)
+                }
+            }
+            downloads[id] = .downloaded
+            await autoSelectAfterDownload(id: id)
+        } catch is CancellationError {
+            downloads[id] = .notDownloaded
+        } catch {
+            downloads[id] = .failed(message: shortDescription(error))
+        }
+    }
+
+    /// Pre-flight checks for `downloadModel`: model exists, is runnable,
+    /// has enough disk, and no other download is in flight.
+    private func canStartDownload(id: String) -> Bool {
+        // One-at-a-time guard
+        let hasInFlight = downloads.values.contains {
+            if case .downloading = $0 { return true }
+            return false
+        }
+        guard !hasInFlight else { return false }
+
+        guard let model = models.catalog.first(where: { $0.id == id })
+        else { return false }
+
+        let ram = hardware.physicalMemoryBytes
+        guard ModelSuitability.canRun(model, ram: ram) else { return false }
+
+        let freeBytes = models.url(for: id)
+            .flatMap { hardware.availableDiskBytes(at: $0) }
+        guard ModelSuitability.hasEnoughDisk(model, freeBytes: freeBytes) else { return false }
+        return true
+    }
+
+    /// After a successful download, auto-selects the model if no valid
+    /// selection exists or the model is already the active fallback.
+    private func autoSelectAfterDownload(id: String) async {
+        if activeModelID == id, selectedModelID != id {
+            // Already active via fallback; persist it
+            await selectModel(id: id)
+        } else if selectedModelID.isEmpty || !models.isDownloaded(selectedModelID) {
+            await selectModel(id: id)
+        }
+    }
+
+    /// Delete the model with the given id from disk.
+    ///
+    /// If the deleted model was selected, recomputes selection: first remaining
+    /// downloaded model in catalog order, or clears if none remain.
+    public func deleteModel(id: String) async {
+        do {
+            try models.delete(id)
+        } catch {
+            logger.error("Failed to delete model \(id): \(error)")
+            return
+        }
+
+        downloads[id] = .notDownloaded
+
+        if selectedModelID == id {
+            // Recompute: first remaining downloaded model in catalog order
+            if let fallback = models.catalog.first(where: {
+                $0.id != id && downloads[$0.id] == .downloaded
+            }) {
+                await selectModel(id: fallback.id)
+            } else {
+                selectedModelID = ""
+                try? await store.updateSettings { settings in
+                    settings.selectedModelID = ""
+                }
+            }
+        }
+    }
+
+    /// Select a model as the active default.
+    ///
+    /// Guard: the model must be downloaded and runnable.
+    public func selectModel(id: String) async {
+        guard let model = models.catalog.first(where: { $0.id == id })
+        else { return }
+        guard downloads[id] == .downloaded else { return }
+
+        let ram = hardware.physicalMemoryBytes
+        guard ModelSuitability.canRun(model, ram: ram) else { return }
+
+        selectedModelID = id
+        try? await store.updateSettings { settings in
+            settings.selectedModelID = id
+        }
+    }
+
+    // MARK: - Private
+
+    private func shortDescription(_ error: some Error) -> String {
+        if let llmError = error as? LLMServiceError {
+            return llmError.localizedDescription
+        }
+        return error.localizedDescription
+    }
+}
+
+// MARK: - Download progress throttle
+
+/// Tracks the last reported download fraction to avoid dispatching thousands
+/// of MainActor tasks during a multi-GB download. Only reports when the
+/// fraction changes by >= 1% or transitions to/from nil.
+///
+/// Marked `@unchecked Sendable` because it is only mutated from the
+/// `ModelProviding.download` progress callback (single call site).
+final class LastFraction: @unchecked Sendable {
+    private var value: Double?
+
+    /// Returns `true` if the caller should dispatch a UI update for this fraction.
+    func shouldUpdate(to newFraction: Double?) -> Bool {
+        guard let newFraction else {
+            // nil fraction (unknown total): report only the first time
+            if value == nil { return false }
+            value = nil
+            return true
+        }
+        guard let previous = value else {
+            value = newFraction
+            return true
+        }
+        if newFraction - previous >= 0.01 || newFraction >= 1.0 {
+            value = newFraction
+            return true
+        }
+        return false
+    }
+}

--- a/Packages/BiscottiKit/Sources/Intelligence/ModelManager.swift
+++ b/Packages/BiscottiKit/Sources/Intelligence/ModelManager.swift
@@ -280,6 +280,20 @@ public final class ModelManager {
         }
     }
 
+    /// Clears the explicit language-model selection so the app reverts to
+    /// the hardware-recommended default.
+    ///
+    /// After clearing, `activeModelID` falls back to the first downloaded
+    /// catalog model (if any), and the next `refresh()` migration will
+    /// re-adopt that catalog-default. Does **not** call `refresh()` itself
+    /// — this is a pure clear.
+    public func clearSelectedModel() async {
+        selectedModelID = ""
+        try? await store.updateSettings { settings in
+            settings.selectedModelID = ""
+        }
+    }
+
     /// Select a model as the active default.
     ///
     /// Guard: the model must be downloaded and runnable.

--- a/Packages/BiscottiKit/Sources/Intelligence/ModelPolicy.swift
+++ b/Packages/BiscottiKit/Sources/Intelligence/ModelPolicy.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// Product-level policy for each catalog model: RAM requirements, UI copy,
+/// and recommendation thresholds. Kept in the app layer (Intelligence), not
+/// in `LocalLLM`, so the library stays free of product policy.
+public enum ModelPolicy {
+    // MARK: - Threshold constants (SI: 1 GB = 1_000_000_000)
+
+    private static let oneGB: UInt64 = 1_000_000_000
+
+    /// Minimum RAM to run the 12B model. Below this, the model is not
+    /// runnable and the UI greys it out.
+    public static let ramFloor12B: UInt64 = 15 * oneGB
+
+    /// RAM threshold for recommending the 12B model over E2B. At or above
+    /// this, 12B is recommended; below, E2B is recommended.
+    public static let recommendationRAMThreshold: UInt64 = 24 * oneGB
+
+    // MARK: - Per-model policy
+
+    /// UI marketing description for the model, shown in the Manage Models
+    /// sheet. Matches the catalog copy from the functional spec.
+    public static func description(id: String) -> String {
+        switch id {
+        case "gemma-4-12b":
+            "Intelligent, but slower and larger. Requires 7 GB of disk and uses 8 GB RAM."
+        case "gemma-4-e2b":
+            "Small and fast, but not as intelligent. Requires 3 GB of disk and uses 4 GB of RAM."
+        default:
+            ""
+        }
+    }
+
+    /// Minimum physical RAM in bytes required to run this model.
+    /// Returns 0 for models that run on any supported Mac.
+    public static func minRAMBytesToRun(id: String) -> UInt64 {
+        switch id {
+        case "gemma-4-12b":
+            ramFloor12B
+        default:
+            0
+        }
+    }
+
+    /// Human-readable approximate RAM usage string for UI copy.
+    public static func approxRAMUsageDescription(id: String) -> String {
+        switch id {
+        case "gemma-4-12b":
+            "8 GB"
+        case "gemma-4-e2b":
+            "4 GB"
+        default:
+            ""
+        }
+    }
+}

--- a/Packages/BiscottiKit/Sources/Intelligence/ModelProviding.swift
+++ b/Packages/BiscottiKit/Sources/Intelligence/ModelProviding.swift
@@ -1,11 +1,29 @@
 import Foundation
+import LocalLLM
 
-/// Abstracts model presence checks and downloading.
-/// Real impl wraps `ModelDownloader` + `LocalLLMPaths`; fakes in tests.
+/// Abstracts multi-model presence checks, downloading, and deletion.
+/// Real impl wraps `LLMModelCatalog` + `ModelInventory` + `ModelDownloader`;
+/// fakes in tests implement the protocol in-memory.
 public protocol ModelProviding: Sendable {
-    var modelURL: URL { get }
-    func isDownloaded() -> Bool
+    /// The catalog of available models (display order).
+    var catalog: [LLMModel] { get }
+
+    /// The on-disk path for a catalog model, or `nil` if the id is unknown.
+    func url(for id: String) -> URL?
+
+    /// Whether the model with the given id is downloaded on disk.
+    func isDownloaded(_ id: String) -> Bool
+
+    /// The ids of all catalog models currently downloaded.
+    func downloadedModelIDs() -> [String]
+
+    /// Download the model with the given id. Calls `progress` periodically
+    /// with (bytesDownloaded, totalBytes).
     func download(
+        _ id: String,
         progress: @Sendable @escaping (Int64, Int64?) -> Void
     ) async throws
+
+    /// Delete the model with the given id from disk.
+    func delete(_ id: String) throws
 }

--- a/Packages/BiscottiKit/Sources/Intelligence/ModelSuitability.swift
+++ b/Packages/BiscottiKit/Sources/Intelligence/ModelSuitability.swift
@@ -1,0 +1,56 @@
+import LocalLLM
+
+/// Pure functions that determine whether a model can run on this hardware,
+/// which model to recommend, and whether there is enough disk to download.
+///
+/// All inputs are value types (RAM bytes, disk bytes, catalog entries) --
+/// no side effects, fully unit-testable with fabricated values.
+public enum ModelSuitability {
+    /// Whether `model` is runnable on a Mac with `ram` bytes of physical RAM.
+    ///
+    /// A model is runnable iff the machine's RAM meets or exceeds the model's
+    /// RAM floor. Models with no floor (e.g. E2B) are always runnable.
+    public static func canRun(_ model: LLMModel, ram: UInt64) -> Bool {
+        ram >= ModelPolicy.minRAMBytesToRun(id: model.id)
+    }
+
+    /// The catalog model id recommended for a Mac with `ram` bytes of RAM,
+    /// or `nil` if the catalog is empty.
+    ///
+    /// - If RAM >= 24 GB and the catalog contains the 12B model, recommend 12B.
+    /// - Otherwise recommend the smallest always-runnable model (E2B).
+    ///
+    /// Never returns a non-runnable model id.
+    public static func recommendedModelID(
+        catalog: [LLMModel], ram: UInt64
+    ) -> String? {
+        guard !catalog.isEmpty else { return nil }
+
+        if ram >= ModelPolicy.recommendationRAMThreshold {
+            // Recommend 12B if it's in the catalog (it's guaranteed runnable
+            // at >= 24 GB since its floor is 15 GB).
+            if let model12b = catalog.first(where: { $0.id == "gemma-4-12b" }) {
+                assert(canRun(model12b, ram: ram))
+                return model12b.id
+            }
+        }
+
+        // Default: the smallest runnable model -- last in catalog order
+        // (catalog is sorted largest-first: 12B, E2B). This ensures E2B is
+        // recommended for machines below the 24 GB threshold even if 12B is
+        // technically runnable (the "middle band" at 15-23 GB).
+        return catalog.last { canRun($0, ram: ram) }?.id
+    }
+
+    /// Whether there is enough free disk space to download `model`.
+    ///
+    /// Returns `true` when `freeBytes` is `nil` (unknown capacity) -- never
+    /// falsely block a download on a failed capacity read; the downloader's
+    /// size validation is the backstop.
+    public static func hasEnoughDisk(
+        _ model: LLMModel, freeBytes: Int64?
+    ) -> Bool {
+        guard let freeBytes else { return true }
+        return freeBytes >= model.approxDownloadBytes
+    }
+}

--- a/Packages/BiscottiKit/Sources/ManualTestKit/Scripts/LocalLLMScript.swift
+++ b/Packages/BiscottiKit/Sources/ManualTestKit/Scripts/LocalLLMScript.swift
@@ -152,7 +152,26 @@ public extension TestScript {
                 prompt: "Did the 2nd call reuse most of the prefix (high cached count, "
                     + "much faster prompt eval) and was the 2nd response coherent?"
             ),
-            // 21. Reclamation check
+            // 21. E2B model download
+            .action(
+                id: "llm_e2b_download",
+                label: "Download E2B model (shows progress)",
+                run: { _ in /* wired by the app target */ }
+            ),
+            // 22. E2B multi-turn KV-cache reuse inference
+            .action(
+                id: "llm_e2b_kv_reuse",
+                label: "Run KV-cache reuse test on E2B model via BiscottiLLM.xpc",
+                run: { _ in /* wired by the app target */ }
+            ),
+            // 23. E2B KV-cache reuse observation
+            .humanQuestion(
+                id: "llm_e2b_kv_reuse_quality",
+                prompt: "Did the E2B model's 2nd call reuse most of the prefix "
+                    + "(high cached count, much faster prompt eval) and was "
+                    + "the 2nd response coherent?"
+            ),
+            // 24. Reclamation check
             .autoCheck(
                 id: "llm_reclamation",
                 label: "No BiscottiLLM service process running after connection close",

--- a/Packages/BiscottiKit/Sources/MeetingDetailUI/MeetingDetailViewModel.swift
+++ b/Packages/BiscottiKit/Sources/MeetingDetailUI/MeetingDetailViewModel.swift
@@ -541,7 +541,7 @@ public extension MeetingDetailViewModel {
 
     /// Whether the AI model is downloaded and available.
     var modelAvailable: Bool {
-        core.intelligence.isModelDownloaded
+        core.modelManager.isModelAvailable
     }
 
     /// Whether the Regenerate Summary overflow menu item should appear.

--- a/Packages/BiscottiKit/Sources/ModelManagementUI/ManageModelsSheet.swift
+++ b/Packages/BiscottiKit/Sources/ModelManagementUI/ManageModelsSheet.swift
@@ -68,13 +68,17 @@ public final class ManageModelsViewModel {
 
 /// Sheet listing every catalog model with per-state actions (download,
 /// delete, choose) and the Recommended badge. Presented from the
-/// "AI Language Model" settings row.
-struct ManageModelsSheet: View {
+/// "AI Language Model" settings row and the onboarding model-download step.
+public struct ManageModelsSheet: View {
     @Bindable var viewModel: ManageModelsViewModel
 
     @Environment(\.dismiss) private var dismiss
 
-    var body: some View {
+    public init(viewModel: ManageModelsViewModel) {
+        self.viewModel = viewModel
+    }
+
+    public var body: some View {
         VStack(alignment: .leading, spacing: Tokens.spacingMD) {
             // Header
             Text("AI Language Model")

--- a/Packages/BiscottiKit/Sources/ModelManagementUI/ManageModelsSheet.swift
+++ b/Packages/BiscottiKit/Sources/ModelManagementUI/ManageModelsSheet.swift
@@ -187,7 +187,7 @@ struct ModelRowView: View {
                 VStack(alignment: .leading, spacing: 2) {
                     descriptionOrProgress
                 }
-                Spacer()
+                .frame(maxWidth: .infinity, alignment: .leading)
                 primaryAction
             }
         }
@@ -240,21 +240,27 @@ struct ModelRowView: View {
 
     // MARK: - Description / progress / warning (left column, lines 2-3)
 
+    /// The model description text, styled for left-aligned wrapping.
+    private var descriptionText: some View {
+        Text(choice.description)
+            .font(Tokens.metadataFont)
+            .foregroundStyle(Tokens.secondaryText)
+            .multilineTextAlignment(.leading)
+            .fixedSize(horizontal: false, vertical: true)
+            .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
     @ViewBuilder
     private var descriptionOrProgress: some View {
         // Guard cannotRun first — non-runnable models show only the
         // description + warning, never download/failure progress.
         if choice.blockedReason == .cannotRun {
-            Text(choice.description)
-                .font(Tokens.metadataFont)
-                .foregroundStyle(Tokens.secondaryText)
+            descriptionText
             warningLabel(for: .cannotRun)
         } else {
             switch choice.downloadState {
             case let .downloading(fraction):
-                Text(choice.description)
-                    .font(Tokens.metadataFont)
-                    .foregroundStyle(Tokens.secondaryText)
+                descriptionText
                 if let fraction {
                     ProgressView(value: fraction)
                     Text("Downloading\u{2026} \(Int(fraction * 100))%")
@@ -269,17 +275,13 @@ struct ModelRowView: View {
                 }
 
             case let .failed(message):
-                Text(choice.description)
-                    .font(Tokens.metadataFont)
-                    .foregroundStyle(Tokens.secondaryText)
+                descriptionText
                 Text("Download failed: \(message)")
                     .font(Tokens.metadataFont)
                     .foregroundStyle(.signalRed)
 
             default:
-                Text(choice.description)
-                    .font(Tokens.metadataFont)
-                    .foregroundStyle(Tokens.secondaryText)
+                descriptionText
 
                 // Warnings (e.g. insufficientDisk)
                 if let reason = choice.blockedReason {

--- a/Packages/BiscottiKit/Sources/OnboardingUI/ModelDownloadCard.swift
+++ b/Packages/BiscottiKit/Sources/OnboardingUI/ModelDownloadCard.swift
@@ -126,6 +126,44 @@ extension ModelDownloadRow where ExtraContent == EmptyView {
     }
 }
 
+// MARK: - IndeterminateBar
+
+/// A sage capsule segment that bounces back and forth within a hairline track.
+/// Falls back to a static left-parked segment when Reduce Motion is on.
+private struct IndeterminateBar: View {
+    let trackWidth: CGFloat
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var animate = false
+
+    private let segmentWidth: CGFloat = 40
+
+    private var maxOffset: CGFloat {
+        trackWidth - segmentWidth
+    }
+
+    var body: some View {
+        ZStack(alignment: .leading) {
+            Capsule()
+                .fill(Color.hairline)
+                .frame(width: trackWidth, height: 3)
+            Capsule()
+                .fill(Color.sage)
+                .frame(width: segmentWidth, height: 3)
+                .offset(x: animate ? maxOffset : 0)
+        }
+        .onAppear {
+            guard !reduceMotion else { return }
+            withAnimation(
+                .easeInOut(duration: 0.9)
+                    .repeatForever(autoreverses: true)
+            ) {
+                animate = true
+            }
+        }
+    }
+}
+
 // MARK: - DownloadControl
 
 /// The trailing control for a model download row.
@@ -134,10 +172,13 @@ struct DownloadControl: View {
     let state: ModelRowState
     let onDownload: () -> Void
 
+    /// Shared width for the bar tracks and the entire control column.
+    private let controlWidth: CGFloat = 120
+
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
-        VStack(alignment: .trailing, spacing: 6) {
+        VStack(alignment: .center, spacing: 6) {
             switch state {
             case let .idle(sizeCaption):
                 GrantPill(
@@ -148,6 +189,7 @@ struct DownloadControl: View {
                 Text(sizeCaption)
                     .font(.biscottiMono(11))
                     .foregroundStyle(.inkTertiary)
+                    .multilineTextAlignment(.center)
 
             case let .downloading(progress):
                 downloadingContent(progress)
@@ -162,7 +204,7 @@ struct DownloadControl: View {
                 Text(message)
                     .font(.biscottiMono(11))
                     .foregroundStyle(.signalRed)
-                    .multilineTextAlignment(.trailing)
+                    .multilineTextAlignment(.center)
                 GrantPill(
                     title: "Retry",
                     systemImage: "arrow.clockwise",
@@ -174,6 +216,7 @@ struct DownloadControl: View {
                     .controlSize(.small)
             }
         }
+        .frame(width: controlWidth, alignment: .center)
     }
 
     // MARK: - Downloading states
@@ -182,12 +225,12 @@ struct DownloadControl: View {
     private func downloadingContent(_ progress: RowDownloadProgress) -> some View {
         switch progress {
         case let .indeterminate(status):
-            indeterminateBar
+            IndeterminateBar(trackWidth: controlWidth)
             if let status {
                 Text(status)
                     .font(.biscottiMono(11))
                     .foregroundStyle(.inkSecondary)
-                    .lineLimit(1)
+                    .multilineTextAlignment(.center)
             }
 
         case let .determinate(fraction):
@@ -196,37 +239,27 @@ struct DownloadControl: View {
                 Text("Downloading\u{2026} \(Int(fraction * 100))%")
                     .font(.biscottiMono(11))
                     .foregroundStyle(.inkSecondary)
+                    .multilineTextAlignment(.center)
             } else {
-                indeterminateBar
+                IndeterminateBar(trackWidth: controlWidth)
                 Text("Downloading\u{2026}")
                     .font(.biscottiMono(11))
                     .foregroundStyle(.inkSecondary)
+                    .multilineTextAlignment(.center)
             }
         }
     }
 
-    /// Indeterminate sage capsule bar (120x3, fill half-width, centered).
-    private var indeterminateBar: some View {
-        ZStack(alignment: .leading) {
-            Capsule()
-                .fill(Color.hairline)
-                .frame(width: 120, height: 3)
-            Capsule()
-                .fill(Color.sage)
-                .frame(width: 60, height: 3)
-        }
-    }
-
-    /// Determinate sage capsule bar (120x3, fill proportional to fraction).
+    /// Determinate sage capsule bar; fill proportional to fraction.
     private func determinateBar(fraction: Double) -> some View {
         ZStack(alignment: .leading) {
             Capsule()
                 .fill(Color.hairline)
-                .frame(width: 120, height: 3)
+                .frame(width: controlWidth, height: 3)
             Capsule()
                 .fill(Color.sage)
                 .frame(
-                    width: max(3, 120 * min(fraction, 1.0)),
+                    width: max(3, controlWidth * min(fraction, 1.0)),
                     height: 3
                 )
                 .animation(
@@ -244,6 +277,7 @@ struct DownloadControl: View {
                 .font(.caption2)
             Text("Insufficient free space on disk")
                 .font(.system(size: 12.5))
+                .multilineTextAlignment(.center)
         }
         .foregroundStyle(.warningOchre)
     }

--- a/Packages/BiscottiKit/Sources/OnboardingUI/ModelDownloadCard.swift
+++ b/Packages/BiscottiKit/Sources/OnboardingUI/ModelDownloadCard.swift
@@ -168,6 +168,10 @@ struct DownloadControl: View {
                     systemImage: "arrow.clockwise",
                     action: onDownload
                 )
+
+            case .checking:
+                ProgressView()
+                    .controlSize(.small)
             }
         }
     }

--- a/Packages/BiscottiKit/Sources/OnboardingUI/ModelDownloadCard.swift
+++ b/Packages/BiscottiKit/Sources/OnboardingUI/ModelDownloadCard.swift
@@ -90,7 +90,7 @@ struct ModelDownloadRow<ExtraContent: View>: View {
                     .font(.system(size: 12.5))
                     .foregroundStyle(.inkSecondary)
                     .multilineTextAlignment(.leading)
-                    .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
 
                 extraContent
             }
@@ -205,28 +205,28 @@ struct DownloadControl: View {
         }
     }
 
-    /// Indeterminate sage capsule bar (240x3, fill half-width, centered).
+    /// Indeterminate sage capsule bar (120x3, fill half-width, centered).
     private var indeterminateBar: some View {
         ZStack(alignment: .leading) {
             Capsule()
                 .fill(Color.hairline)
-                .frame(width: 240, height: 3)
+                .frame(width: 120, height: 3)
             Capsule()
                 .fill(Color.sage)
-                .frame(width: 120, height: 3)
+                .frame(width: 60, height: 3)
         }
     }
 
-    /// Determinate sage capsule bar (240x3, fill proportional to fraction).
+    /// Determinate sage capsule bar (120x3, fill proportional to fraction).
     private func determinateBar(fraction: Double) -> some View {
         ZStack(alignment: .leading) {
             Capsule()
                 .fill(Color.hairline)
-                .frame(width: 240, height: 3)
+                .frame(width: 120, height: 3)
             Capsule()
                 .fill(Color.sage)
                 .frame(
-                    width: max(3, 240 * min(fraction, 1.0)),
+                    width: max(3, 120 * min(fraction, 1.0)),
                     height: 3
                 )
                 .animation(

--- a/Packages/BiscottiKit/Sources/OnboardingUI/ModelDownloadCard.swift
+++ b/Packages/BiscottiKit/Sources/OnboardingUI/ModelDownloadCard.swift
@@ -46,7 +46,8 @@ struct ModelCard: View {
             extraContent: {
                 if case .idle = state {
                     RecommendationLine(
-                        modelName: viewModel.recommendedLanguageDisplayName,
+                        modelName: viewModel.languageTargetDisplayName,
+                        isRecommended: viewModel.languageTargetIsRecommended,
                         onSeeAll: { viewModel.showVariantSheet = true }
                     )
                 }
@@ -290,16 +291,18 @@ struct DownloadControl: View {
 
 // MARK: - RecommendationLine
 
-/// Grey line showing the recommended model and a "See all options"
+/// Grey line showing the target model name and a "See all options"
 /// affordance. Shown only when the language row is idle.
+/// When `isRecommended` is true, prefixes the name with "Recommended ·".
 struct RecommendationLine: View {
     let modelName: String?
+    let isRecommended: Bool
     let onSeeAll: () -> Void
 
     var body: some View {
         HStack(spacing: 10) {
             if let modelName {
-                Text("Recommended \u{00B7} \(modelName)")
+                Text(isRecommended ? "Recommended \u{00B7} \(modelName)" : modelName)
                     .font(.system(size: 12.5))
                     .foregroundStyle(.inkSecondary)
             }

--- a/Packages/BiscottiKit/Sources/OnboardingUI/ModelDownloadCard.swift
+++ b/Packages/BiscottiKit/Sources/OnboardingUI/ModelDownloadCard.swift
@@ -1,0 +1,277 @@
+import DesignSystem
+import SwiftUI
+
+// MARK: - ModelCard
+
+/// Two-row card for the model download onboarding step.
+/// Transcription row on top, language row on bottom, separated
+/// by an inset divider matching the permission card chrome.
+struct ModelCard: View {
+    @Bindable var viewModel: OnboardingViewModel
+
+    var body: some View {
+        VStack(spacing: 0) {
+            transcriptionRow
+
+            InsetDivider(leadingInset: 48)
+
+            languageRow
+        }
+        .homeCard()
+        .frame(maxWidth: 560)
+    }
+
+    private var transcriptionRow: some View {
+        ModelDownloadRow(
+            icon: "waveform",
+            name: "Transcription & Speaker ID",
+            why: "Turns speech into text and labels who\u{2019}s speaking.",
+            state: viewModel.transcriptionRowState(),
+            onDownload: {
+                Task { await viewModel.startTranscriptionDownload() }
+            }
+        )
+    }
+
+    private var languageRow: some View {
+        let state = viewModel.languageRowState()
+        return ModelDownloadRow(
+            icon: "sparkles",
+            name: "Language Model",
+            why: "Meeting summaries, speaker matching, and automatic titles.",
+            state: state,
+            onDownload: {
+                viewModel.startLanguageDownload()
+            },
+            extraContent: {
+                if case .idle = state {
+                    RecommendationLine(
+                        modelName: viewModel.recommendedLanguageDisplayName,
+                        onSeeAll: { viewModel.showVariantSheet = true }
+                    )
+                }
+            }
+        )
+    }
+}
+
+// MARK: - ModelDownloadRow
+
+/// A single row in the model download card. Mirrors the
+/// `PermissionRow` skeleton (icon tile + name + why + trailing control)
+/// but top-aligned and with an optional extra content line.
+struct ModelDownloadRow<ExtraContent: View>: View {
+    let icon: String
+    let name: String
+    let why: String
+    let state: ModelRowState
+    let onDownload: () -> Void
+    @ViewBuilder let extraContent: ExtraContent
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 14) {
+            // Icon tile (same metrics as PermissionRow)
+            RoundedRectangle(cornerRadius: 9)
+                .fill(Color.accentWashSoft)
+                .frame(width: 34, height: 34)
+                .overlay(
+                    Image(systemName: icon)
+                        .font(.system(size: 18, weight: .medium))
+                        .foregroundStyle(.sage)
+                )
+
+            // Name + why + optional extra
+            VStack(alignment: .leading, spacing: 2) {
+                Text(name)
+                    .font(.system(size: 14.5, weight: .semibold))
+                    .foregroundStyle(.ink)
+
+                Text(why)
+                    .font(.system(size: 12.5))
+                    .foregroundStyle(.inkSecondary)
+                    .multilineTextAlignment(.leading)
+                    .lineLimit(2)
+
+                extraContent
+            }
+
+            Spacer(minLength: 0)
+
+            // Trailing download control
+            DownloadControl(state: state, onDownload: onDownload)
+        }
+        .padding(.vertical, 15)
+        .padding(.horizontal, 16)
+    }
+}
+
+// MARK: - Convenience init (no extra content)
+
+extension ModelDownloadRow where ExtraContent == EmptyView {
+    init(
+        icon: String,
+        name: String,
+        why: String,
+        state: ModelRowState,
+        onDownload: @escaping () -> Void
+    ) {
+        self.init(
+            icon: icon,
+            name: name,
+            why: why,
+            state: state,
+            onDownload: onDownload,
+            extraContent: { EmptyView() }
+        )
+    }
+}
+
+// MARK: - DownloadControl
+
+/// The trailing control for a model download row.
+/// Switches on `ModelRowState` to show the appropriate UI.
+struct DownloadControl: View {
+    let state: ModelRowState
+    let onDownload: () -> Void
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    var body: some View {
+        VStack(alignment: .trailing, spacing: 6) {
+            switch state {
+            case let .idle(sizeCaption):
+                GrantPill(
+                    title: "Download",
+                    systemImage: "arrow.down.circle",
+                    action: onDownload
+                )
+                Text(sizeCaption)
+                    .font(.biscottiMono(11))
+                    .foregroundStyle(.inkTertiary)
+
+            case let .downloading(progress):
+                downloadingContent(progress)
+
+            case .ready:
+                GrantedTag("READY")
+
+            case .insufficientDisk:
+                diskWarning
+
+            case let .failed(message):
+                Text(message)
+                    .font(.biscottiMono(11))
+                    .foregroundStyle(.signalRed)
+                    .multilineTextAlignment(.trailing)
+                GrantPill(
+                    title: "Retry",
+                    systemImage: "arrow.clockwise",
+                    action: onDownload
+                )
+            }
+        }
+    }
+
+    // MARK: - Downloading states
+
+    @ViewBuilder
+    private func downloadingContent(_ progress: RowDownloadProgress) -> some View {
+        switch progress {
+        case let .indeterminate(status):
+            indeterminateBar
+            if let status {
+                Text(status)
+                    .font(.biscottiMono(11))
+                    .foregroundStyle(.inkSecondary)
+                    .lineLimit(1)
+            }
+
+        case let .determinate(fraction):
+            if let fraction {
+                determinateBar(fraction: fraction)
+                Text("Downloading\u{2026} \(Int(fraction * 100))%")
+                    .font(.biscottiMono(11))
+                    .foregroundStyle(.inkSecondary)
+            } else {
+                indeterminateBar
+                Text("Downloading\u{2026}")
+                    .font(.biscottiMono(11))
+                    .foregroundStyle(.inkSecondary)
+            }
+        }
+    }
+
+    /// Indeterminate sage capsule bar (240x3, fill half-width, centered).
+    private var indeterminateBar: some View {
+        ZStack(alignment: .leading) {
+            Capsule()
+                .fill(Color.hairline)
+                .frame(width: 240, height: 3)
+            Capsule()
+                .fill(Color.sage)
+                .frame(width: 120, height: 3)
+        }
+    }
+
+    /// Determinate sage capsule bar (240x3, fill proportional to fraction).
+    private func determinateBar(fraction: Double) -> some View {
+        ZStack(alignment: .leading) {
+            Capsule()
+                .fill(Color.hairline)
+                .frame(width: 240, height: 3)
+            Capsule()
+                .fill(Color.sage)
+                .frame(
+                    width: max(3, 240 * min(fraction, 1.0)),
+                    height: 3
+                )
+                .animation(
+                    reduceMotion ? .none : .easeInOut(duration: 0.2),
+                    value: fraction
+                )
+        }
+    }
+
+    // MARK: - Disk warning
+
+    private var diskWarning: some View {
+        HStack(spacing: 4) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.caption2)
+            Text("Insufficient free space on disk")
+                .font(.system(size: 12.5))
+        }
+        .foregroundStyle(.warningOchre)
+    }
+}
+
+// MARK: - RecommendationLine
+
+/// Grey line showing the recommended model and a "See all options"
+/// affordance. Shown only when the language row is idle.
+struct RecommendationLine: View {
+    let modelName: String?
+    let onSeeAll: () -> Void
+
+    var body: some View {
+        HStack(spacing: 10) {
+            if let modelName {
+                Text("Recommended \u{00B7} \(modelName)")
+                    .font(.system(size: 12.5))
+                    .foregroundStyle(.inkSecondary)
+            }
+
+            Button(action: onSeeAll) {
+                HStack(spacing: 3) {
+                    Text("See all options")
+                        .font(.system(size: 12.5, weight: .semibold))
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 11))
+                }
+                .foregroundStyle(.inkSecondary)
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.top, 6)
+    }
+}

--- a/Packages/BiscottiKit/Sources/OnboardingUI/ModelDownloadCard.swift
+++ b/Packages/BiscottiKit/Sources/OnboardingUI/ModelDownloadCard.swift
@@ -190,6 +190,7 @@ struct DownloadControl: View {
                     .font(.biscottiMono(11))
                     .foregroundStyle(.inkTertiary)
                     .multilineTextAlignment(.center)
+                    .fixedSize(horizontal: false, vertical: true)
 
             case let .downloading(progress):
                 downloadingContent(progress)
@@ -205,6 +206,7 @@ struct DownloadControl: View {
                     .font(.biscottiMono(11))
                     .foregroundStyle(.signalRed)
                     .multilineTextAlignment(.center)
+                    .fixedSize(horizontal: false, vertical: true)
                 GrantPill(
                     title: "Retry",
                     systemImage: "arrow.clockwise",
@@ -231,6 +233,7 @@ struct DownloadControl: View {
                     .font(.biscottiMono(11))
                     .foregroundStyle(.inkSecondary)
                     .multilineTextAlignment(.center)
+                    .fixedSize(horizontal: false, vertical: true)
             }
 
         case let .determinate(fraction):
@@ -240,12 +243,14 @@ struct DownloadControl: View {
                     .font(.biscottiMono(11))
                     .foregroundStyle(.inkSecondary)
                     .multilineTextAlignment(.center)
+                    .fixedSize(horizontal: false, vertical: true)
             } else {
                 IndeterminateBar(trackWidth: controlWidth)
                 Text("Downloading\u{2026}")
                     .font(.biscottiMono(11))
                     .foregroundStyle(.inkSecondary)
                     .multilineTextAlignment(.center)
+                    .fixedSize(horizontal: false, vertical: true)
             }
         }
     }

--- a/Packages/BiscottiKit/Sources/OnboardingUI/ModelRowState.swift
+++ b/Packages/BiscottiKit/Sources/OnboardingUI/ModelRowState.swift
@@ -23,6 +23,8 @@ enum ModelRowState: Equatable {
     case ready
     /// Download failed; message describes the error.
     case failed(message: String)
+    /// Probing readiness / disk space in the background.
+    case checking
 }
 
 // MARK: - Model download derivation + row-state mappers
@@ -75,13 +77,16 @@ public extension OnboardingViewModel {
         if transcriptionReady {
             return .ready
         }
-        if transcriptionInsufficientDisk {
-            return .insufficientDisk
-        }
         if isDownloading {
             return .downloading(
                 .indeterminate(status: downloadStatus)
             )
+        }
+        if isPreparingModelStep {
+            return .checking
+        }
+        if transcriptionInsufficientDisk {
+            return .insufficientDisk
         }
         if downloadFailed, let status = downloadStatus {
             return .failed(message: status)
@@ -96,7 +101,7 @@ public extension OnboardingViewModel {
         }
 
         guard let targetID = languageTargetModelID else {
-            return .idle(sizeCaption: "")
+            return isPreparingModelStep ? .checking : .idle(sizeCaption: "")
         }
 
         // Check in-flight download state
@@ -109,6 +114,10 @@ public extension OnboardingViewModel {
             case .downloaded, .notDownloaded, .unknown:
                 break
             }
+        }
+
+        if isPreparingModelStep {
+            return .checking
         }
 
         // Check disk block via model choices

--- a/Packages/BiscottiKit/Sources/OnboardingUI/ModelRowState.swift
+++ b/Packages/BiscottiKit/Sources/OnboardingUI/ModelRowState.swift
@@ -70,6 +70,30 @@ public extension OnboardingViewModel {
         transcriptionReady && languageReady
     }
 
+    // MARK: - "Started" derivation (ready OR actively downloading)
+
+    /// Whether the transcription model has started (ready or downloading).
+    var transcriptionStarted: Bool {
+        transcriptionReady || isDownloading
+    }
+
+    /// Whether the language model has started (ready or actively downloading).
+    var languageStarted: Bool {
+        if languageReady { return true }
+        guard let targetID = languageTargetModelID else { return false }
+        if case .downloading = appCore.modelManager.downloads[targetID] {
+            return true
+        }
+        return false
+    }
+
+    /// Whether both model downloads have at least started (each is
+    /// either ready or actively downloading). Used by the footer to
+    /// show "Continue" without waiting for completion.
+    var bothModelsStarted: Bool {
+        transcriptionStarted && languageStarted
+    }
+
     // MARK: - Row-state mappers
 
     /// Computes the view-state for the transcription model row.

--- a/Packages/BiscottiKit/Sources/OnboardingUI/ModelRowState.swift
+++ b/Packages/BiscottiKit/Sources/OnboardingUI/ModelRowState.swift
@@ -45,19 +45,69 @@ public extension OnboardingViewModel {
 
     // MARK: - Language row derivation
 
-    /// The language model id the "Download" pill targets: the active
-    /// model if one is already downloaded, else the recommended model.
+    /// The language model id the onboarding row targets, resolved in
+    /// priority order so the row tracks the user's effective choice:
+    ///
+    /// 1. An actively **downloading** model (`.downloading`) -- the user's
+    ///    current action, always wins.
+    /// 2. `activeModelID` -- a downloaded + selected/fallback model. Checked
+    ///    before `.failed` so a stale failure doesn't shadow a working model.
+    /// 3. A **failed** download (`.failed`) -- shows the error for retry when
+    ///    no active model exists yet.
+    /// 4. `selectedModelID` if non-empty and a valid catalog model id
+    ///    (explicit user selection, even if mid-state).
+    /// 5. `recommendedModelID()` -- hardware-based default.
     var languageTargetModelID: String? {
-        appCore.modelManager.activeModelID
-            ?? appCore.modelManager.recommendedModelID()
+        if let downloading = languageDownloadingModelID {
+            return downloading
+        }
+        if let active = appCore.modelManager.activeModelID {
+            return active
+        }
+        if let failed = languageFailedModelID {
+            return failed
+        }
+        let sel = appCore.modelManager.selectedModelID
+        if !sel.isEmpty, LLMModelCatalog.model(id: sel) != nil {
+            return sel
+        }
+        return appCore.modelManager.recommendedModelID()
     }
 
-    /// Display name of the hardware-recommended language model.
-    var recommendedLanguageDisplayName: String? {
-        guard let id = appCore.modelManager.recommendedModelID() else {
-            return nil
-        }
+    /// Display name of the target language model.
+    var languageTargetDisplayName: String? {
+        guard let id = languageTargetModelID else { return nil }
         return LLMModelCatalog.model(id: id)?.displayName
+    }
+
+    /// Whether the current target is the hardware-recommended model.
+    var languageTargetIsRecommended: Bool {
+        languageTargetModelID == appCore.modelManager.recommendedModelID()
+    }
+
+    // MARK: - Private helpers
+
+    /// The model id whose download is actively in progress (`.downloading`),
+    /// if any. Iterates the catalog in display order for deterministic results
+    /// (dictionary iteration order is not stable).
+    private var languageDownloadingModelID: String? {
+        for model in LLMModelCatalog.all {
+            if case .downloading = appCore.modelManager.downloads[model.id] {
+                return model.id
+            }
+        }
+        return nil
+    }
+
+    /// The first model id in catalog order whose download has failed
+    /// (`.failed`), if any. Deterministic via catalog-order iteration.
+    private var languageFailedModelID: String? {
+        for model in LLMModelCatalog.all {
+            if case .failed = appCore.modelManager.downloads[model.id] {
+                return model.id
+            }
+        }
+        return nil
     }
 
     /// Whether a language model is downloaded and available.
@@ -78,6 +128,12 @@ public extension OnboardingViewModel {
     }
 
     /// Whether the language model has started (ready or actively downloading).
+    ///
+    /// Intentionally checks only `.downloading`, not `.failed`. A failed
+    /// attempt should not flip the footer to "Continue" -- the user needs
+    /// to retry or skip. Note that `languageTargetModelID` *can* resolve
+    /// to a `.failed` model (priority 3), so the target and "started"
+    /// may diverge; that is the desired behavior.
     var languageStarted: Bool {
         if languageReady { return true }
         guard let targetID = languageTargetModelID else { return false }

--- a/Packages/BiscottiKit/Sources/OnboardingUI/ModelRowState.swift
+++ b/Packages/BiscottiKit/Sources/OnboardingUI/ModelRowState.swift
@@ -1,0 +1,139 @@
+import Intelligence
+import LocalLLM
+
+/// Progress style for a model download row.
+enum RowDownloadProgress: Equatable {
+    /// Indeterminate bar + optional status string (transcription).
+    case indeterminate(status: String?)
+    /// Determinate bar with optional fraction (language). Nil fraction
+    /// falls back to an indeterminate spinner in the UI.
+    case determinate(fraction: Double?)
+}
+
+/// The view-state for a single model download row. Computed by the
+/// view model from observable state so SwiftUI re-renders on change.
+enum ModelRowState: Equatable {
+    /// Not yet downloaded, enough disk. Caption shows the approximate size.
+    case idle(sizeCaption: String)
+    /// Not enough free disk space to download this model.
+    case insufficientDisk
+    /// Download in progress.
+    case downloading(RowDownloadProgress)
+    /// Model is downloaded and ready to use.
+    case ready
+    /// Download failed; message describes the error.
+    case failed(message: String)
+}
+
+// MARK: - Model download derivation + row-state mappers
+
+public extension OnboardingViewModel {
+    // MARK: - Transcription row derivation
+
+    /// Whether the transcription model is ready (already cached or just
+    /// downloaded).
+    var transcriptionReady: Bool {
+        transcriptionDownloaded || downloadComplete
+    }
+
+    /// Whether the transcription model cannot be downloaded due to disk.
+    internal var transcriptionInsufficientDisk: Bool {
+        !hasSufficientDisk
+    }
+
+    // MARK: - Language row derivation
+
+    /// The language model id the "Download" pill targets: the active
+    /// model if one is already downloaded, else the recommended model.
+    var languageTargetModelID: String? {
+        appCore.modelManager.activeModelID
+            ?? appCore.modelManager.recommendedModelID()
+    }
+
+    /// Display name of the hardware-recommended language model.
+    var recommendedLanguageDisplayName: String? {
+        guard let id = appCore.modelManager.recommendedModelID() else {
+            return nil
+        }
+        return LLMModelCatalog.model(id: id)?.displayName
+    }
+
+    /// Whether a language model is downloaded and available.
+    var languageReady: Bool {
+        appCore.modelManager.isModelAvailable
+    }
+
+    /// Whether both model classes are ready (transcription + language).
+    var bothModelsReady: Bool {
+        transcriptionReady && languageReady
+    }
+
+    // MARK: - Row-state mappers
+
+    /// Computes the view-state for the transcription model row.
+    internal func transcriptionRowState() -> ModelRowState {
+        if transcriptionReady {
+            return .ready
+        }
+        if transcriptionInsufficientDisk {
+            return .insufficientDisk
+        }
+        if isDownloading {
+            return .downloading(
+                .indeterminate(status: downloadStatus)
+            )
+        }
+        if downloadFailed, let status = downloadStatus {
+            return .failed(message: status)
+        }
+        return .idle(sizeCaption: "~1.5 GB")
+    }
+
+    /// Computes the view-state for the language model row.
+    internal func languageRowState() -> ModelRowState {
+        if languageReady {
+            return .ready
+        }
+
+        guard let targetID = languageTargetModelID else {
+            return .idle(sizeCaption: "")
+        }
+
+        // Check in-flight download state
+        if let state = appCore.modelManager.downloads[targetID] {
+            switch state {
+            case let .downloading(fraction):
+                return .downloading(.determinate(fraction: fraction))
+            case let .failed(message):
+                return .failed(message: message)
+            case .downloaded, .notDownloaded, .unknown:
+                break
+            }
+        }
+
+        // Check disk block via model choices
+        let choices = appCore.modelManager.modelChoices()
+        if let choice = choices.first(where: { $0.id == targetID }),
+           choice.blockedReason == .insufficientDisk
+        {
+            return .insufficientDisk
+        }
+
+        // Idle: show approximate download size
+        let sizeCaption: String = if let model = LLMModelCatalog.model(id: targetID) {
+            Self.formatBytes(model.approxDownloadBytes)
+        } else {
+            ""
+        }
+        return .idle(sizeCaption: sizeCaption)
+    }
+
+    /// Formats a byte count to a human-readable "~N.N GB" string.
+    internal static func formatBytes(_ bytes: Int64) -> String {
+        let gigabytes = Double(bytes) / 1_000_000_000
+        if gigabytes == gigabytes.rounded() {
+            return "~\(Int(gigabytes)) GB"
+        }
+        return String(format: "~%.1f GB", gigabytes)
+    }
+}

--- a/Packages/BiscottiKit/Sources/OnboardingUI/ModelRowState.swift
+++ b/Packages/BiscottiKit/Sources/OnboardingUI/ModelRowState.swift
@@ -150,6 +150,18 @@ public extension OnboardingViewModel {
         transcriptionStarted && languageStarted
     }
 
+    // MARK: - Footer caption
+
+    /// Caption shown beneath the footer button. Non-empty only on the
+    /// model-download step when "Continue" is available (both models
+    /// started) but at least one download is still in progress.
+    var footerCaption: String {
+        guard currentStep == .modelDownload, bothModelsStarted, !bothModelsReady else {
+            return ""
+        }
+        return "Downloads will continue in the background"
+    }
+
     // MARK: - Row-state mappers
 
     /// Computes the view-state for the transcription model row.

--- a/Packages/BiscottiKit/Sources/OnboardingUI/OnboardingScaffold.swift
+++ b/Packages/BiscottiKit/Sources/OnboardingUI/OnboardingScaffold.swift
@@ -5,6 +5,7 @@ import SwiftUI
 /// ProgressHeader (top), centered content, BrandFooter (bottom).
 struct OnboardingScaffold<Content: View>: View {
     let step: OnboardingViewModel.Step
+    var contentMaxWidth: CGFloat = 520
     @ViewBuilder let content: Content
 
     var body: some View {
@@ -15,7 +16,7 @@ struct OnboardingScaffold<Content: View>: View {
             Spacer(minLength: 24)
 
             content
-                .frame(maxWidth: 520)
+                .frame(maxWidth: contentMaxWidth)
                 .multilineTextAlignment(.center)
 
             Spacer(minLength: 24)

--- a/Packages/BiscottiKit/Sources/OnboardingUI/OnboardingStepViews.swift
+++ b/Packages/BiscottiKit/Sources/OnboardingUI/OnboardingStepViews.swift
@@ -312,24 +312,34 @@ extension OnboardingView {
     // MARK: - Shared footer button
 
     var footerButton: some View {
-        // Fixed min-height so toggling Skip <-> Continue doesn't
-        // shift the layout vertically (the primary button is taller
-        // than the plain Skip link).
-        Group {
-            if viewModel.isCurrentStepComplete {
-                Button("Continue") {
-                    Task { await viewModel.advance() }
+        VStack(spacing: 6) {
+            // Fixed min-height so toggling Skip <-> Continue doesn't
+            // shift the layout vertically (the primary button is taller
+            // than the plain Skip link).
+            Group {
+                if viewModel.isCurrentStepComplete {
+                    Button("Continue") {
+                        Task { await viewModel.advance() }
+                    }
+                    .buttonStyle(OnboardingPrimaryButtonStyle())
+                } else {
+                    Button("Skip") {
+                        Task { await viewModel.skip() }
+                    }
+                    .buttonStyle(.plain)
+                    .font(.system(size: 13.5))
+                    .foregroundStyle(.inkTertiary)
                 }
-                .buttonStyle(OnboardingPrimaryButtonStyle())
-            } else {
-                Button("Skip") {
-                    Task { await viewModel.skip() }
-                }
-                .buttonStyle(.plain)
-                .font(.system(size: 13.5))
-                .foregroundStyle(.inkTertiary)
             }
+            .frame(minHeight: 40)
+
+            // Always present (blank => reserves one line, no layout shift).
+            Text(viewModel.footerCaption.isEmpty ? " " : viewModel.footerCaption)
+                .font(.biscottiMono(11))
+                .foregroundStyle(.inkSecondary)
+                .multilineTextAlignment(.center)
+                .lineLimit(1)
+                .padding(.top, 2)
         }
-        .frame(minHeight: 40)
     }
 }

--- a/Packages/BiscottiKit/Sources/OnboardingUI/OnboardingStepViews.swift
+++ b/Packages/BiscottiKit/Sources/OnboardingUI/OnboardingStepViews.swift
@@ -1,5 +1,6 @@
 import Calendar
 import DesignSystem
+import ModelManagementUI
 import Permissions
 import SwiftUI
 
@@ -266,71 +267,24 @@ extension OnboardingView {
                 .font(.biscottiSerif(34))
                 .foregroundStyle(.ink)
 
-            (
-                Text("A one-time download (")
-                    .font(.system(size: 16))
-                    +
-                    Text("~1.5 GB")
-                    .font(.biscottiMono(15))
-                    +
-                    Text(
-                        ").\nEverything runs entirely on your Mac \u{2014} no cloud, ever."
-                    )
-                    .font(.system(size: 16))
+            Text(
+                "One-time download. AI runs locally \u{2014} nothing leaves your Mac."
             )
+            .font(.system(size: 16))
             .foregroundStyle(.inkSecondary)
             .frame(maxWidth: 430)
             .padding(.top, 12)
 
-            downloadContent
-                .padding(.top, 24)
+            ModelCard(viewModel: viewModel)
+                .padding(.top, 20)
 
             footerButton
                 .padding(.top, 24)
         }
-    }
-
-    @ViewBuilder
-    private var downloadContent: some View {
-        if !viewModel.hasSufficientDisk {
-            Banner(
-                "Not enough disk space. Need ~"
-                    + "\(OnboardingViewModel.requiredDiskSpaceMB) MB.",
-                style: .warning
+        .sheet(isPresented: $viewModel.showVariantSheet) {
+            ManageModelsSheet(
+                viewModel: ManageModelsViewModel(core: viewModel.appCore)
             )
-            .frame(maxWidth: 520)
-        } else if viewModel.downloadComplete {
-            GrantedTag("COMPLETE")
-        } else if viewModel.isDownloading {
-            VStack(spacing: 8) {
-                // Static indeterminate bar -- the download stream
-                // provides status text but no numeric fraction.
-                ZStack(alignment: .leading) {
-                    Capsule()
-                        .fill(Color.hairline)
-                        .frame(width: 240, height: 3)
-                    Capsule()
-                        .fill(Color.sage)
-                        .frame(width: 120, height: 3)
-                }
-
-                if let status = viewModel.downloadStatus {
-                    Text(status)
-                        .font(.biscottiMono(11))
-                        .foregroundStyle(.inkSecondary)
-                }
-            }
-        } else {
-            Button {
-                Task { await viewModel.startTranscriptionDownload() }
-            } label: {
-                HStack(spacing: 6) {
-                    Image(systemName: "arrow.down.circle")
-                        .font(.system(size: 15, weight: .medium))
-                    Text("Download Now")
-                }
-            }
-            .buttonStyle(OnboardingPrimaryButtonStyle())
         }
     }
 

--- a/Packages/BiscottiKit/Sources/OnboardingUI/OnboardingStepViews.swift
+++ b/Packages/BiscottiKit/Sources/OnboardingUI/OnboardingStepViews.swift
@@ -322,7 +322,7 @@ extension OnboardingView {
             }
         } else {
             Button {
-                Task { await viewModel.startDownload() }
+                Task { await viewModel.startTranscriptionDownload() }
             } label: {
                 HStack(spacing: 6) {
                     Image(systemName: "arrow.down.circle")

--- a/Packages/BiscottiKit/Sources/OnboardingUI/OnboardingView.swift
+++ b/Packages/BiscottiKit/Sources/OnboardingUI/OnboardingView.swift
@@ -15,7 +15,10 @@ public struct OnboardingView: View {
     }
 
     public var body: some View {
-        OnboardingScaffold(step: viewModel.currentStep) {
+        OnboardingScaffold(
+            step: viewModel.currentStep,
+            contentMaxWidth: viewModel.currentStep == .modelDownload ? 560 : 520
+        ) {
             stepContent
         }
     }

--- a/Packages/BiscottiKit/Sources/OnboardingUI/OnboardingViewModel+Calendar.swift
+++ b/Packages/BiscottiKit/Sources/OnboardingUI/OnboardingViewModel+Calendar.swift
@@ -1,0 +1,63 @@
+import Calendar
+
+// MARK: - Calendar selection helpers
+
+public extension OnboardingViewModel {
+    /// Whether a calendar is enabled (checked).
+    func isCalendarEnabled(_ calendarID: String) -> Bool {
+        guard let enabled = enabledCalendarIDs else { return true }
+        return enabled.contains(calendarID)
+    }
+
+    /// Toggle a calendar on/off. Persists to settings.
+    func toggleCalendar(_ calendarID: String) async {
+        let allIDs = calendarGroups
+            .flatMap(\.calendars)
+            .map(\.id)
+
+        var newSet: Set<String>
+        if let current = enabledCalendarIDs {
+            newSet = current
+            if newSet.contains(calendarID) {
+                newSet.remove(calendarID)
+            } else {
+                newSet.insert(calendarID)
+            }
+        } else {
+            newSet = Set(allIDs)
+            newSet.remove(calendarID)
+        }
+
+        if newSet.count == allIDs.count {
+            enabledCalendarIDs = nil
+        } else {
+            enabledCalendarIDs = newSet
+        }
+
+        do {
+            let updated = enabledCalendarIDs
+            try await appCore.store.updateSettings { settings in
+                settings.enabledCalendarIDs = updated
+            }
+        } catch {
+            // Revert on failure
+            enabledCalendarIDs = nil
+        }
+    }
+
+    /// Groups CalendarInfo items by sourceTitle (same logic as SettingsVM).
+    static func groupCalendars(
+        _ infos: [CalendarInfo]
+    ) -> [OnboardingCalendarGroup] {
+        let grouped = Dictionary(grouping: infos, by: \.sourceTitle)
+        return grouped
+            .sorted { $0.key < $1.key }
+            .map { source, calendars in
+                OnboardingCalendarGroup(
+                    id: source,
+                    sourceTitle: source,
+                    calendars: calendars.sorted { $0.title < $1.title }
+                )
+            }
+    }
+}

--- a/Packages/BiscottiKit/Sources/OnboardingUI/OnboardingViewModel.swift
+++ b/Packages/BiscottiKit/Sources/OnboardingUI/OnboardingViewModel.swift
@@ -91,6 +91,10 @@ public final class OnboardingViewModel {
     /// was entered (set by `prepareModelStep()`).
     public private(set) var transcriptionDownloaded: Bool = false
 
+    /// True while `prepareModelStep()` is probing readiness/disk in the
+    /// background. Model rows show a spinner while set.
+    public internal(set) var isPreparingModelStep: Bool = false
+
     /// Presentation state for the "See all options" Manage Models sheet.
     public var showVariantSheet: Bool = false
 
@@ -308,6 +312,7 @@ public final class OnboardingViewModel {
         downloadComplete = false
         downloadFailed = false
         transcriptionDownloaded = false
+        isPreparingModelStep = false
         showVariantSheet = false
         hasSufficientDisk = true
     }
@@ -327,12 +332,12 @@ public final class OnboardingViewModel {
                 calendarGroups = Self.groupCalendars(infos)
                 currentStep = .calendarSelection
             } else {
-                await prepareModelStep()
                 currentStep = .modelDownload
+                await prepareModelStep()
             }
         case .calendarSelection:
-            await prepareModelStep()
             currentStep = .modelDownload
+            await prepareModelStep()
         case .modelDownload:
             currentStep = .done
         case .done:
@@ -343,7 +348,13 @@ public final class OnboardingViewModel {
 
     /// Prepares state for the model download step: probes transcription
     /// readiness, refreshes the ModelManager, and checks disk space.
+    /// Sets `isPreparingModelStep` while running so the UI can show
+    /// spinners. The `Task.yield()` lets SwiftUI paint the model screen
+    /// (with spinner rows) before the slow probes execute.
     private func prepareModelStep() async {
+        isPreparingModelStep = true
+        defer { isPreparingModelStep = false }
+        await Task.yield()
         await core.modelManager.refresh()
         transcriptionDownloaded = await core.transcription.modelsReady()
         checkDiskSpace()

--- a/Packages/BiscottiKit/Sources/OnboardingUI/OnboardingViewModel.swift
+++ b/Packages/BiscottiKit/Sources/OnboardingUI/OnboardingViewModel.swift
@@ -83,7 +83,7 @@ public final class OnboardingViewModel {
 
     /// Model download state (transcription).
     public private(set) var downloadStatus: String?
-    public private(set) var isDownloading: Bool = false
+    public internal(set) var isDownloading: Bool = false
     public private(set) var downloadComplete: Bool = false
     public private(set) var downloadFailed: Bool = false
 
@@ -148,7 +148,7 @@ public final class OnboardingViewModel {
         case .permissions:
             allPermissionsGranted ? .continueButton : .skip
         case .modelDownload:
-            bothModelsReady ? .continueButton : .skip
+            bothModelsStarted ? .continueButton : .skip
         }
     }
 

--- a/Packages/BiscottiKit/Sources/OnboardingUI/OnboardingViewModel.swift
+++ b/Packages/BiscottiKit/Sources/OnboardingUI/OnboardingViewModel.swift
@@ -3,6 +3,8 @@ import AppKit
 import Calendar
 import DataStore
 import Foundation
+import Intelligence
+import LocalLLM
 import Permissions
 import TranscriptionService
 
@@ -74,13 +76,23 @@ public final class OnboardingViewModel {
     public var showFixPermissionsAlert: Bool = false
 
     /// Calendar selection (reuses the grouped pattern).
-    public private(set) var calendarGroups: [OnboardingCalendarGroup] = []
-    public private(set) var enabledCalendarIDs: Set<String>?
+    /// Setters are internal so calendar-related extensions within the
+    /// module can mutate them.
+    public internal(set) var calendarGroups: [OnboardingCalendarGroup] = []
+    public internal(set) var enabledCalendarIDs: Set<String>?
 
-    /// Model download state.
+    /// Model download state (transcription).
     public private(set) var downloadStatus: String?
     public private(set) var isDownloading: Bool = false
     public private(set) var downloadComplete: Bool = false
+    public private(set) var downloadFailed: Bool = false
+
+    /// True when transcription models were already on disk when the step
+    /// was entered (set by `prepareModelStep()`).
+    public private(set) var transcriptionDownloaded: Bool = false
+
+    /// Presentation state for the "See all options" Manage Models sheet.
+    public var showVariantSheet: Bool = false
 
     // MARK: - Granted-state derivation
 
@@ -104,6 +116,14 @@ public final class OnboardingViewModel {
         microphoneGranted && systemAudioGranted && calendarGranted && notificationsGranted
     }
 
+    // MARK: - AppCore exposure (for sheet construction)
+
+    /// Read-only access to the application core, used by the view to
+    /// construct `ManageModelsViewModel(core:)` for the variant sheet.
+    public var appCore: AppCore {
+        core
+    }
+
     /// The footer button to display for a given step.
     public enum FooterButton: Equatable, Sendable {
         /// Show the primary "Continue" button (step action is done).
@@ -124,7 +144,7 @@ public final class OnboardingViewModel {
         case .permissions:
             allPermissionsGranted ? .continueButton : .skip
         case .modelDownload:
-            downloadComplete ? .continueButton : .skip
+            bothModelsReady ? .continueButton : .skip
         }
     }
 
@@ -136,8 +156,9 @@ public final class OnboardingViewModel {
     /// Disk space check for the model download step.
     public private(set) var hasSufficientDisk: Bool = true
 
-    /// Approximate disk space required for models (MB).
-    public static let requiredDiskSpaceMB: Int = 2000
+    /// Approximate disk space required for the transcription model (MB).
+    /// Aligned with the ~1.5 GB WhisperKit model bundle.
+    public static let requiredDiskSpaceMB: Int = 1500
 
     /// Seam for reading available disk bytes. Defaults to the real
     /// filesystem check. Override in tests for determinism.
@@ -223,51 +244,10 @@ public final class OnboardingViewModel {
         notificationsGranted = granted
     }
 
-    /// Whether a calendar is enabled (checked).
-    public func isCalendarEnabled(_ calendarID: String) -> Bool {
-        guard let enabled = enabledCalendarIDs else { return true }
-        return enabled.contains(calendarID)
-    }
-
-    /// Toggle a calendar on/off. Persists to settings.
-    public func toggleCalendar(_ calendarID: String) async {
-        let allIDs = calendarGroups
-            .flatMap(\.calendars)
-            .map(\.id)
-
-        var newSet: Set<String>
-        if let current = enabledCalendarIDs {
-            newSet = current
-            if newSet.contains(calendarID) {
-                newSet.remove(calendarID)
-            } else {
-                newSet.insert(calendarID)
-            }
-        } else {
-            newSet = Set(allIDs)
-            newSet.remove(calendarID)
-        }
-
-        if newSet.count == allIDs.count {
-            enabledCalendarIDs = nil
-        } else {
-            enabledCalendarIDs = newSet
-        }
-
-        do {
-            let updated = enabledCalendarIDs
-            try await core.store.updateSettings { settings in
-                settings.enabledCalendarIDs = updated
-            }
-        } catch {
-            // Revert on failure
-            enabledCalendarIDs = nil
-        }
-    }
-
-    /// Start the model download (on the model download step).
-    public func startDownload() async {
+    /// Start the transcription model download.
+    public func startTranscriptionDownload() async {
         isDownloading = true
+        downloadFailed = false
         downloadStatus = "Preparing\u{2026}"
         do {
             try await core.transcription
@@ -278,10 +258,19 @@ public final class OnboardingViewModel {
                 }
             downloadComplete = true
         } catch {
+            downloadFailed = true
             downloadStatus =
                 "Download failed. You can retry or skip."
         }
         isDownloading = false
+    }
+
+    /// Start the language model download for the current target model.
+    public func startLanguageDownload() {
+        guard let targetID = languageTargetModelID else { return }
+        Task {
+            await core.modelManager.downloadModel(id: targetID)
+        }
     }
 
     /// Open System Settings for a denied permission.
@@ -317,6 +306,9 @@ public final class OnboardingViewModel {
         downloadStatus = nil
         isDownloading = false
         downloadComplete = false
+        downloadFailed = false
+        transcriptionDownloaded = false
+        showVariantSheet = false
         hasSufficientDisk = true
     }
 
@@ -335,11 +327,11 @@ public final class OnboardingViewModel {
                 calendarGroups = Self.groupCalendars(infos)
                 currentStep = .calendarSelection
             } else {
-                checkDiskSpace()
+                await prepareModelStep()
                 currentStep = .modelDownload
             }
         case .calendarSelection:
-            checkDiskSpace()
+            await prepareModelStep()
             currentStep = .modelDownload
         case .modelDownload:
             currentStep = .done
@@ -347,6 +339,14 @@ public final class OnboardingViewModel {
             await completeOnboarding()
         }
         syncLivePermissionState()
+    }
+
+    /// Prepares state for the model download step: probes transcription
+    /// readiness, refreshes the ModelManager, and checks disk space.
+    private func prepareModelStep() async {
+        await core.modelManager.refresh()
+        transcriptionDownloaded = await core.transcription.modelsReady()
+        checkDiskSpace()
     }
 
     /// Reads the live system permission state for the current step
@@ -378,21 +378,5 @@ public final class OnboardingViewModel {
             * 1_048_576
         let available = availableDiskBytes()
         hasSufficientDisk = available >= requiredBytes
-    }
-
-    /// Groups CalendarInfo items by sourceTitle (same logic as SettingsVM).
-    public static func groupCalendars(
-        _ infos: [CalendarInfo]
-    ) -> [OnboardingCalendarGroup] {
-        let grouped = Dictionary(grouping: infos, by: \.sourceTitle)
-        return grouped
-            .sorted { $0.key < $1.key }
-            .map { source, calendars in
-                OnboardingCalendarGroup(
-                    id: source,
-                    sourceTitle: source,
-                    calendars: calendars.sorted { $0.title < $1.title }
-                )
-            }
     }
 }

--- a/Packages/BiscottiKit/Sources/OnboardingUI/OnboardingViewModel.swift
+++ b/Packages/BiscottiKit/Sources/OnboardingUI/OnboardingViewModel.swift
@@ -164,6 +164,11 @@ public final class OnboardingViewModel {
     /// Aligned with the ~1.5 GB WhisperKit model bundle.
     public static let requiredDiskSpaceMB: Int = 1500
 
+    /// Pre-warm task that runs model probes early (on the permissions
+    /// screen) so the model-download screen arrives spinner-free when
+    /// probes finish in time. Nil until `beginModelPrep()` is called.
+    private var modelPrepTask: Task<Void, Never>?
+
     /// Seam for reading available disk bytes. Defaults to the real
     /// filesystem check. Override in tests for determinism.
     private let availableDiskBytes: @MainActor () -> Int64
@@ -298,6 +303,8 @@ public final class OnboardingViewModel {
     /// from the beginning (e.g. via the debug "Replay Onboarding"
     /// button in Settings).
     public func resetForReplay() {
+        modelPrepTask?.cancel()
+        modelPrepTask = nil
         currentStep = .welcome
         microphoneResult = .notDetermined
         systemAudioResult = .notRequested
@@ -326,6 +333,7 @@ public final class OnboardingViewModel {
         switch currentStep {
         case .welcome:
             currentStep = .permissions
+            beginModelPrep()
         case .permissions:
             if calendarResult == .authorized {
                 let infos = await core.calendar.calendars()
@@ -333,11 +341,13 @@ public final class OnboardingViewModel {
                 currentStep = .calendarSelection
             } else {
                 currentStep = .modelDownload
-                await prepareModelStep()
+                beginModelPrep()
+                await modelPrepTask?.value
             }
         case .calendarSelection:
             currentStep = .modelDownload
-            await prepareModelStep()
+            beginModelPrep()
+            await modelPrepTask?.value
         case .modelDownload:
             currentStep = .done
         case .done:
@@ -346,17 +356,30 @@ public final class OnboardingViewModel {
         syncLivePermissionState()
     }
 
-    /// Prepares state for the model download step: probes transcription
-    /// readiness, refreshes the ModelManager, and checks disk space.
-    /// Sets `isPreparingModelStep` while running so the UI can show
-    /// spinners. The `Task.yield()` lets SwiftUI paint the model screen
-    /// (with spinner rows) before the slow probes execute.
-    private func prepareModelStep() async {
+    /// Idempotently starts background model probes. The pre-warm begins
+    /// on the permissions screen (`.welcome -> .permissions` transition)
+    /// so that by the time the user reaches the model-download screen the
+    /// probes are usually finished and rows show final state immediately.
+    ///
+    /// If the model-download screen is reached before the task completes,
+    /// the transition `await`s `modelPrepTask?.value` so the screen
+    /// paints with spinners (the `currentStep` is already set before
+    /// the await) and the caller does not return until probes finish.
+    private func beginModelPrep() {
+        guard modelPrepTask == nil else { return }
         isPreparingModelStep = true
-        defer { isPreparingModelStep = false }
-        await Task.yield()
+        modelPrepTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            defer { isPreparingModelStep = false }
+            await runModelProbes()
+        }
+    }
+
+    /// Runs the actual model probes: ModelManager refresh, read-only
+    /// transcription presence check, and disk space check.
+    private func runModelProbes() async {
         await core.modelManager.refresh()
-        transcriptionDownloaded = await core.transcription.modelsReady()
+        transcriptionDownloaded = await core.transcription.modelsArePresent()
         checkDiskSpace()
     }
 

--- a/Packages/BiscottiKit/Sources/OnboardingUI/PermissionRow.swift
+++ b/Packages/BiscottiKit/Sources/OnboardingUI/PermissionRow.swift
@@ -92,12 +92,24 @@ extension PermissionRow where Denial == EmptyView {
 // MARK: - Grant pill button
 
 /// A small sage pill button used for the "Grant" action in permission rows.
+/// Generalized to accept a custom title and optional leading SF Symbol;
+/// defaults preserve the existing call-site signature.
 struct GrantPill: View {
+    var title: String = "Grant"
+    var systemImage: String?
     let action: () -> Void
 
     var body: some View {
-        Button("Grant", action: action)
-            .buttonStyle(JoinRecordButtonStyle())
+        Button(action: action) {
+            HStack(spacing: 4) {
+                if let systemImage {
+                    Image(systemName: systemImage)
+                        .font(.system(size: 13, weight: .medium))
+                }
+                Text(title)
+            }
+        }
+        .buttonStyle(JoinRecordButtonStyle())
     }
 }
 

--- a/Packages/BiscottiKit/Sources/SettingsUI/ManageModelsSheet.swift
+++ b/Packages/BiscottiKit/Sources/SettingsUI/ManageModelsSheet.swift
@@ -1,0 +1,365 @@
+import AppCore
+import DesignSystem
+import Intelligence
+import LocalLLM
+import SwiftUI
+
+// MARK: - ManageModelsViewModel
+
+/// Thin view model for the Manage Models sheet.
+///
+/// Delegates all state reads to `ModelManager` (via `AppCore`) and all
+/// mutations to `ModelManager` actions. Owns only the delete-confirmation
+/// target (ephemeral UI state).
+@MainActor @Observable
+public final class ManageModelsViewModel {
+    private let core: AppCore
+
+    /// The model targeted for deletion, driving the confirmation dialog.
+    /// Set by the Delete button; cleared by cancel or confirm.
+    public var deleteTarget: ModelChoice?
+
+    public init(core: AppCore) {
+        self.core = core
+    }
+
+    // MARK: - Reads (delegated to ModelManager)
+
+    /// The per-model choice matrix for the sheet rows.
+    public var modelChoices: [ModelChoice] {
+        core.modelManager.modelChoices()
+    }
+
+    /// Whether any model download is currently in flight.
+    public var isDownloading: Bool {
+        core.modelManager.downloads.values.contains {
+            if case .downloading = $0 { return true }
+            return false
+        }
+    }
+
+    // MARK: - Actions
+
+    /// Start downloading the model with the given id.
+    public func download(id: String) {
+        Task { await core.modelManager.downloadModel(id: id) }
+    }
+
+    /// Stage a model for deletion (shows the confirmation dialog).
+    public func requestDelete(choice: ModelChoice) {
+        deleteTarget = choice
+    }
+
+    /// Confirm and execute the staged deletion.
+    public func confirmDelete() {
+        guard let target = deleteTarget else { return }
+        let id = target.model.id
+        deleteTarget = nil
+        Task { await core.modelManager.deleteModel(id: id) }
+    }
+
+    /// Select a model as the active default.
+    public func choose(id: String) {
+        Task { await core.modelManager.selectModel(id: id) }
+    }
+}
+
+// MARK: - ManageModelsSheet
+
+/// Sheet listing every catalog model with per-state actions (download,
+/// delete, choose) and the Recommended badge. Presented from the
+/// "AI Language Model" settings row.
+struct ManageModelsSheet: View {
+    @Bindable var viewModel: ManageModelsViewModel
+
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Tokens.spacingMD) {
+            // Header
+            Text("AI Language Model")
+                .font(.headline)
+
+            Text(
+                "Choose the model used to summarize your meetings. It runs entirely on your Mac."
+            )
+            .font(Tokens.metadataFont)
+            .foregroundStyle(Tokens.secondaryText)
+
+            // Model rows
+            VStack(spacing: Tokens.spacingSM) {
+                ForEach(viewModel.modelChoices) { choice in
+                    ModelRowView(
+                        choice: choice,
+                        isDownloading: viewModel.isDownloading,
+                        onDownload: { viewModel.download(id: choice.model.id) },
+                        onDelete: { viewModel.requestDelete(choice: choice) },
+                        onChoose: { viewModel.choose(id: choice.model.id) }
+                    )
+                }
+            }
+
+            // Footer
+            HStack {
+                Spacer()
+                Button("Done") {
+                    dismiss()
+                }
+                .keyboardShortcut(.cancelAction)
+            }
+        }
+        .padding(Tokens.spacingMD * 1.5)
+        .frame(width: 480)
+        .confirmationDialog(
+            deleteDialogTitle,
+            isPresented: showDeleteConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button("Delete", role: .destructive) {
+                viewModel.confirmDelete()
+            }
+        } message: {
+            Text(deleteDialogMessage)
+        }
+    }
+
+    // MARK: - Delete confirmation helpers
+
+    private var showDeleteConfirmation: Binding<Bool> {
+        Binding(
+            get: { viewModel.deleteTarget != nil },
+            set: { show in
+                if !show { viewModel.deleteTarget = nil }
+            }
+        )
+    }
+
+    private var deleteDialogTitle: String {
+        guard let target = viewModel.deleteTarget else { return "" }
+        return "Delete \(target.model.displayName)?"
+    }
+
+    private var deleteDialogMessage: String {
+        guard let target = viewModel.deleteTarget else { return "" }
+        // Integer division is fine here — catalog models are whole-GB sizes.
+        let sizeGB = target.model.approxDownloadBytes / 1_000_000_000
+        return "This frees about \(sizeGB) GB. You can download it again anytime."
+    }
+}
+
+// MARK: - ModelRowView
+
+/// A single model row in the Manage Models sheet.
+///
+/// Renders the per-state matrix from `ModelChoice` (ui_design §2.2):
+/// blocked (not runnable), insufficient disk, downloadable, downloading,
+/// failed, downloaded+selected, downloaded+not-selected.
+struct ModelRowView: View {
+    let choice: ModelChoice
+    /// Whether any model (possibly another) is currently downloading.
+    let isDownloading: Bool
+    let onDownload: () -> Void
+    let onDelete: () -> Void
+    let onChoose: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Tokens.spacingXS) {
+            // Line 1: name + recommended badge + selection control
+            HStack {
+                Text(choice.model.displayName)
+                    .fontWeight(.medium)
+
+                if choice.isRecommended {
+                    recommendedBadge
+                }
+
+                Spacer()
+
+                selectionControl
+            }
+
+            // Line 2: description + primary action
+            HStack(alignment: .top) {
+                VStack(alignment: .leading, spacing: 2) {
+                    descriptionOrProgress
+                }
+                Spacer()
+                primaryAction
+            }
+        }
+        .padding(Tokens.spacingSM)
+        .background(Color.neutralChip.opacity(0.5))
+        .clipShape(RoundedRectangle(cornerRadius: Tokens.buttonRadius))
+        .opacity(choice.blockedReason == .cannotRun ? 0.5 : 1.0)
+    }
+
+    // MARK: - Recommended badge
+
+    private var recommendedBadge: some View {
+        HStack(spacing: 4) {
+            Image(systemName: "star.fill")
+                .font(.caption2)
+            Text("Recommended")
+                .font(.caption)
+        }
+        .foregroundStyle(.sage)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 3)
+        .background(
+            Capsule().fill(Color.sage.opacity(0.15))
+        )
+    }
+
+    // MARK: - Selection control (trailing, line 1)
+
+    @ViewBuilder
+    private var selectionControl: some View {
+        if choice.blockedReason == .cannotRun {
+            EmptyView()
+        } else if choice.isDownloaded, choice.isSelected {
+            // Default indicator
+            HStack(spacing: 4) {
+                Image(systemName: "checkmark.circle.fill")
+                    .foregroundStyle(.sage)
+                Text("Default")
+                    .font(Tokens.metadataFont)
+                    .foregroundStyle(Tokens.secondaryText)
+            }
+        } else if choice.isDownloaded, choice.runnable {
+            Button("Choose Model") {
+                onChoose()
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+        }
+    }
+
+    // MARK: - Description / progress / warning (left column, lines 2-3)
+
+    @ViewBuilder
+    private var descriptionOrProgress: some View {
+        // Guard cannotRun first — non-runnable models show only the
+        // description + warning, never download/failure progress.
+        if choice.blockedReason == .cannotRun {
+            Text(choice.description)
+                .font(Tokens.metadataFont)
+                .foregroundStyle(Tokens.secondaryText)
+            warningLabel(for: .cannotRun)
+        } else {
+            switch choice.downloadState {
+            case let .downloading(fraction):
+                Text(choice.description)
+                    .font(Tokens.metadataFont)
+                    .foregroundStyle(Tokens.secondaryText)
+                if let fraction {
+                    ProgressView(value: fraction)
+                    Text("Downloading\u{2026} \(Int(fraction * 100))%")
+                        .font(Tokens.metadataFont)
+                        .foregroundStyle(Tokens.secondaryText)
+                } else {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text("Downloading\u{2026}")
+                        .font(Tokens.metadataFont)
+                        .foregroundStyle(Tokens.secondaryText)
+                }
+
+            case let .failed(message):
+                Text(choice.description)
+                    .font(Tokens.metadataFont)
+                    .foregroundStyle(Tokens.secondaryText)
+                Text("Download failed: \(message)")
+                    .font(Tokens.metadataFont)
+                    .foregroundStyle(.signalRed)
+
+            default:
+                Text(choice.description)
+                    .font(Tokens.metadataFont)
+                    .foregroundStyle(Tokens.secondaryText)
+
+                // Warnings (e.g. insufficientDisk)
+                if let reason = choice.blockedReason {
+                    warningLabel(for: reason)
+                }
+            }
+        }
+    }
+
+    private func warningLabel(for reason: ModelBlockedReason) -> some View {
+        HStack(spacing: 4) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.caption2)
+            Text(reason.warningText)
+                .font(.caption)
+        }
+        .foregroundStyle(Tokens.warningChipText)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 3)
+        .background(
+            Capsule().fill(Tokens.warningChipFill)
+        )
+    }
+
+    // MARK: - Primary action (trailing, line 2)
+
+    @ViewBuilder
+    private var primaryAction: some View {
+        // Check cannotRun first — a non-runnable model should never show
+        // Retry/Download/Choose regardless of download state.
+        if choice.blockedReason == .cannotRun {
+            EmptyView()
+        } else {
+            switch choice.downloadState {
+            case .downloading:
+                // No action button while downloading
+                EmptyView()
+
+            case .failed:
+                Button("Retry") {
+                    onDownload()
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+
+            default:
+                if choice.isDownloaded {
+                    Button("Delete") {
+                        onDelete()
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                } else {
+                    // Not downloaded — Download button
+                    Button("Download") {
+                        onDownload()
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                    .disabled(
+                        choice.blockedReason == .insufficientDisk
+                            || (isDownloading && !isThisModelDownloading)
+                    )
+                }
+            }
+        }
+    }
+
+    private var isThisModelDownloading: Bool {
+        if case .downloading = choice.downloadState { return true }
+        return false
+    }
+}
+
+// MARK: - ModelBlockedReason + warning text
+
+extension ModelBlockedReason {
+    /// The user-facing warning string for this blocked reason.
+    var warningText: String {
+        switch self {
+        case .cannotRun:
+            "This Mac can\u{2019}t run this model"
+        case .insufficientDisk:
+            "Insufficient free space on disk"
+        }
+    }
+}

--- a/Packages/BiscottiKit/Sources/SettingsUI/SettingsView.swift
+++ b/Packages/BiscottiKit/Sources/SettingsUI/SettingsView.swift
@@ -14,6 +14,7 @@ public struct SettingsView: View {
     /// SettingsSystemAudioRow.swift can bind to it.
     @Bindable var viewModel: SettingsViewModel
     @State private var showAlertsHelp = false
+    @State private var showManageModels = false
 
     public init(viewModel: SettingsViewModel) {
         self.viewModel = viewModel
@@ -303,10 +304,7 @@ private extension SettingsView {
                 .foregroundStyle(Tokens.secondaryText)
             }
 
-            // Conditional download row when no model is present
-            if !viewModel.modelAvailable {
-                modelDownloadRow
-            }
+            aiLanguageModelRow
         } header: {
             HStack {
                 Text(Self.sectionTitles[3])
@@ -314,6 +312,41 @@ private extension SettingsView {
                 Text(Self.aiEnhancementsHeaderCaption)
                     .font(Tokens.metadataFont)
                     .foregroundStyle(Tokens.secondaryText)
+            }
+        }
+        .sheet(isPresented: $showManageModels) {
+            ManageModelsSheet(
+                viewModel: ManageModelsViewModel(core: viewModel.appCore)
+            )
+        }
+    }
+
+    var aiLanguageModelRow: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: Tokens.spacingXS) {
+                Text("AI Language Model")
+                Text("The AI model used to summarize meetings")
+                    .font(Tokens.metadataFont)
+                    .foregroundStyle(Tokens.secondaryText)
+            }
+
+            Spacer()
+
+            if let displayName = viewModel.activeModelDisplayName {
+                Text(displayName)
+                    .font(Tokens.metadataFont)
+                    .foregroundStyle(Tokens.secondaryText)
+                Button("Manage") {
+                    showManageModels = true
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+            } else {
+                Button("Download\u{2026}") {
+                    showManageModels = true
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
             }
         }
     }
@@ -329,54 +362,6 @@ private extension SettingsView {
                 Task { await viewModel.setAIAnalysisEnabled(newValue) }
             }
         )
-    }
-
-    @ViewBuilder
-    var modelDownloadRow: some View {
-        // Only rendered inside `if !viewModel.modelAvailable`, so
-        // `.downloaded` is unreachable; grouped with the idle states
-        // for exhaustiveness.
-        switch viewModel.modelDownload {
-        case .notDownloaded, .unknown, .downloaded:
-            VStack(alignment: .leading, spacing: Tokens.spacingXS) {
-                Text("Download Local Language AI Model?")
-                Text("Several GB \u{00B7} runs entirely on your Mac.")
-                    .font(Tokens.metadataFont)
-                    .foregroundStyle(Tokens.secondaryText)
-                Button("Download") {
-                    viewModel.startModelDownload()
-                }
-                .buttonStyle(.bordered)
-                .controlSize(.small)
-            }
-
-        case let .downloading(fraction):
-            VStack(alignment: .leading, spacing: Tokens.spacingXS) {
-                if let fraction {
-                    ProgressView(value: fraction)
-                    Text("Downloading\u{2026} \(Int(fraction * 100))%")
-                        .font(Tokens.metadataFont)
-                        .foregroundStyle(Tokens.secondaryText)
-                } else {
-                    ProgressView()
-                    Text("Downloading\u{2026}")
-                        .font(Tokens.metadataFont)
-                        .foregroundStyle(Tokens.secondaryText)
-                }
-            }
-
-        case let .failed(message):
-            VStack(alignment: .leading, spacing: Tokens.spacingXS) {
-                Text("Download failed: \(message)")
-                    .font(Tokens.metadataFont)
-                    .foregroundStyle(.red)
-                Button("Retry") {
-                    viewModel.startModelDownload()
-                }
-                .buttonStyle(.bordered)
-                .controlSize(.small)
-            }
-        }
     }
 }
 

--- a/Packages/BiscottiKit/Sources/SettingsUI/SettingsView.swift
+++ b/Packages/BiscottiKit/Sources/SettingsUI/SettingsView.swift
@@ -4,6 +4,7 @@ import Calendar
 import DataStore
 import DesignSystem
 import Intelligence
+import ModelManagementUI
 import Permissions
 import SwiftUI
 

--- a/Packages/BiscottiKit/Sources/SettingsUI/SettingsView.swift
+++ b/Packages/BiscottiKit/Sources/SettingsUI/SettingsView.swift
@@ -282,6 +282,13 @@ public struct SettingsView: View {
                     Label("Replay Onboarding", systemImage: "arrow.counterclockwise")
                 }
                 .foregroundStyle(.sage)
+
+                Button {
+                    viewModel.clearSelectedModel()
+                } label: {
+                    Label("Clear Selected LLM", systemImage: "arrow.uturn.backward")
+                }
+                .foregroundStyle(.sage)
             }
         }
     #endif

--- a/Packages/BiscottiKit/Sources/SettingsUI/SettingsViewModel.swift
+++ b/Packages/BiscottiKit/Sources/SettingsUI/SettingsViewModel.swift
@@ -81,14 +81,25 @@ public final class SettingsViewModel {
     /// Whether AI analysis (summary + speaker inference) is enabled (persisted).
     public private(set) var aiAnalysisEnabled: Bool = true
 
-    /// Current model download lifecycle state (observed from Intelligence).
+    /// Current model download lifecycle state for the active model
+    /// (observed from ModelManager).
     public var modelDownload: ModelDownloadState {
-        core.intelligence.download
+        let mgr = core.modelManager
+        if let activeID = mgr.activeModelID {
+            return mgr.downloads[activeID] ?? .notDownloaded
+        }
+        // No active model: show the first in-flight download, or notDownloaded
+        for (_, state) in mgr.downloads {
+            if case .downloading = state {
+                return state
+            }
+        }
+        return .notDownloaded
     }
 
-    /// Whether the AI model is present on disk.
+    /// Whether any AI model is available (active model exists).
     public var modelAvailable: Bool {
-        core.intelligence.isModelDownloaded
+        core.modelManager.isModelAvailable
     }
 
     // MARK: - Calendar state
@@ -385,7 +396,7 @@ public final class SettingsViewModel {
             enabledCalendarIDs = nil
         }
 
-        core.intelligence.refreshModelState()
+        await core.modelManager.refresh()
 
         // SMAppService is the source of truth for launch-at-login
         launchAtLogin = readLaunchAtLoginStatus()
@@ -508,9 +519,11 @@ public extension SettingsViewModel {
         }
     }
 
-    /// Starts the AI model download. Runs asynchronously; the download
-    /// state is observed through `modelDownload` (from Intelligence).
+    /// Starts an AI model download. Runs asynchronously; the download
+    /// state is observed through `modelDownload` (from ModelManager).
+    /// Downloads the recommended model when no specific id is given.
     func startModelDownload() {
-        Task { await core.intelligence.downloadModel() }
+        guard let id = core.modelManager.recommendedModelID() else { return }
+        Task { await core.modelManager.downloadModel(id: id) }
     }
 }

--- a/Packages/BiscottiKit/Sources/SettingsUI/SettingsViewModel.swift
+++ b/Packages/BiscottiKit/Sources/SettingsUI/SettingsViewModel.swift
@@ -258,6 +258,12 @@ public final class SettingsViewModel {
         public func replayOnboarding() {
             core.showOnboardingReplay()
         }
+
+        /// Debug-only: clears the persisted language-model selection so the
+        /// app reverts to the hardware-recommended default.
+        public func clearSelectedModel() {
+            Task { await core.modelManager.clearSelectedModel() }
+        }
     #endif
 
     // MARK: - Calendar actions

--- a/Packages/BiscottiKit/Sources/SettingsUI/SettingsViewModel.swift
+++ b/Packages/BiscottiKit/Sources/SettingsUI/SettingsViewModel.swift
@@ -4,6 +4,7 @@ import Calendar
 import DataStore
 import Foundation
 import Intelligence
+import LocalLLM
 import Permissions
 import ServiceManagement
 
@@ -30,7 +31,14 @@ public struct CalendarGroup: Identifiable, Sendable, Equatable {
 /// overview with inline request actions, and general preferences.
 @MainActor @Observable
 public final class SettingsViewModel {
-    private let core: AppCore
+    /// Exposed (read-only) so `ManageModelsSheet` can be constructed from the
+    /// same `AppCore` instance. Not used for direct mutations outside this VM.
+    let appCore: AppCore
+
+    /// Legacy alias -- internal code still references `core` throughout.
+    private var core: AppCore {
+        appCore
+    }
 
     /// Seam for reading the system launch-at-login status. Defaults to
     /// `SMAppService.mainApp.status == .enabled`. Injected in tests.
@@ -81,25 +89,15 @@ public final class SettingsViewModel {
     /// Whether AI analysis (summary + speaker inference) is enabled (persisted).
     public private(set) var aiAnalysisEnabled: Bool = true
 
-    /// Current model download lifecycle state for the active model
-    /// (observed from ModelManager).
-    public var modelDownload: ModelDownloadState {
-        let mgr = core.modelManager
-        if let activeID = mgr.activeModelID {
-            return mgr.downloads[activeID] ?? .notDownloaded
-        }
-        // No active model: show the first in-flight download, or notDownloaded
-        for (_, state) in mgr.downloads {
-            if case .downloading = state {
-                return state
-            }
-        }
-        return .notDownloaded
-    }
-
     /// Whether any AI model is available (active model exists).
     public var modelAvailable: Bool {
         core.modelManager.isModelAvailable
+    }
+
+    /// Display name of the currently active model, or `nil` if none.
+    public var activeModelDisplayName: String? {
+        guard let id = core.modelManager.activeModelID else { return nil }
+        return LLMModelCatalog.model(id: id)?.displayName
     }
 
     // MARK: - Calendar state
@@ -146,7 +144,7 @@ public final class SettingsViewModel {
         core: AppCore,
         readLaunchAtLoginStatus: (@MainActor () -> Bool)? = nil
     ) {
-        self.core = core
+        appCore = core
         self.readLaunchAtLoginStatus = readLaunchAtLoginStatus ?? {
             #if canImport(ServiceManagement)
                 ServiceManagement.SMAppService.mainApp.status == .enabled
@@ -517,13 +515,5 @@ public extension SettingsViewModel {
         } catch {
             aiAnalysisEnabled = !enabled
         }
-    }
-
-    /// Starts an AI model download. Runs asynchronously; the download
-    /// state is observed through `modelDownload` (from ModelManager).
-    /// Downloads the recommended model when no specific id is given.
-    func startModelDownload() {
-        guard let id = core.modelManager.recommendedModelID() else { return }
-        Task { await core.modelManager.downloadModel(id: id) }
     }
 }

--- a/Packages/BiscottiKit/Sources/TranscriptionService/Transcribing.swift
+++ b/Packages/BiscottiKit/Sources/TranscriptionService/Transcribing.swift
@@ -20,6 +20,11 @@ public protocol Transcribing: Sendable {
         customVocabulary: [String]
     ) async throws -> TranscriptResult
 
+    /// Returns `true` when models are already present on disk (no download
+    /// needed). This is a read-only probe -- it must not download, load,
+    /// or mutate any engine state.
+    func modelsPresent() async -> Bool
+
     /// Release the transcription worker and its resources. For XPC-backed
     /// implementations this tears down the connection so the heavyweight
     /// worker process can exit. The engine remains usable; subsequent calls

--- a/Packages/BiscottiKit/Sources/TranscriptionService/TranscriptionService.swift
+++ b/Packages/BiscottiKit/Sources/TranscriptionService/TranscriptionService.swift
@@ -76,15 +76,14 @@ public final class TranscriptionService {
         try await engine.ensureModelsDownloaded(status: status)
     }
 
-    /// Returns `true` when models are already downloaded and ready.
-    /// Attempts a dry-run download (no-op if cached) to determine readiness.
-    public func modelsReady() async -> Bool {
-        do {
-            try await engine.ensureModelsDownloaded(status: nil)
-            return true
-        } catch {
-            return false
-        }
+    /// Returns `true` when models are already present on disk and do NOT
+    /// need to be downloaded.
+    ///
+    /// This is a **read-only** probe -- it checks the filesystem only.
+    /// Unlike the removed `modelsReady()` (which called the download path),
+    /// this method never triggers a download or mutates engine state.
+    public func modelsArePresent() async -> Bool {
+        await engine.modelsPresent()
     }
 
     // MARK: - Private

--- a/Packages/BiscottiKit/Tests/AppCoreTests/AppCoreIntelligenceTests.swift
+++ b/Packages/BiscottiKit/Tests/AppCoreTests/AppCoreIntelligenceTests.swift
@@ -130,12 +130,8 @@ struct AppCoreIntelligenceTests {
         // Verify the intelligence service is the same instance
         #expect(fix.core.intelligence === fix.intelligence)
 
-        // Verify model state reflects the fake provider
-        #expect(fix.core.intelligence.isModelDownloaded == false)
-
-        // Flip the fake and verify
-        fix.fakeModelProvider.downloaded = true
-        #expect(fix.core.intelligence.isModelDownloaded == true)
+        // Verify model state reflects via the modelManager
+        #expect(fix.core.modelManager.isModelAvailable == false)
     }
 
     // MARK: - runAutoEnhancements via AppCore

--- a/Packages/BiscottiKit/Tests/BiscottiTestSupport/CoreFixture.swift
+++ b/Packages/BiscottiKit/Tests/BiscottiTestSupport/CoreFixture.swift
@@ -471,6 +471,7 @@ public func makeCoreFixture(
     useImmediateDetectorClock: Bool = false,
     modelDownloaded: Bool = false,
     hardwareRAMBytes: UInt64 = 32_000_000_000,
+    hardwareDiskBytes: Int64? = 100_000_000_000,
     testName: String = "Test"
 ) throws -> CoreFixture {
     let store = try DataStore(storage: .inMemory)
@@ -552,7 +553,8 @@ public func makeCoreFixture(
         downloaded: modelDownloaded
     )
     let fakeHardwareProbe = FakeCoreHardwareProbe(
-        physicalMemoryBytes: hardwareRAMBytes
+        physicalMemoryBytes: hardwareRAMBytes,
+        diskBytes: hardwareDiskBytes
     )
     let modelManager = ModelManager(
         store: store,

--- a/Packages/BiscottiKit/Tests/BiscottiTestSupport/CoreFixture.swift
+++ b/Packages/BiscottiKit/Tests/BiscottiTestSupport/CoreFixture.swift
@@ -33,6 +33,7 @@ public struct CoreFixture {
     public let fakeActivitySource: FakeActivitySource
     public let fakeScheduler: FakeScheduler?
     public let intelligence: Intelligence
+    public let modelManager: ModelManager
     public let fakeLLMRunner: FakeCoreLLMRunner
     public let fakeModelProvider: FakeCoreModelProvider
 
@@ -349,6 +350,7 @@ public final class FakeCoreLLMRunner: LLMRunning, @unchecked Sendable {
     public init() {}
 
     public func withSession<T: Sendable>(
+        model _: URL,
         config _: LocalLLM.EngineConfig,
         _ body: @Sendable (any LLMSession) async throws -> T
     ) async throws -> T {
@@ -383,25 +385,69 @@ public struct FakeCoreLLMSession: LLMSession {
 }
 
 /// A fake model provider for AppCore integration tests.
+/// Supports multi-model protocol with configurable per-model download state.
 public final class FakeCoreModelProvider: ModelProviding,
     @unchecked Sendable
 {
     public var downloaded: Bool
-    public let modelURL: URL
+    public let catalog: [LLMModel]
+    private var downloadedIDs: Set<String>
 
     public init(downloaded: Bool = false) {
         self.downloaded = downloaded
-        modelURL = URL(fileURLWithPath: "/fake/model.gguf")
+        catalog = LLMModelCatalog.all
+        // When downloaded=true, mark the first catalog model as downloaded
+        // (simulates existing 12B-downloaded users)
+        if downloaded {
+            downloadedIDs = [LLMModelCatalog.all.first?.id ?? ""]
+        } else {
+            downloadedIDs = []
+        }
     }
 
-    public func isDownloaded() -> Bool {
-        downloaded
+    public func url(for id: String) -> URL? {
+        LLMModelCatalog.model(id: id).map {
+            URL(fileURLWithPath: "/fake/\($0.fileName)")
+        }
+    }
+
+    public func isDownloaded(_ id: String) -> Bool {
+        downloadedIDs.contains(id)
+    }
+
+    public func downloadedModelIDs() -> [String] {
+        catalog.filter { downloadedIDs.contains($0.id) }.map(\.id)
     }
 
     public func download(
+        _ id: String,
         progress _: @Sendable @escaping (Int64, Int64?) -> Void
     ) async throws {
+        downloadedIDs.insert(id)
         downloaded = true
+    }
+
+    public func delete(_ id: String) throws {
+        downloadedIDs.remove(id)
+        downloaded = !downloadedIDs.isEmpty
+    }
+}
+
+/// A fake hardware probe for CoreFixture tests.
+public struct FakeCoreHardwareProbe: HardwareProbing {
+    public var physicalMemoryBytes: UInt64
+    public var diskBytes: Int64?
+
+    public init(
+        physicalMemoryBytes: UInt64 = 32_000_000_000,
+        diskBytes: Int64? = 100_000_000_000
+    ) {
+        self.physicalMemoryBytes = physicalMemoryBytes
+        self.diskBytes = diskBytes
+    }
+
+    public func availableDiskBytes(at _: URL) -> Int64? {
+        diskBytes
     }
 }
 
@@ -504,10 +550,23 @@ public func makeCoreFixture(
     let fakeModelProvider = FakeCoreModelProvider(
         downloaded: modelDownloaded
     )
+    let fakeHardwareProbe = FakeCoreHardwareProbe()
+    let modelManager = ModelManager(
+        store: store,
+        models: fakeModelProvider,
+        hardware: fakeHardwareProbe
+    )
+    // Pre-populate download states so modelManager reflects the fake provider
+    if modelDownloaded {
+        for id in fakeModelProvider.downloadedModelIDs() {
+            modelManager.downloads[id] = .downloaded
+        }
+    }
+
     let intelligence = Intelligence(
         store: store,
         llm: fakeLLMRunner,
-        models: fakeModelProvider,
+        modelManager: modelManager,
         settings: { AISettings(enabled: true) }
     )
 
@@ -520,6 +579,7 @@ public func makeCoreFixture(
         detector: detector,
         notifications: notificationService,
         intelligence: intelligence,
+        modelManager: modelManager,
         scheduler: scheduler
     )
 
@@ -538,6 +598,7 @@ public func makeCoreFixture(
         fakeActivitySource: fakeActivitySource,
         fakeScheduler: fakeScheduler,
         intelligence: intelligence,
+        modelManager: modelManager,
         fakeLLMRunner: fakeLLMRunner,
         fakeModelProvider: fakeModelProvider
     )

--- a/Packages/BiscottiKit/Tests/BiscottiTestSupport/CoreFixture.swift
+++ b/Packages/BiscottiKit/Tests/BiscottiTestSupport/CoreFixture.swift
@@ -470,6 +470,7 @@ public func makeCoreFixture(
     useFakeScheduler: Bool = false,
     useImmediateDetectorClock: Bool = false,
     modelDownloaded: Bool = false,
+    hardwareRAMBytes: UInt64 = 32_000_000_000,
     testName: String = "Test"
 ) throws -> CoreFixture {
     let store = try DataStore(storage: .inMemory)
@@ -550,7 +551,9 @@ public func makeCoreFixture(
     let fakeModelProvider = FakeCoreModelProvider(
         downloaded: modelDownloaded
     )
-    let fakeHardwareProbe = FakeCoreHardwareProbe()
+    let fakeHardwareProbe = FakeCoreHardwareProbe(
+        physicalMemoryBytes: hardwareRAMBytes
+    )
     let modelManager = ModelManager(
         store: store,
         models: fakeModelProvider,

--- a/Packages/BiscottiKit/Tests/BiscottiTestSupport/FakeTranscriber.swift
+++ b/Packages/BiscottiKit/Tests/BiscottiTestSupport/FakeTranscriber.swift
@@ -12,6 +12,7 @@ public struct FakeTranscriber: Transcribing, @unchecked Sendable {
         public var ensureModelsCalled = false
         public var processAudioCalled = false
         public var shutdownCalled = false
+        public var modelsPresentCalled = false
         public var lastMicURL: URL?
         public var lastSystemURL: URL?
         public var lastVocabulary: [String]?
@@ -21,6 +22,9 @@ public struct FakeTranscriber: Transcribing, @unchecked Sendable {
 
         /// Number of times `shutdown` has been called.
         public var shutdownCallCount = 0
+
+        /// Number of times `modelsPresent` has been called.
+        public var modelsPresentCallCount = 0
 
         /// Error to throw from `ensureModelsDownloaded`, if any.
         public var ensureModelsError: (any Error)?
@@ -33,6 +37,10 @@ public struct FakeTranscriber: Transcribing, @unchecked Sendable {
 
         /// Status messages to emit during `ensureModelsDownloaded`.
         public var statusMessages: [String]
+
+        /// The value returned by `modelsPresent()`. Defaults to `true`
+        /// (models present on disk) to match the common test scenario.
+        public var modelsPresentResult: Bool = true
 
         public init(
             cannedResult: TranscriptResult,
@@ -89,6 +97,12 @@ public struct FakeTranscriber: Transcribing, @unchecked Sendable {
             throw error
         }
         return backing.cannedResult
+    }
+
+    public func modelsPresent() async -> Bool {
+        backing.modelsPresentCalled = true
+        backing.modelsPresentCallCount += 1
+        return backing.modelsPresentResult
     }
 
     public func shutdown() async {

--- a/Packages/BiscottiKit/Tests/DataStoreTests/SettingsAndQueryTests.swift
+++ b/Packages/BiscottiKit/Tests/DataStoreTests/SettingsAndQueryTests.swift
@@ -47,6 +47,21 @@ struct SettingsTests {
         #expect(result.enabledCalendarIDs == nil)
     }
 
+    @Test("selectedModelID defaults to empty string")
+    func selectedModelIDDefaultsToEmpty() async throws {
+        let store = try makeStore()
+        let result = try await store.settings()
+        #expect(result.selectedModelID == "")
+    }
+
+    @Test("selectedModelID round-trips through updateSettings")
+    func selectedModelIDRoundTrip() async throws {
+        let store = try makeStore()
+        try await store.updateSettings { $0.selectedModelID = "gemma-4-e2b" }
+        let result = try await store.settings()
+        #expect(result.selectedModelID == "gemma-4-e2b")
+    }
+
     @Test("settings() returns the same singleton on subsequent calls")
     func settingsSingleton() async throws {
         let store = try makeStore()

--- a/Packages/BiscottiKit/Tests/IntelligenceTests/IntelligenceTests.swift
+++ b/Packages/BiscottiKit/Tests/IntelligenceTests/IntelligenceTests.swift
@@ -21,12 +21,17 @@ final class FakeLLMRunner: LLMRunning, @unchecked Sendable {
     /// The most recently passed `EngineConfig`.
     var lastConfig: EngineConfig?
 
+    /// The most recently passed model URL.
+    var lastModelURL: URL?
+
     func withSession<T: Sendable>(
+        model: URL,
         config: EngineConfig,
         _ body: @Sendable (any LLMSession) async throws -> T
     ) async throws -> T {
         sessionCount += 1
         lastConfig = config
+        lastModelURL = model
         return try await body(session)
     }
 }
@@ -128,25 +133,36 @@ private func makeGenerationResult(text: String) -> GenerationResult {
     return try! JSONDecoder().decode(GenerationResult.self, from: data)
 }
 
-/// Fake model provider with toggleable download state.
+/// Fake model provider with configurable per-model download state.
 final class FakeModelProvider: ModelProviding, @unchecked Sendable {
-    var downloaded: Bool
-    let modelURL: URL
+    let catalog: [LLMModel]
+    var downloadedIDs: Set<String>
 
     var downloadCalled = false
     var downloadShouldFail = false
     var downloadProgress: [(Int64, Int64?)] = []
 
-    init(downloaded: Bool = true) {
-        self.downloaded = downloaded
-        modelURL = URL(fileURLWithPath: "/fake/model.gguf")
+    init(downloadedIDs: Set<String> = []) {
+        catalog = LLMModelCatalog.all
+        self.downloadedIDs = downloadedIDs
     }
 
-    func isDownloaded() -> Bool {
-        downloaded
+    func url(for id: String) -> URL? {
+        LLMModelCatalog.model(id: id).map {
+            URL(fileURLWithPath: "/fake/\($0.fileName)")
+        }
+    }
+
+    func isDownloaded(_ id: String) -> Bool {
+        downloadedIDs.contains(id)
+    }
+
+    func downloadedModelIDs() -> [String] {
+        catalog.filter { downloadedIDs.contains($0.id) }.map(\.id)
     }
 
     func download(
+        _ id: String,
         progress: @Sendable @escaping (Int64, Int64?) -> Void
     ) async throws {
         downloadCalled = true
@@ -159,7 +175,29 @@ final class FakeModelProvider: ModelProviding, @unchecked Sendable {
                 userInfo: [NSLocalizedDescriptionKey: "Download failed"]
             )
         }
-        downloaded = true
+        downloadedIDs.insert(id)
+    }
+
+    func delete(_ id: String) throws {
+        downloadedIDs.remove(id)
+    }
+}
+
+/// Fake hardware probe for tests.
+struct FakeHardwareProbe: HardwareProbing {
+    var physicalMemoryBytes: UInt64
+    var diskBytes: Int64?
+
+    init(
+        physicalMemoryBytes: UInt64 = 32_000_000_000,
+        diskBytes: Int64? = 100_000_000_000
+    ) {
+        self.physicalMemoryBytes = physicalMemoryBytes
+        self.diskBytes = diskBytes
+    }
+
+    func availableDiskBytes(at _: URL) -> Int64? {
+        diskBytes
     }
 }
 
@@ -189,6 +227,7 @@ final class BlockingLLMRunner: LLMRunning, @unchecked Sendable {
     }
 
     func withSession<T: Sendable>(
+        model _: URL,
         config _: EngineConfig,
         _ body: @Sendable (any LLMSession) async throws -> T
     ) async throws -> T {
@@ -250,9 +289,13 @@ private func makeMeetingWithTranscript(
 struct IntelligenceFixture {
     let intel: Intelligence
     let runner: FakeLLMRunner
+    let modelManager: ModelManager
     let models: FakeModelProvider
 }
 
+/// Creates an Intelligence with a ModelManager backed by fakes.
+/// When `downloaded` is true, the first catalog model (12B) is marked as
+/// downloaded and pre-populated in the ModelManager's download state.
 @MainActor private func makeIntelligence(
     store: DataStore,
     session: FakeSession = FakeSession(),
@@ -260,13 +303,29 @@ struct IntelligenceFixture {
     enabled: Bool = true
 ) -> IntelligenceFixture {
     let runner = FakeLLMRunner(session: session)
-    let models = FakeModelProvider(downloaded: downloaded)
+    let firstModelID = LLMModelCatalog.all.first?.id ?? ""
+    let downloadedIDs: Set<String> = downloaded
+        ? [firstModelID]
+        : []
+    let models = FakeModelProvider(downloadedIDs: downloadedIDs)
+    let hardware = FakeHardwareProbe()
+    let modelManager = ModelManager(
+        store: store, models: models, hardware: hardware
+    )
+    // Pre-populate download states
+    for model in models.catalog {
+        modelManager.downloads[model.id] = models.isDownloaded(model.id)
+            ? .downloaded : .notDownloaded
+    }
     let settings = AISettings(enabled: enabled)
     let intel = Intelligence(
-        store: store, llm: runner, models: models,
+        store: store, llm: runner, modelManager: modelManager,
         settings: { settings }
     )
-    return IntelligenceFixture(intel: intel, runner: runner, models: models)
+    return IntelligenceFixture(
+        intel: intel, runner: runner,
+        modelManager: modelManager, models: models
+    )
 }
 
 // MARK: - SpeakerMappingParser Tests
@@ -829,9 +888,17 @@ struct IntelligenceOrchestrationTests {
         )
 
         let blocker = BlockingLLMRunner()
-        let models = FakeModelProvider(downloaded: true)
+        let models = try FakeModelProvider(downloadedIDs: [#require(LLMModelCatalog.all.first?.id)])
+        let hardware = FakeHardwareProbe()
+        let modelManager = ModelManager(
+            store: store, models: models, hardware: hardware
+        )
+        for model in models.catalog {
+            modelManager.downloads[model.id] = models.isDownloaded(model.id)
+                ? .downloaded : .notDownloaded
+        }
         let intel = Intelligence(
-            store: store, llm: blocker, models: models,
+            store: store, llm: blocker, modelManager: modelManager,
             settings: { AISettings(enabled: true) }
         )
 
@@ -895,6 +962,25 @@ struct IntelligenceOrchestrationTests {
         let expectedContextSize = base + expectedReserve
         #expect(session.reconfigureCalls.first == expectedContextSize)
         #expect(expectedContextSize == 4159)
+    }
+
+    @Test("active model URL is passed to withSession")
+    @MainActor func activeModelURLPassedToRunner() async throws {
+        let store = try makeStore()
+        let (meetingID, _) = try await makeMeetingWithTranscript(store: store)
+
+        let session = FakeSession()
+        session.generateResponses = ["0 | Alice |"]
+        session.streamingTokens = [["Summary"]]
+
+        let fixture = makeIntelligence(store: store, session: session)
+        await fixture.intel.runAutoEnhancements(meetingID: meetingID)
+
+        #expect(fixture.runner.sessionCount == 1)
+        // Verify the runner received the active model URL
+        let expectedURL = fixture.modelManager.activeModelURL()
+        #expect(fixture.runner.lastModelURL == expectedURL)
+        #expect(expectedURL != nil)
     }
 }
 
@@ -1019,9 +1105,17 @@ struct IntelligenceRunAnalysisTests {
         )
 
         let blocker = BlockingLLMRunner()
-        let models = FakeModelProvider(downloaded: true)
+        let models = try FakeModelProvider(downloadedIDs: [#require(LLMModelCatalog.all.first?.id)])
+        let hardware = FakeHardwareProbe()
+        let modelManager = ModelManager(
+            store: store, models: models, hardware: hardware
+        )
+        for model in models.catalog {
+            modelManager.downloads[model.id] = models.isDownloaded(model.id)
+                ? .downloaded : .notDownloaded
+        }
         let intel = Intelligence(
-            store: store, llm: blocker, models: models,
+            store: store, llm: blocker, modelManager: modelManager,
             settings: { AISettings(enabled: true) }
         )
 
@@ -1061,89 +1155,6 @@ struct IntelligenceRunAnalysisTests {
         #expect(config?.contextSize == 0)
 
         #expect(session.reconfigureCalls.count == 1)
-    }
-}
-
-// MARK: - Intelligence Download Tests
-
-@Suite("Intelligence download state machine")
-struct IntelligenceDownloadTests {
-    @Test("refreshModelState reflects disk presence")
-    @MainActor func refreshModelState() throws {
-        let store = try makeStore()
-        let models = FakeModelProvider(downloaded: false)
-        let intel = Intelligence(
-            store: store,
-            llm: FakeLLMRunner(),
-            models: models,
-            settings: { AISettings(enabled: true) }
-        )
-
-        #expect(intel.download == .notDownloaded)
-
-        models.downloaded = true
-        intel.refreshModelState()
-        #expect(intel.download == .downloaded)
-
-        models.downloaded = false
-        intel.refreshModelState()
-        #expect(intel.download == .notDownloaded)
-    }
-
-    @Test("successful download transitions to .downloaded")
-    @MainActor func successfulDownload() async throws {
-        let store = try makeStore()
-        let models = FakeModelProvider(downloaded: false)
-        let intel = Intelligence(
-            store: store,
-            llm: FakeLLMRunner(),
-            models: models,
-            settings: { AISettings(enabled: true) }
-        )
-
-        await intel.downloadModel()
-
-        #expect(intel.download == .downloaded)
-        #expect(models.downloadCalled)
-        #expect(intel.isModelDownloaded)
-    }
-
-    @Test("failed download transitions to .failed")
-    @MainActor func failedDownload() async throws {
-        let store = try makeStore()
-        let models = FakeModelProvider(downloaded: false)
-        models.downloadShouldFail = true
-
-        let intel = Intelligence(
-            store: store,
-            llm: FakeLLMRunner(),
-            models: models,
-            settings: { AISettings(enabled: true) }
-        )
-
-        await intel.downloadModel()
-
-        if case let .failed(message) = intel.download {
-            #expect(message.contains("Download failed"))
-        } else {
-            Issue.record("Expected .failed state")
-        }
-    }
-
-    @Test("isModelDownloaded reflects provider state")
-    @MainActor func isModelDownloaded() throws {
-        let store = try makeStore()
-        let models = FakeModelProvider(downloaded: true)
-        let intel = Intelligence(
-            store: store,
-            llm: FakeLLMRunner(),
-            models: models,
-            settings: { AISettings(enabled: true) }
-        )
-
-        #expect(intel.isModelDownloaded == true)
-        models.downloaded = false
-        #expect(intel.isModelDownloaded == false)
     }
 }
 
@@ -1547,13 +1558,13 @@ struct TitleOrchestrationTests {
             store: store, title: Meeting.defaultTitle
         )
 
-        // All speakers assigned → no speaker turn
+        // All speakers assigned -> no speaker turn
         let alice = try await store.findOrCreatePerson(name: "Alice", email: nil)
         let bob = try await store.findOrCreatePerson(name: "Bob", email: nil)
         try await store.setSpeakerAssignment(speakerID: 0, personID: alice, for: transcriptID)
         try await store.setSpeakerAssignment(speakerID: 1, personID: bob, for: transcriptID)
 
-        // Summary edited → no summary turn
+        // Summary edited -> no summary turn
         try await store.setSummary("User's notes", for: meetingID)
 
         let session = FakeSession()

--- a/Packages/BiscottiKit/Tests/IntelligenceTests/ModelManagerTests.swift
+++ b/Packages/BiscottiKit/Tests/IntelligenceTests/ModelManagerTests.swift
@@ -1,0 +1,896 @@
+import DataStore
+import Foundation
+import LocalLLM
+import Testing
+import Transcription
+@testable import Intelligence
+
+// MARK: - Fakes
+
+/// Fake model provider with configurable per-model download state.
+private final class MMFakeModelProvider: ModelProviding,
+    @unchecked Sendable
+{
+    let catalog: [LLMModel]
+    var downloadedIDs: Set<String>
+
+    var downloadShouldFail = false
+    var downloadCalledIDs: [String] = []
+
+    init(downloadedIDs: Set<String> = []) {
+        catalog = LLMModelCatalog.all
+        self.downloadedIDs = downloadedIDs
+    }
+
+    func url(for id: String) -> URL? {
+        LLMModelCatalog.model(id: id).map {
+            URL(fileURLWithPath: "/fake/\($0.fileName)")
+        }
+    }
+
+    func isDownloaded(_ id: String) -> Bool {
+        downloadedIDs.contains(id)
+    }
+
+    func downloadedModelIDs() -> [String] {
+        catalog.filter { downloadedIDs.contains($0.id) }.map(\.id)
+    }
+
+    func download(
+        _ id: String,
+        progress _: @Sendable @escaping (Int64, Int64?) -> Void
+    ) async throws {
+        downloadCalledIDs.append(id)
+        if downloadShouldFail {
+            throw NSError(
+                domain: "FakeDownload", code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "Download failed"]
+            )
+        }
+        downloadedIDs.insert(id)
+    }
+
+    func delete(_ id: String) throws {
+        downloadedIDs.remove(id)
+    }
+}
+
+/// Fake model provider whose download suspends until explicitly released.
+/// Used for one-at-a-time guard tests.
+private final class BlockingModelProvider: ModelProviding,
+    @unchecked Sendable
+{
+    let catalog: [LLMModel] = LLMModelCatalog.all
+    var downloadedIDs: Set<String> = []
+
+    private let enteredStream: AsyncStream<Void>
+    private let enteredContinuation: AsyncStream<Void>.Continuation
+    private let releaseStream: AsyncStream<Void>
+    private let releaseContinuation: AsyncStream<Void>.Continuation
+
+    var downloadCalledIDs: [String] = []
+
+    init() {
+        let (eStream, eCont) = AsyncStream<Void>.makeStream()
+        enteredStream = eStream
+        enteredContinuation = eCont
+        let (rStream, rCont) = AsyncStream<Void>.makeStream()
+        releaseStream = rStream
+        releaseContinuation = rCont
+    }
+
+    func url(for id: String) -> URL? {
+        LLMModelCatalog.model(id: id).map {
+            URL(fileURLWithPath: "/fake/\($0.fileName)")
+        }
+    }
+
+    func isDownloaded(_ id: String) -> Bool {
+        downloadedIDs.contains(id)
+    }
+
+    func downloadedModelIDs() -> [String] {
+        catalog.filter { downloadedIDs.contains($0.id) }.map(\.id)
+    }
+
+    func download(
+        _ id: String,
+        progress _: @Sendable @escaping (Int64, Int64?) -> Void
+    ) async throws {
+        downloadCalledIDs.append(id)
+        enteredContinuation.yield()
+        var iterator = releaseStream.makeAsyncIterator()
+        _ = await iterator.next()
+        downloadedIDs.insert(id)
+    }
+
+    func delete(_ id: String) throws {
+        downloadedIDs.remove(id)
+    }
+
+    func waitUntilEntered() async {
+        var iterator = enteredStream.makeAsyncIterator()
+        _ = await iterator.next()
+    }
+
+    func release() {
+        releaseContinuation.yield()
+    }
+}
+
+/// Fake hardware probe with configurable RAM and disk.
+private struct MMFakeHardwareProbe: HardwareProbing {
+    var physicalMemoryBytes: UInt64
+    var diskBytes: Int64?
+
+    init(
+        physicalMemoryBytes: UInt64 = 32_000_000_000,
+        diskBytes: Int64? = 100_000_000_000
+    ) {
+        self.physicalMemoryBytes = physicalMemoryBytes
+        self.diskBytes = diskBytes
+    }
+
+    func availableDiskBytes(at _: URL) -> Int64? {
+        diskBytes
+    }
+}
+
+// MARK: - Helpers
+
+private let model12B = "gemma-4-12b"
+private let modelE2B = "gemma-4-e2b"
+
+/// Groups the ModelManager and its fakes for test convenience.
+private struct ManagerFixture {
+    let mgr: ModelManager
+    let models: MMFakeModelProvider
+    let store: DataStore
+}
+
+private func makeStore() throws -> DataStore {
+    try DataStore(storage: .inMemory)
+}
+
+@MainActor private func makeManager(
+    store: DataStore? = nil,
+    downloadedIDs: Set<String> = [],
+    ram: UInt64 = 32_000_000_000,
+    disk: Int64? = 100_000_000_000
+) throws -> ManagerFixture {
+    let dataStore = try store ?? makeStore()
+    let models = MMFakeModelProvider(downloadedIDs: downloadedIDs)
+    let hardware = MMFakeHardwareProbe(
+        physicalMemoryBytes: ram, diskBytes: disk
+    )
+    let manager = ModelManager(
+        store: dataStore, models: models, hardware: hardware
+    )
+    return ManagerFixture(mgr: manager, models: models, store: dataStore)
+}
+
+// MARK: - Active-model resolution + migration
+
+@Suite("ModelManager active-model resolution")
+struct ModelManagerResolutionTests {
+    @Test("selected + downloaded resolves to that model")
+    @MainActor func selectedAndDownloaded() async throws {
+        let fix = try makeManager(downloadedIDs: [model12B])
+        try await fix.store.updateSettings { settings in
+            settings.selectedModelID = model12B
+        }
+
+        await fix.mgr.refresh()
+
+        #expect(fix.mgr.activeModelID == model12B)
+        #expect(fix.mgr.selectedModelID == model12B)
+        #expect(fix.mgr.isModelAvailable == true)
+        #expect(fix.mgr.activeModelURL() != nil)
+    }
+
+    @Test("empty selection falls back to first downloaded in catalog order")
+    @MainActor func emptySelectionFallback() async throws {
+        let fix = try makeManager(
+            downloadedIDs: [model12B, modelE2B]
+        )
+
+        await fix.mgr.refresh()
+
+        #expect(fix.mgr.activeModelID == model12B)
+        #expect(fix.mgr.selectedModelID == model12B)
+    }
+
+    @Test("stale selection (non-downloaded) falls back to first downloaded")
+    @MainActor func staleSelectionFallback() async throws {
+        let store = try makeStore()
+        try await store.updateSettings { settings in
+            settings.selectedModelID = model12B
+        }
+
+        let fix = try makeManager(
+            store: store, downloadedIDs: [modelE2B]
+        )
+
+        await fix.mgr.refresh()
+
+        #expect(fix.mgr.activeModelID == modelE2B)
+        #expect(fix.mgr.selectedModelID == modelE2B)
+
+        let settings = try await store.settings()
+        #expect(settings.selectedModelID == modelE2B)
+    }
+
+    @Test("no downloaded models -> nil active, not available")
+    @MainActor func noDownloadedModels() async throws {
+        let fix = try makeManager(downloadedIDs: [])
+
+        await fix.mgr.refresh()
+
+        #expect(fix.mgr.activeModelID == nil)
+        #expect(fix.mgr.isModelAvailable == false)
+        #expect(fix.mgr.activeModelURL() == nil)
+    }
+
+    @Test("existing-user migration: 12B downloaded, empty selection -> 12B persisted")
+    @MainActor func existingUserMigration() async throws {
+        let store = try makeStore()
+        let fix = try makeManager(
+            store: store, downloadedIDs: [model12B]
+        )
+
+        await fix.mgr.refresh()
+
+        #expect(fix.mgr.activeModelID == model12B)
+        #expect(fix.mgr.selectedModelID == model12B)
+
+        let settings = try await store.settings()
+        #expect(settings.selectedModelID == model12B)
+    }
+
+    @Test("selected model already correct: no redundant write-back")
+    @MainActor func noRedundantWriteBack() async throws {
+        let store = try makeStore()
+        try await store.updateSettings { settings in
+            settings.selectedModelID = model12B
+        }
+
+        let fix = try makeManager(
+            store: store, downloadedIDs: [model12B]
+        )
+
+        await fix.mgr.refresh()
+
+        #expect(fix.mgr.selectedModelID == model12B)
+        let settings = try await store.settings()
+        #expect(settings.selectedModelID == model12B)
+    }
+
+    @Test("refresh preserves in-flight download state")
+    @MainActor func refreshPreservesInFlight() async throws {
+        let fix = try makeManager(downloadedIDs: [])
+
+        fix.mgr.downloads[modelE2B] = .downloading(fraction: 0.5)
+
+        await fix.mgr.refresh()
+
+        if case let .downloading(fraction) = fix.mgr.downloads[modelE2B] {
+            #expect(fraction == 0.5)
+        } else {
+            Issue.record("Expected .downloading state to be preserved")
+        }
+    }
+}
+
+// MARK: - Auto-select on first download
+
+@Suite("ModelManager auto-select on download")
+struct ModelManagerAutoSelectTests {
+    @Test("first download auto-selects when no valid selection")
+    @MainActor func firstDownloadAutoSelects() async throws {
+        let fix = try makeManager(downloadedIDs: [])
+
+        await fix.mgr.refresh()
+        #expect(fix.mgr.activeModelID == nil)
+
+        await fix.mgr.downloadModel(id: modelE2B)
+
+        #expect(fix.mgr.selectedModelID == modelE2B)
+        #expect(fix.mgr.activeModelID == modelE2B)
+        #expect(fix.mgr.downloads[modelE2B] == .downloaded)
+
+        let settings = try await fix.store.settings()
+        #expect(settings.selectedModelID == modelE2B)
+    }
+
+    @Test("download does not change selection when valid selection exists")
+    @MainActor func downloadKeepsExistingSelection() async throws {
+        let fix = try makeManager(downloadedIDs: [model12B])
+
+        await fix.mgr.refresh()
+        #expect(fix.mgr.selectedModelID == model12B)
+
+        await fix.mgr.downloadModel(id: modelE2B)
+
+        #expect(fix.mgr.selectedModelID == model12B)
+        #expect(fix.mgr.activeModelID == model12B)
+    }
+
+    @Test("failed download does not auto-select")
+    @MainActor func failedDownloadNoAutoSelect() async throws {
+        let store = try makeStore()
+        let models = MMFakeModelProvider(downloadedIDs: [])
+        models.downloadShouldFail = true
+        let hardware = MMFakeHardwareProbe()
+        let mgr = ModelManager(
+            store: store, models: models, hardware: hardware
+        )
+
+        await mgr.refresh()
+        await mgr.downloadModel(id: modelE2B)
+
+        #expect(mgr.selectedModelID == "")
+        #expect(mgr.activeModelID == nil)
+
+        if case .failed = mgr.downloads[modelE2B] {
+            // expected
+        } else {
+            Issue.record("Expected .failed state after download error")
+        }
+    }
+}
+
+// MARK: - Delete -> fallback / clear
+
+@Suite("ModelManager delete")
+struct ModelManagerDeleteTests {
+    @Test("delete selected model falls back to next downloaded")
+    @MainActor func deleteFallsBackToNext() async throws {
+        let fix = try makeManager(
+            downloadedIDs: [model12B, modelE2B]
+        )
+
+        await fix.mgr.refresh()
+        #expect(fix.mgr.selectedModelID == model12B)
+
+        await fix.mgr.deleteModel(id: model12B)
+
+        #expect(fix.mgr.selectedModelID == modelE2B)
+        #expect(fix.mgr.activeModelID == modelE2B)
+        #expect(fix.mgr.downloads[model12B] == .notDownloaded)
+
+        let settings = try await fix.store.settings()
+        #expect(settings.selectedModelID == modelE2B)
+    }
+
+    @Test("delete last model clears selection entirely")
+    @MainActor func deleteLastClearsSelection() async throws {
+        let fix = try makeManager(downloadedIDs: [modelE2B])
+
+        await fix.mgr.refresh()
+        #expect(fix.mgr.selectedModelID == modelE2B)
+
+        await fix.mgr.deleteModel(id: modelE2B)
+
+        #expect(fix.mgr.selectedModelID == "")
+        #expect(fix.mgr.activeModelID == nil)
+        #expect(fix.mgr.isModelAvailable == false)
+
+        let settings = try await fix.store.settings()
+        #expect(settings.selectedModelID == "")
+    }
+
+    @Test("delete non-selected model does not change selection")
+    @MainActor func deleteNonSelectedKeepsSelection() async throws {
+        let fix = try makeManager(
+            downloadedIDs: [model12B, modelE2B]
+        )
+
+        await fix.mgr.refresh()
+        #expect(fix.mgr.selectedModelID == model12B)
+
+        await fix.mgr.deleteModel(id: modelE2B)
+
+        #expect(fix.mgr.selectedModelID == model12B)
+        #expect(fix.mgr.activeModelID == model12B)
+    }
+}
+
+// MARK: - Select guard
+
+@Suite("ModelManager select guard")
+struct ModelManagerSelectGuardTests {
+    @Test("selecting a non-downloaded model is rejected")
+    @MainActor func selectNonDownloaded() async throws {
+        let fix = try makeManager(downloadedIDs: [model12B])
+
+        await fix.mgr.refresh()
+        #expect(fix.mgr.selectedModelID == model12B)
+
+        await fix.mgr.selectModel(id: modelE2B)
+
+        #expect(fix.mgr.selectedModelID == model12B)
+    }
+
+    @Test("selecting a non-runnable model is rejected")
+    @MainActor func selectNonRunnable() async throws {
+        // 8 GB RAM: 12B requires 15 GB, so selectModel rejects it
+        let fix = try makeManager(
+            downloadedIDs: [model12B, modelE2B],
+            ram: 8_000_000_000
+        )
+
+        await fix.mgr.refresh()
+
+        // Force selection to E2B first (runnable at any RAM)
+        await fix.mgr.selectModel(id: modelE2B)
+        #expect(fix.mgr.selectedModelID == modelE2B)
+
+        // Now try to select 12B (not runnable at 8 GB RAM)
+        await fix.mgr.selectModel(id: model12B)
+
+        // Should be rejected -- still E2B
+        #expect(fix.mgr.selectedModelID == modelE2B)
+    }
+
+    @Test("selecting an unknown model id is rejected")
+    @MainActor func selectUnknownID() async throws {
+        let fix = try makeManager(downloadedIDs: [model12B])
+
+        await fix.mgr.refresh()
+        #expect(fix.mgr.selectedModelID == model12B)
+
+        await fix.mgr.selectModel(id: "nonexistent-model")
+
+        #expect(fix.mgr.selectedModelID == model12B)
+    }
+
+    @Test("selecting a valid downloaded runnable model succeeds")
+    @MainActor func selectValid() async throws {
+        let fix = try makeManager(
+            downloadedIDs: [model12B, modelE2B]
+        )
+
+        await fix.mgr.refresh()
+        #expect(fix.mgr.selectedModelID == model12B)
+
+        await fix.mgr.selectModel(id: modelE2B)
+
+        #expect(fix.mgr.selectedModelID == modelE2B)
+        #expect(fix.mgr.activeModelID == modelE2B)
+
+        let settings = try await fix.store.settings()
+        #expect(settings.selectedModelID == modelE2B)
+    }
+}
+
+// MARK: - One-at-a-time download guard
+
+@Suite("ModelManager one-at-a-time download")
+struct ModelManagerOneAtATimeTests {
+    @Test("second download is blocked while first is in flight")
+    @MainActor func secondDownloadBlocked() async throws {
+        let store = try makeStore()
+        let models = BlockingModelProvider()
+        let hardware = MMFakeHardwareProbe()
+        let mgr = ModelManager(
+            store: store, models: models, hardware: hardware
+        )
+
+        for model in models.catalog {
+            mgr.downloads[model.id] = .notDownloaded
+        }
+
+        let task1 = Task { @MainActor in
+            await mgr.downloadModel(id: modelE2B)
+        }
+
+        await models.waitUntilEntered()
+
+        if case .downloading = mgr.downloads[modelE2B] {
+            // expected
+        } else {
+            Issue.record("Expected E2B to be in .downloading state")
+        }
+
+        // Try to start second download -- should be blocked
+        await mgr.downloadModel(id: model12B)
+
+        #expect(models.downloadCalledIDs.count == 1)
+        #expect(models.downloadCalledIDs.first == modelE2B)
+
+        models.release()
+        await task1.value
+
+        #expect(mgr.downloads[modelE2B] == .downloaded)
+    }
+
+    @Test("download blocked for non-runnable model")
+    @MainActor func downloadBlockedNotRunnable() async throws {
+        let fix = try makeManager(
+            downloadedIDs: [], ram: 8_000_000_000
+        )
+
+        await fix.mgr.refresh()
+        await fix.mgr.downloadModel(id: model12B)
+
+        #expect(fix.models.downloadCalledIDs.isEmpty)
+        #expect(fix.mgr.downloads[model12B] == .notDownloaded)
+    }
+
+    @Test("download blocked for insufficient disk")
+    @MainActor func downloadBlockedInsufficientDisk() async throws {
+        let fix = try makeManager(
+            downloadedIDs: [], disk: 1_000_000_000
+        )
+
+        await fix.mgr.refresh()
+        await fix.mgr.downloadModel(id: modelE2B)
+
+        #expect(fix.models.downloadCalledIDs.isEmpty)
+    }
+}
+
+// MARK: - modelChoices matrix
+
+@Suite("ModelManager modelChoices")
+struct ModelManagerModelChoicesTests {
+    @Test("32 GB RAM, plenty of disk, 12B downloaded+selected")
+    @MainActor func fullSetup32GB() async throws {
+        let fix = try makeManager(downloadedIDs: [model12B])
+
+        await fix.mgr.refresh()
+
+        let choices = fix.mgr.modelChoices()
+        #expect(choices.count == LLMModelCatalog.all.count)
+
+        let row12B = choices.first { $0.id == model12B }
+        #expect(row12B != nil)
+        #expect(row12B?.runnable == true)
+        #expect(row12B?.isDownloaded == true)
+        #expect(row12B?.isSelected == true)
+        #expect(row12B?.isRecommended == true)
+        #expect(row12B?.hasEnoughDiskToDownload == true)
+        #expect(row12B?.blockedReason == nil)
+        #expect(row12B?.downloadState == .downloaded)
+
+        let rowE2B = choices.first { $0.id == modelE2B }
+        #expect(rowE2B != nil)
+        #expect(rowE2B?.runnable == true)
+        #expect(rowE2B?.isDownloaded == false)
+        #expect(rowE2B?.isSelected == false)
+        #expect(rowE2B?.isRecommended == false)
+        #expect(rowE2B?.blockedReason == nil)
+    }
+
+    @Test("8 GB RAM: 12B not runnable, E2B recommended")
+    @MainActor func lowRAM() async throws {
+        let fix = try makeManager(
+            downloadedIDs: [modelE2B], ram: 8_000_000_000
+        )
+
+        await fix.mgr.refresh()
+
+        let choices = fix.mgr.modelChoices()
+
+        let row12B = choices.first { $0.id == model12B }
+        #expect(row12B?.runnable == false)
+        #expect(row12B?.blockedReason == .cannotRun)
+        #expect(row12B?.isRecommended == false)
+
+        let rowE2B = choices.first { $0.id == modelE2B }
+        #expect(rowE2B?.runnable == true)
+        #expect(rowE2B?.isRecommended == true)
+        #expect(rowE2B?.blockedReason == nil)
+    }
+
+    @Test("insufficient disk: not-downloaded model blocked")
+    @MainActor func insufficientDisk() async throws {
+        let fix = try makeManager(
+            downloadedIDs: [], disk: 1_000_000_000
+        )
+
+        await fix.mgr.refresh()
+
+        let choices = fix.mgr.modelChoices()
+
+        let rowE2B = choices.first { $0.id == modelE2B }
+        #expect(rowE2B?.hasEnoughDiskToDownload == false)
+        #expect(rowE2B?.blockedReason == .insufficientDisk)
+
+        let row12B = choices.first { $0.id == model12B }
+        #expect(row12B?.hasEnoughDiskToDownload == false)
+        #expect(row12B?.blockedReason == .insufficientDisk)
+    }
+
+    @Test("downloaded model is never blocked by disk")
+    @MainActor func downloadedNotBlockedByDisk() async throws {
+        let fix = try makeManager(
+            downloadedIDs: [modelE2B], disk: 1_000_000_000
+        )
+
+        await fix.mgr.refresh()
+
+        let choices = fix.mgr.modelChoices()
+        let rowE2B = choices.first { $0.id == modelE2B }
+        #expect(rowE2B?.isDownloaded == true)
+        #expect(rowE2B?.blockedReason == nil)
+    }
+
+    @Test("descriptions come from ModelPolicy")
+    @MainActor func descriptionsFromPolicy() async throws {
+        let fix = try makeManager()
+
+        await fix.mgr.refresh()
+
+        let choices = fix.mgr.modelChoices()
+        let row12B = choices.first { $0.id == model12B }
+        #expect(row12B?.description == ModelPolicy.description(id: model12B))
+        #expect(row12B?.description.contains("7 GB") == true)
+
+        let rowE2B = choices.first { $0.id == modelE2B }
+        #expect(rowE2B?.description == ModelPolicy.description(id: modelE2B))
+    }
+
+    @Test("no models downloaded: no row is selected")
+    @MainActor func noModelsNoneSelected() async throws {
+        let fix = try makeManager(downloadedIDs: [])
+
+        await fix.mgr.refresh()
+
+        let choices = fix.mgr.modelChoices()
+        let selectedCount = choices.filter(\.isSelected).count
+        #expect(selectedCount == 0)
+    }
+}
+
+// MARK: - Intelligence integration
+
+@Suite("ModelManager Intelligence integration")
+struct ModelManagerIntelligenceIntegrationTests {
+    /// Fake LLM runner that records the model URL.
+    private final class RecordingLLMRunner: LLMRunning,
+        @unchecked Sendable
+    {
+        var sessionCount = 0
+        var lastModelURL: URL?
+        let session: RecordingSession
+
+        init() {
+            session = RecordingSession()
+        }
+
+        func withSession<T: Sendable>(
+            model: URL,
+            config _: EngineConfig,
+            _ body: @Sendable (any LLMSession) async throws -> T
+        ) async throws -> T {
+            sessionCount += 1
+            lastModelURL = model
+            return try await body(session)
+        }
+    }
+
+    private final class RecordingSession: LLMSession,
+        @unchecked Sendable
+    {
+        private var generateCallIndex = 0
+        var generateResponses: [String] = []
+        var streamingTokens: [[String]] = []
+        private var streamingCallIndex = 0
+
+        func countTokens(messages _: [LLMMessage]) async throws -> Int {
+            100
+        }
+
+        func reconfigure(contextSize _: Int) async throws {}
+
+        func generate(
+            messages _: [LLMMessage], options _: GenerationOptions
+        ) async throws -> String {
+            let idx = generateCallIndex
+            generateCallIndex += 1
+            guard idx < generateResponses.count else { return "" }
+            return generateResponses[idx]
+        }
+
+        func generateStreaming(
+            messages _: [LLMMessage], options _: GenerationOptions
+        ) async -> AsyncThrowingStream<StreamEvent, Error> {
+            let idx = streamingCallIndex
+            streamingCallIndex += 1
+            let tokens: [String] = if idx < streamingTokens.count {
+                streamingTokens[idx]
+            } else {
+                []
+            }
+            let doneText = tokens.joined()
+            let result = makeStreamResult(text: doneText)
+            let events: [StreamEvent] =
+                tokens.map { .token($0) } + [.done(result)]
+            var iterator = events.makeIterator()
+            return AsyncThrowingStream { iterator.next() }
+        }
+    }
+
+    private static func makeStreamResult(
+        text: String
+    ) -> GenerationResult {
+        let json: [String: Any] = [
+            "text": text,
+            "promptTokenCount": 0,
+            "generatedTokenCount": 1,
+            "cachedPromptTokenCount": 0,
+            "finishReason": ["endOfTurn": [String: Any]()],
+            "promptEvalDuration": 0.0,
+            "generationDuration": 0.0,
+            "totalDuration": 0.0,
+            "renderedPrompt": "",
+            "rawText": text
+        ]
+        // swiftlint:disable:next force_try
+        let data = try! JSONSerialization.data(withJSONObject: json)
+        // swiftlint:disable:next force_try
+        return try! JSONDecoder().decode(
+            GenerationResult.self, from: data
+        )
+    }
+
+    private static func makeTranscriptResult() -> TranscriptResult {
+        TranscriptResult(
+            transcriptionMethodId: "v1",
+            language: "en",
+            speakerCount: 2,
+            segments: [
+                TranscriptSegment(
+                    speakerID: 0, speakerLabel: "Speaker 0",
+                    startTime: 0, endTime: 5,
+                    text: "Hello everyone", confidence: 0.9,
+                    noSpeechProbability: 0.1, words: nil
+                ),
+                TranscriptSegment(
+                    speakerID: 1, speakerLabel: "Speaker 1",
+                    startTime: 5, endTime: 10,
+                    text: "Hi there", confidence: 0.85,
+                    noSpeechProbability: 0.15, words: nil
+                )
+            ],
+            speakerEmbeddings: [:],
+            processingDuration: 3.0
+        )
+    }
+
+    @Test("Intelligence passes active model URL to LLM runner")
+    @MainActor func passesActiveModelURL() async throws {
+        let fix = try makeManager(downloadedIDs: [model12B])
+        await fix.mgr.refresh()
+
+        let runner = RecordingLLMRunner()
+        runner.session.generateResponses = ["0 | Alice |"]
+        runner.session.streamingTokens = [["Summary"]]
+
+        let intel = Intelligence(
+            store: fix.store, llm: runner, modelManager: fix.mgr,
+            settings: { AISettings(enabled: true) }
+        )
+
+        let meetingID = try await fix.store.createMeeting(title: "Test")
+        let result = Self.makeTranscriptResult()
+        let txID = try await fix.store.addTranscript(
+            result, vocabularyUsed: [],
+            mappedEventIdentifier: nil, to: meetingID
+        )
+        try await fix.store.setPreferredTranscript(txID, for: meetingID)
+
+        await intel.runAutoEnhancements(meetingID: meetingID)
+
+        #expect(runner.sessionCount == 1)
+
+        let expectedURL = fix.models.url(for: model12B)
+        #expect(runner.lastModelURL == expectedURL)
+        #expect(expectedURL != nil)
+    }
+
+    @Test("Intelligence no-ops when no active model")
+    @MainActor func noOpsWhenNoModel() async throws {
+        let fix = try makeManager(downloadedIDs: [])
+        await fix.mgr.refresh()
+
+        let runner = RecordingLLMRunner()
+        let intel = Intelligence(
+            store: fix.store, llm: runner, modelManager: fix.mgr,
+            settings: { AISettings(enabled: true) }
+        )
+
+        let meetingID = try await fix.store.createMeeting(title: "Test")
+        let result = Self.makeTranscriptResult()
+        let txID = try await fix.store.addTranscript(
+            result, vocabularyUsed: [],
+            mappedEventIdentifier: nil, to: meetingID
+        )
+        try await fix.store.setPreferredTranscript(txID, for: meetingID)
+
+        await intel.runAutoEnhancements(meetingID: meetingID)
+
+        #expect(runner.sessionCount == 0)
+        #expect(intel.jobs[meetingID] == nil)
+    }
+
+    @Test("Intelligence uses correct model after selection change")
+    @MainActor func usesModelAfterSelectionChange() async throws {
+        let fix = try makeManager(
+            downloadedIDs: [model12B, modelE2B]
+        )
+        await fix.mgr.refresh()
+        #expect(fix.mgr.activeModelID == model12B)
+
+        await fix.mgr.selectModel(id: modelE2B)
+        #expect(fix.mgr.activeModelID == modelE2B)
+
+        let runner = RecordingLLMRunner()
+        runner.session.generateResponses = ["0 | Alice |"]
+        runner.session.streamingTokens = [["Summary"]]
+
+        let intel = Intelligence(
+            store: fix.store, llm: runner, modelManager: fix.mgr,
+            settings: { AISettings(enabled: true) }
+        )
+
+        let meetingID = try await fix.store.createMeeting(title: "Test")
+        let result = Self.makeTranscriptResult()
+        let txID = try await fix.store.addTranscript(
+            result, vocabularyUsed: [],
+            mappedEventIdentifier: nil, to: meetingID
+        )
+        try await fix.store.setPreferredTranscript(txID, for: meetingID)
+
+        await intel.runAutoEnhancements(meetingID: meetingID)
+
+        let expectedURL = fix.models.url(for: modelE2B)
+        #expect(runner.lastModelURL == expectedURL)
+    }
+}
+
+// MARK: - LastFraction tests
+
+@Suite("LastFraction download throttle")
+struct LastFractionTests {
+    @Test("first fraction is always reported")
+    func firstFractionReported() {
+        let tracker = LastFraction()
+        #expect(tracker.shouldUpdate(to: 0.0) == true)
+    }
+
+    @Test("small increment is suppressed")
+    func smallIncrementSuppressed() {
+        let tracker = LastFraction()
+        _ = tracker.shouldUpdate(to: 0.0)
+        #expect(tracker.shouldUpdate(to: 0.005) == false)
+    }
+
+    @Test("1% increment is reported")
+    func onePercentReported() {
+        let tracker = LastFraction()
+        _ = tracker.shouldUpdate(to: 0.0)
+        #expect(tracker.shouldUpdate(to: 0.01) == true)
+    }
+
+    @Test("100% is always reported")
+    func hundredPercentReported() {
+        let tracker = LastFraction()
+        _ = tracker.shouldUpdate(to: 0.99)
+        #expect(tracker.shouldUpdate(to: 1.0) == true)
+    }
+
+    @Test("nil after non-nil is reported")
+    func nilAfterNonNil() {
+        let tracker = LastFraction()
+        _ = tracker.shouldUpdate(to: 0.5)
+        #expect(tracker.shouldUpdate(to: nil) == true)
+    }
+
+    @Test("nil when no previous value is suppressed")
+    func nilFirstIsSuppressed() {
+        let tracker = LastFraction()
+        #expect(tracker.shouldUpdate(to: nil) == false)
+    }
+}

--- a/Packages/BiscottiKit/Tests/IntelligenceTests/ModelManagerTests.swift
+++ b/Packages/BiscottiKit/Tests/IntelligenceTests/ModelManagerTests.swift
@@ -463,6 +463,45 @@ struct ModelManagerSelectGuardTests {
     }
 }
 
+// MARK: - Clear selected model
+
+@Suite("ModelManager clearSelectedModel")
+struct ModelManagerClearSelectedModelTests {
+    @Test("clearSelectedModel resets in-memory and persisted selection")
+    @MainActor func clearResetsSelection() async throws {
+        let fix = try makeManager(downloadedIDs: [model12B, modelE2B])
+
+        await fix.mgr.refresh()
+        // Start with an explicit selection
+        await fix.mgr.selectModel(id: modelE2B)
+        #expect(fix.mgr.selectedModelID == modelE2B)
+
+        await fix.mgr.clearSelectedModel()
+
+        // In-memory should be empty
+        #expect(fix.mgr.selectedModelID == "")
+        // Persisted should be empty
+        let settings = try await fix.store.settings()
+        #expect(settings.selectedModelID == "")
+        // activeModelID falls back to first downloaded in catalog order
+        #expect(fix.mgr.activeModelID == model12B)
+    }
+
+    @Test("clearSelectedModel when already empty is a no-op")
+    @MainActor func clearWhenAlreadyEmpty() async throws {
+        let fix = try makeManager(downloadedIDs: [])
+
+        await fix.mgr.refresh()
+        #expect(fix.mgr.selectedModelID == "")
+
+        await fix.mgr.clearSelectedModel()
+
+        #expect(fix.mgr.selectedModelID == "")
+        let settings = try await fix.store.settings()
+        #expect(settings.selectedModelID == "")
+    }
+}
+
 // MARK: - One-at-a-time download guard
 
 @Suite("ModelManager one-at-a-time download")

--- a/Packages/BiscottiKit/Tests/IntelligenceTests/ModelSuitabilityTests.swift
+++ b/Packages/BiscottiKit/Tests/IntelligenceTests/ModelSuitabilityTests.swift
@@ -1,0 +1,179 @@
+import LocalLLM
+import Testing
+@testable import Intelligence
+
+// MARK: - Helpers
+
+private let oneGB: UInt64 = 1_000_000_000
+private let catalog = LLMModelCatalog.all
+
+// Catalog entries by index -- 12B is first, E2B is second (display order).
+// Using index access avoids force-unwrapping the optional `model(id:)` lookup
+// at file scope where `try #require` is unavailable.
+private let model12B = LLMModelCatalog.all[0]
+private let modelE2B = LLMModelCatalog.all[1]
+
+// MARK: - canRun tests
+
+@Suite("ModelSuitability.canRun")
+struct CanRunTests {
+    @Test(
+        "12B: RAM boundary (15 GB floor)",
+        arguments: [
+            (ram: 8 * oneGB, expected: false),
+            (ram: 14 * oneGB, expected: false),
+            (ram: 15 * oneGB - 1, expected: false),
+            (ram: 15 * oneGB, expected: true),
+            (ram: 16 * oneGB, expected: true),
+            (ram: 24 * oneGB, expected: true),
+            (ram: 64 * oneGB, expected: true)
+        ]
+    )
+    func canRun12B(ram: UInt64, expected: Bool) {
+        #expect(ModelSuitability.canRun(model12B, ram: ram) == expected)
+    }
+
+    @Test(
+        "E2B: always runnable",
+        arguments: [
+            8 * oneGB,
+            16 * oneGB,
+            64 * oneGB
+        ]
+    )
+    func canRunE2B(ram: UInt64) {
+        #expect(ModelSuitability.canRun(modelE2B, ram: ram) == true)
+    }
+}
+
+// MARK: - recommendedModelID tests
+
+@Suite("ModelSuitability.recommendedModelID")
+struct RecommendedModelIDTests {
+    @Test(
+        "below 24 GB recommends E2B",
+        arguments: [
+            8 * oneGB,
+            15 * oneGB,
+            16 * oneGB,
+            24 * oneGB - 1
+        ]
+    )
+    func below24GBRecommendsE2B(ram: UInt64) {
+        let recommended = ModelSuitability.recommendedModelID(
+            catalog: catalog, ram: ram
+        )
+        #expect(recommended == "gemma-4-e2b")
+    }
+
+    @Test("at 24 GB recommends 12B")
+    func at24GBRecommends12B() {
+        let recommended = ModelSuitability.recommendedModelID(
+            catalog: catalog, ram: 24 * oneGB
+        )
+        #expect(recommended == "gemma-4-12b")
+    }
+
+    @Test("above 24 GB recommends 12B")
+    func above24GBRecommends12B() {
+        let recommended = ModelSuitability.recommendedModelID(
+            catalog: catalog, ram: 64 * oneGB
+        )
+        #expect(recommended == "gemma-4-12b")
+    }
+
+    @Test("empty catalog returns nil")
+    func emptyCatalogReturnsNil() {
+        let recommended = ModelSuitability.recommendedModelID(
+            catalog: [], ram: 64 * oneGB
+        )
+        #expect(recommended == nil)
+    }
+
+    @Test("never recommends a non-runnable model")
+    func neverRecommendsNonRunnable() throws {
+        // At every tested RAM level, the recommended model must pass canRun.
+        for ram in [8, 12, 15, 16, 24, 32, 64].map({ UInt64($0) * oneGB }) {
+            guard let id = ModelSuitability.recommendedModelID(
+                catalog: catalog, ram: ram
+            ) else { continue }
+            let model = try #require(LLMModelCatalog.model(id: id))
+            #expect(
+                ModelSuitability.canRun(model, ram: ram),
+                "Recommended \(id) at \(ram / oneGB) GB but it is not runnable"
+            )
+        }
+    }
+}
+
+// MARK: - hasEnoughDisk tests
+
+@Suite("ModelSuitability.hasEnoughDisk")
+struct HasEnoughDiskTests {
+    @Test("nil freeBytes returns true (never block on unknown)")
+    func nilFreeBytesReturnsTrue() {
+        #expect(ModelSuitability.hasEnoughDisk(model12B, freeBytes: nil) == true)
+        #expect(ModelSuitability.hasEnoughDisk(modelE2B, freeBytes: nil) == true)
+    }
+
+    @Test(
+        "12B disk boundaries (7 GB required)",
+        arguments: [
+            (free: Int64(0), expected: false),
+            (free: Int64(7_000_000_000 - 1), expected: false),
+            (free: Int64(7_000_000_000), expected: true),
+            (free: Int64(20_000_000_000), expected: true)
+        ]
+    )
+    func disk12B(free: Int64, expected: Bool) {
+        #expect(ModelSuitability.hasEnoughDisk(model12B, freeBytes: free) == expected)
+    }
+
+    @Test(
+        "E2B disk boundaries (3 GB required)",
+        arguments: [
+            (free: Int64(0), expected: false),
+            (free: Int64(3_000_000_000 - 1), expected: false),
+            (free: Int64(3_000_000_000), expected: true),
+            (free: Int64(10_000_000_000), expected: true)
+        ]
+    )
+    func diskE2B(free: Int64, expected: Bool) {
+        #expect(ModelSuitability.hasEnoughDisk(modelE2B, freeBytes: free) == expected)
+    }
+}
+
+// MARK: - ModelPolicy tests
+
+@Suite("ModelPolicy")
+struct ModelPolicyTests {
+    @Test("description is non-empty for known model IDs")
+    func descriptionKnownIDs() {
+        #expect(!ModelPolicy.description(id: "gemma-4-12b").isEmpty)
+        #expect(!ModelPolicy.description(id: "gemma-4-e2b").isEmpty)
+    }
+
+    @Test("description is empty for unknown model ID")
+    func descriptionUnknownID() {
+        #expect(ModelPolicy.description(id: "unknown-model").isEmpty)
+    }
+
+    @Test("minRAMBytesToRun: 12B has floor, E2B is 0")
+    func minRAMBytesToRun() {
+        #expect(ModelPolicy.minRAMBytesToRun(id: "gemma-4-12b") == 15_000_000_000)
+        #expect(ModelPolicy.minRAMBytesToRun(id: "gemma-4-e2b") == 0)
+        #expect(ModelPolicy.minRAMBytesToRun(id: "unknown") == 0)
+    }
+
+    @Test("approxRAMUsageDescription for known IDs")
+    func approxRAMUsage() {
+        #expect(ModelPolicy.approxRAMUsageDescription(id: "gemma-4-12b") == "8 GB")
+        #expect(ModelPolicy.approxRAMUsageDescription(id: "gemma-4-e2b") == "4 GB")
+    }
+
+    @Test("threshold constants have expected values")
+    func thresholdConstants() {
+        #expect(ModelPolicy.ramFloor12B == 15_000_000_000)
+        #expect(ModelPolicy.recommendationRAMThreshold == 24_000_000_000)
+    }
+}

--- a/Packages/BiscottiKit/Tests/ManualTestKitTests/ScriptShapeTests.swift
+++ b/Packages/BiscottiKit/Tests/ManualTestKitTests/ScriptShapeTests.swift
@@ -105,9 +105,9 @@ struct ScriptShapeTests {
         #expect(script.id == "local_llm")
     }
 
-    @Test("Local LLM script has exactly 21 steps")
+    @Test("Local LLM script has exactly 24 steps")
     func localLLMStepCount() {
-        #expect(TestScript.localLLM.steps.count == 21)
+        #expect(TestScript.localLLM.steps.count == 24)
     }
 
     @Test("Local LLM step IDs match the canonical set")
@@ -134,6 +134,9 @@ struct ScriptShapeTests {
             "llm_kv_reuse_info",
             "llm_kv_reuse",
             "llm_kv_reuse_quality",
+            "llm_e2b_download",
+            "llm_e2b_kv_reuse",
+            "llm_e2b_kv_reuse_quality",
             "llm_reclamation"
         ]
         #expect(ids == expected)

--- a/Packages/BiscottiKit/Tests/MeetingDetailUITests/SummaryTabTests.swift
+++ b/Packages/BiscottiKit/Tests/MeetingDetailUITests/SummaryTabTests.swift
@@ -3,6 +3,7 @@ import BiscottiTestSupport
 import DataStore
 import Foundation
 import Intelligence
+import LocalLLM
 import Testing
 @testable import AppCore
 @testable import MeetingDetailUI
@@ -346,8 +347,11 @@ struct SummaryTabRegenerateTests {
         #expect(viewModel.canRegenerateSummary == false)
 
         // With model, still no transcript
-        fix.fakeModelProvider.downloaded = true
-        fix.intelligence.refreshModelState()
+        try await fix.fakeModelProvider.download(
+            #require(LLMModelCatalog.all.first?.id),
+            progress: { _, _ in }
+        )
+        await fix.modelManager.refresh()
 
         #expect(viewModel.modelAvailable == true)
         #expect(viewModel.canRegenerateSummary == false)

--- a/Packages/BiscottiKit/Tests/ModelManagementUITests/ManageModelsViewModelTests.swift
+++ b/Packages/BiscottiKit/Tests/ModelManagementUITests/ManageModelsViewModelTests.swift
@@ -4,7 +4,7 @@ import Foundation
 import Intelligence
 import LocalLLM
 import Testing
-@testable import SettingsUI
+@testable import ModelManagementUI
 
 @Suite("ManageModelsViewModel")
 @MainActor

--- a/Packages/BiscottiKit/Tests/OnboardingUITests/OnboardingFooterButtonTests.swift
+++ b/Packages/BiscottiKit/Tests/OnboardingUITests/OnboardingFooterButtonTests.swift
@@ -144,7 +144,7 @@ struct OnboardingFooterButtonTests {
         #expect(model.currentStep == .modelDownload)
         // Language is ready (pre-downloaded), but transcription is not yet
         // downloaded via startTranscriptionDownload -- however prepareModelStep
-        // probes modelsReady() which succeeds on the FakeTranscriber, so
+        // probes modelsArePresent() which succeeds on the FakeTranscriber, so
         // transcriptionDownloaded is true. Both models are ready.
         #expect(model.bothModelsReady == true)
         #expect(
@@ -168,7 +168,7 @@ struct OnboardingFooterButtonTests {
         await model.advance() // welcome -> permissions
         await model.skip() // -> modelDownload
 
-        // Transcription is ready (FakeTranscriber succeeds on modelsReady),
+        // Transcription is ready (FakeTranscriber succeeds on modelsArePresent),
         // but language model is not downloaded
         #expect(model.transcriptionReady == true)
         #expect(model.languageReady == false)

--- a/Packages/BiscottiKit/Tests/OnboardingUITests/OnboardingFooterButtonTests.swift
+++ b/Packages/BiscottiKit/Tests/OnboardingUITests/OnboardingFooterButtonTests.swift
@@ -123,8 +123,40 @@ struct OnboardingFooterButtonTests {
 
     // MARK: - Model download: Skip before download, Continue after
 
-    @Test("model download step shows Skip before download, Continue after")
+    @Test("model download step shows Skip before download, Continue when both ready")
     func modelDownloadSkipThenContinue() async throws {
+        // Language model pre-downloaded so only transcription is needed
+        let fixture = try makeCoreFixture(
+            calendarAuthStatus: .denied,
+            modelDownloaded: true
+        )
+        defer { fixture.cleanup() }
+
+        let model = OnboardingViewModel(core: fixture.core)
+
+        // Before downloading: should show Skip (transcription not ready)
+        #expect(model.footerButton(for: .modelDownload) == .skip)
+
+        // Walk to model download step (prepareModelStep refreshes ModelManager)
+        await model.advance() // welcome -> permissions
+        await model.skip() // -> modelDownload
+
+        #expect(model.currentStep == .modelDownload)
+        // Language is ready (pre-downloaded), but transcription is not yet
+        // downloaded via startTranscriptionDownload -- however prepareModelStep
+        // probes modelsReady() which succeeds on the FakeTranscriber, so
+        // transcriptionDownloaded is true. Both models are ready.
+        #expect(model.bothModelsReady == true)
+        #expect(
+            model.footerButton(for: .modelDownload)
+                == .continueButton
+        )
+        #expect(model.isCurrentStepComplete == true)
+    }
+
+    @Test("model download step shows Skip when only transcription ready")
+    func modelDownloadSkipWhenOnlyTranscription() async throws {
+        // No language model pre-downloaded
         let fixture = try makeCoreFixture(
             calendarAuthStatus: .denied
         )
@@ -132,25 +164,15 @@ struct OnboardingFooterButtonTests {
 
         let model = OnboardingViewModel(core: fixture.core)
 
-        // Before downloading: should show Skip
-        #expect(model.footerButton(for: .modelDownload) == .skip)
-
         // Walk to model download step
         await model.advance() // welcome -> permissions
         await model.skip() // -> modelDownload
 
-        #expect(model.currentStep == .modelDownload)
+        // Transcription is ready (FakeTranscriber succeeds on modelsReady),
+        // but language model is not downloaded
+        #expect(model.transcriptionReady == true)
+        #expect(model.languageReady == false)
         #expect(model.footerButton(for: .modelDownload) == .skip)
-        #expect(model.isCurrentStepComplete == false)
-
-        // Download models
-        await model.startDownload()
-        #expect(model.downloadComplete == true)
-        #expect(
-            model.footerButton(for: .modelDownload)
-                == .continueButton
-        )
-        #expect(model.isCurrentStepComplete == true)
     }
 
     // MARK: - Already-granted permission shows Continue on entry

--- a/Packages/BiscottiKit/Tests/OnboardingUITests/OnboardingModelRowStateTests.swift
+++ b/Packages/BiscottiKit/Tests/OnboardingUITests/OnboardingModelRowStateTests.swift
@@ -14,8 +14,8 @@ struct TranscriptionRowStateTests {
     func transcriptionIdle() async throws {
         let fixture = try makeCoreFixture(calendarAuthStatus: .denied)
         defer { fixture.cleanup() }
-        // Prevent FakeTranscriber from reporting models as ready
-        fixture.fakeEngine.backing.ensureModelsError = FakeTranscriberError.notReady
+        // Prevent FakeTranscriber from reporting models as present
+        fixture.fakeEngine.backing.modelsPresentResult = false
 
         let viewModel = OnboardingViewModel(core: fixture.core)
         await viewModel.advance() // welcome -> permissions
@@ -29,7 +29,7 @@ struct TranscriptionRowStateTests {
     func transcriptionReadyOnEntry() async throws {
         let fixture = try makeCoreFixture(calendarAuthStatus: .denied)
         defer { fixture.cleanup() }
-        // FakeTranscriber succeeds on modelsReady by default
+        // FakeTranscriber succeeds on modelsArePresent by default
 
         let viewModel = OnboardingViewModel(core: fixture.core)
         await viewModel.advance() // welcome -> permissions
@@ -43,7 +43,7 @@ struct TranscriptionRowStateTests {
     func transcriptionReadyAfterDownload() async throws {
         let fixture = try makeCoreFixture(calendarAuthStatus: .denied)
         defer { fixture.cleanup() }
-        fixture.fakeEngine.backing.ensureModelsError = FakeTranscriberError.notReady
+        fixture.fakeEngine.backing.modelsPresentResult = false
 
         let viewModel = OnboardingViewModel(core: fixture.core)
         await viewModel.advance()
@@ -63,7 +63,7 @@ struct TranscriptionRowStateTests {
     func transcriptionInsufficientDisk() async throws {
         let fixture = try makeCoreFixture(calendarAuthStatus: .denied)
         defer { fixture.cleanup() }
-        fixture.fakeEngine.backing.ensureModelsError = FakeTranscriberError.notReady
+        fixture.fakeEngine.backing.modelsPresentResult = false
 
         let viewModel = OnboardingViewModel(
             core: fixture.core,
@@ -85,6 +85,7 @@ struct TranscriptionRowStateTests {
     func transcriptionFailed() async throws {
         let fixture = try makeCoreFixture(calendarAuthStatus: .denied)
         defer { fixture.cleanup() }
+        fixture.fakeEngine.backing.modelsPresentResult = false
         fixture.fakeEngine.backing.ensureModelsError = FakeTranscriberError.notReady
 
         let viewModel = OnboardingViewModel(core: fixture.core)
@@ -108,7 +109,7 @@ struct TranscriptionRowCheckingTests {
     func checkingWhilePreparing() async throws {
         let fixture = try makeCoreFixture(calendarAuthStatus: .denied)
         defer { fixture.cleanup() }
-        fixture.fakeEngine.backing.ensureModelsError = FakeTranscriberError.notReady
+        fixture.fakeEngine.backing.modelsPresentResult = false
 
         let viewModel = OnboardingViewModel(core: fixture.core)
         await viewModel.advance() // welcome -> permissions
@@ -123,7 +124,7 @@ struct TranscriptionRowCheckingTests {
     func readyTrumpsChecking() async throws {
         let fixture = try makeCoreFixture(calendarAuthStatus: .denied)
         defer { fixture.cleanup() }
-        // FakeTranscriber succeeds on modelsReady by default
+        // FakeTranscriber succeeds on modelsArePresent by default
 
         let viewModel = OnboardingViewModel(core: fixture.core)
         await viewModel.advance()
@@ -368,7 +369,7 @@ struct FooterMatrixTests {
     func neitherReadyShowsSkip() async throws {
         let fixture = try makeCoreFixture(calendarAuthStatus: .denied)
         defer { fixture.cleanup() }
-        fixture.fakeEngine.backing.ensureModelsError = FakeTranscriberError.notReady
+        fixture.fakeEngine.backing.modelsPresentResult = false
 
         let viewModel = OnboardingViewModel(core: fixture.core)
         await viewModel.advance()
@@ -404,7 +405,7 @@ struct FooterMatrixTests {
             modelDownloaded: true
         )
         defer { fixture.cleanup() }
-        fixture.fakeEngine.backing.ensureModelsError = FakeTranscriberError.notReady
+        fixture.fakeEngine.backing.modelsPresentResult = false
 
         let viewModel = OnboardingViewModel(core: fixture.core)
         await viewModel.advance()
@@ -440,7 +441,7 @@ struct FooterMatrixTests {
     func bothDownloadingShowsContinue() async throws {
         let fixture = try makeCoreFixture(calendarAuthStatus: .denied)
         defer { fixture.cleanup() }
-        fixture.fakeEngine.backing.ensureModelsError = FakeTranscriberError.notReady
+        fixture.fakeEngine.backing.modelsPresentResult = false
 
         let viewModel = OnboardingViewModel(core: fixture.core)
         await viewModel.advance()
@@ -493,7 +494,7 @@ struct FooterMatrixTests {
             modelDownloaded: true
         )
         defer { fixture.cleanup() }
-        fixture.fakeEngine.backing.ensureModelsError = FakeTranscriberError.notReady
+        fixture.fakeEngine.backing.modelsPresentResult = false
 
         let viewModel = OnboardingViewModel(core: fixture.core)
         await viewModel.advance()
@@ -518,7 +519,7 @@ struct BothModelsStartedTests {
     func neitherStarted() async throws {
         let fixture = try makeCoreFixture(calendarAuthStatus: .denied)
         defer { fixture.cleanup() }
-        fixture.fakeEngine.backing.ensureModelsError = FakeTranscriberError.notReady
+        fixture.fakeEngine.backing.modelsPresentResult = false
 
         let viewModel = OnboardingViewModel(core: fixture.core)
         await viewModel.advance()
@@ -533,7 +534,7 @@ struct BothModelsStartedTests {
     func onlyTranscriptionStarted() async throws {
         let fixture = try makeCoreFixture(calendarAuthStatus: .denied)
         defer { fixture.cleanup() }
-        fixture.fakeEngine.backing.ensureModelsError = FakeTranscriberError.notReady
+        fixture.fakeEngine.backing.modelsPresentResult = false
 
         let viewModel = OnboardingViewModel(core: fixture.core)
         await viewModel.advance()
@@ -551,7 +552,7 @@ struct BothModelsStartedTests {
     func onlyLanguageStarted() async throws {
         let fixture = try makeCoreFixture(calendarAuthStatus: .denied)
         defer { fixture.cleanup() }
-        fixture.fakeEngine.backing.ensureModelsError = FakeTranscriberError.notReady
+        fixture.fakeEngine.backing.modelsPresentResult = false
 
         let viewModel = OnboardingViewModel(core: fixture.core)
         await viewModel.advance()
@@ -573,7 +574,7 @@ struct BothModelsStartedTests {
     func bothDownloading() async throws {
         let fixture = try makeCoreFixture(calendarAuthStatus: .denied)
         defer { fixture.cleanup() }
-        fixture.fakeEngine.backing.ensureModelsError = FakeTranscriberError.notReady
+        fixture.fakeEngine.backing.modelsPresentResult = false
 
         let viewModel = OnboardingViewModel(core: fixture.core)
         await viewModel.advance()
@@ -652,7 +653,7 @@ struct ModelStepPreparationTests {
     func prepareSetsTxNotDownloaded() async throws {
         let fixture = try makeCoreFixture(calendarAuthStatus: .denied)
         defer { fixture.cleanup() }
-        fixture.fakeEngine.backing.ensureModelsError = FakeTranscriberError.notReady
+        fixture.fakeEngine.backing.modelsPresentResult = false
 
         let viewModel = OnboardingViewModel(core: fixture.core)
         await viewModel.advance()
@@ -725,6 +726,47 @@ struct ModelStepPreparationTests {
         #expect(viewModel.transcriptionDownloaded == true)
         #expect(viewModel.languageReady == true)
     }
+
+    @Test("beginModelPrep is idempotent -- second call on model-download is a no-op")
+    func beginModelPrepIdempotent() async throws {
+        let fixture = try makeCoreFixture(calendarAuthStatus: .denied)
+        defer { fixture.cleanup() }
+
+        let viewModel = OnboardingViewModel(core: fixture.core)
+        await viewModel.advance() // welcome -> permissions (pre-warm fires)
+        await viewModel.skip() // -> modelDownload (beginModelPrep called again, but guard returns)
+
+        // modelsPresent should be called exactly once (from the single task)
+        #expect(fixture.fakeEngine.backing.modelsPresentCallCount == 1)
+    }
+
+    @Test("resetForReplay clears modelPrepTask and isPreparingModelStep")
+    func resetForReplayClearsPrepTask() async throws {
+        let fixture = try makeCoreFixture(calendarAuthStatus: .denied)
+        defer { fixture.cleanup() }
+
+        let viewModel = OnboardingViewModel(core: fixture.core)
+        await viewModel.advance() // welcome -> permissions (pre-warm fires)
+        await viewModel.skip() // -> modelDownload
+
+        #expect(viewModel.isPreparingModelStep == false)
+        #expect(viewModel.transcriptionDownloaded == true)
+
+        viewModel.resetForReplay()
+
+        // After reset, preparation state is cleared
+        #expect(viewModel.currentStep == .welcome)
+        #expect(viewModel.isPreparingModelStep == false)
+        #expect(viewModel.transcriptionDownloaded == false)
+
+        // A new advance re-fires the pre-warm (task was nilled out)
+        await viewModel.advance() // welcome -> permissions (pre-warm fires again)
+        await viewModel.skip() // -> modelDownload
+
+        // modelsPresent called twice total (once before reset, once after)
+        #expect(fixture.fakeEngine.backing.modelsPresentCallCount == 2)
+        #expect(viewModel.transcriptionDownloaded == true)
+    }
 }
 
 // MARK: - Skip/advance from model download
@@ -736,7 +778,7 @@ struct ModelDownloadNavigationTests {
     func skipAdvancesToDone() async throws {
         let fixture = try makeCoreFixture(calendarAuthStatus: .denied)
         defer { fixture.cleanup() }
-        fixture.fakeEngine.backing.ensureModelsError = FakeTranscriberError.notReady
+        fixture.fakeEngine.backing.modelsPresentResult = false
 
         let viewModel = OnboardingViewModel(core: fixture.core)
         await viewModel.advance() // welcome -> permissions

--- a/Packages/BiscottiKit/Tests/OnboardingUITests/OnboardingModelRowStateTests.swift
+++ b/Packages/BiscottiKit/Tests/OnboardingUITests/OnboardingModelRowStateTests.swift
@@ -99,6 +99,43 @@ struct TranscriptionRowStateTests {
     }
 }
 
+// MARK: - Transcription row-state checking
+
+@Suite("OnboardingViewModel -- Transcription row checking state")
+@MainActor
+struct TranscriptionRowCheckingTests {
+    @Test("checking when isPreparingModelStep and model not ready")
+    func checkingWhilePreparing() async throws {
+        let fixture = try makeCoreFixture(calendarAuthStatus: .denied)
+        defer { fixture.cleanup() }
+        fixture.fakeEngine.backing.ensureModelsError = FakeTranscriberError.notReady
+
+        let viewModel = OnboardingViewModel(core: fixture.core)
+        await viewModel.advance() // welcome -> permissions
+        await viewModel.skip() // -> modelDownload (prepareModelStep completes)
+
+        // Simulate the preparing flag being set (as if mid-preparation)
+        viewModel.isPreparingModelStep = true
+        #expect(viewModel.transcriptionRowState() == .checking)
+    }
+
+    @Test("ready trumps checking when model already downloaded")
+    func readyTrumpsChecking() async throws {
+        let fixture = try makeCoreFixture(calendarAuthStatus: .denied)
+        defer { fixture.cleanup() }
+        // FakeTranscriber succeeds on modelsReady by default
+
+        let viewModel = OnboardingViewModel(core: fixture.core)
+        await viewModel.advance()
+        await viewModel.skip()
+
+        // Model is ready AND we simulate mid-preparation
+        viewModel.isPreparingModelStep = true
+        #expect(viewModel.transcriptionReady == true)
+        #expect(viewModel.transcriptionRowState() == .ready)
+    }
+}
+
 // MARK: - Language row-state mapping
 
 @Suite("OnboardingViewModel -- Language row state")
@@ -206,6 +243,64 @@ struct LanguageRowStateTests {
         await viewModel.skip()
 
         #expect(viewModel.languageRowState() == .insufficientDisk)
+    }
+}
+
+// MARK: - Language row-state checking
+
+@Suite("OnboardingViewModel -- Language row checking state")
+@MainActor
+struct LanguageRowCheckingTests {
+    @Test("checking when isPreparingModelStep and model not ready")
+    func checkingWhilePreparing() async throws {
+        let fixture = try makeCoreFixture(calendarAuthStatus: .denied)
+        defer { fixture.cleanup() }
+
+        let viewModel = OnboardingViewModel(core: fixture.core)
+        await viewModel.advance()
+        await viewModel.skip()
+
+        // Simulate mid-preparation
+        viewModel.isPreparingModelStep = true
+        #expect(viewModel.languageRowState() == .checking)
+    }
+
+    @Test("ready trumps checking when language model downloaded")
+    func readyTrumpsChecking() async throws {
+        let fixture = try makeCoreFixture(
+            calendarAuthStatus: .denied,
+            modelDownloaded: true
+        )
+        defer { fixture.cleanup() }
+
+        let viewModel = OnboardingViewModel(core: fixture.core)
+        await viewModel.advance()
+        await viewModel.skip()
+
+        viewModel.isPreparingModelStep = true
+        #expect(viewModel.languageReady == true)
+        #expect(viewModel.languageRowState() == .ready)
+    }
+
+    @Test("downloading trumps checking during in-flight download")
+    func downloadingTrumpsChecking() async throws {
+        let fixture = try makeCoreFixture(calendarAuthStatus: .denied)
+        defer { fixture.cleanup() }
+
+        let viewModel = OnboardingViewModel(core: fixture.core)
+        await viewModel.advance()
+        await viewModel.skip()
+
+        guard let targetID = viewModel.languageTargetModelID else {
+            Issue.record("No language target model ID")
+            return
+        }
+
+        // Simulate in-flight download AND mid-preparation
+        fixture.modelManager.downloads[targetID] = .downloading(fraction: 0.5)
+        viewModel.isPreparingModelStep = true
+
+        #expect(viewModel.languageRowState() == .downloading(.determinate(fraction: 0.5)))
     }
 }
 
@@ -385,6 +480,36 @@ struct ModelStepPreparationTests {
 
         // After refresh, the language model should be ready
         #expect(viewModel.languageReady == true)
+    }
+
+    @Test("isPreparingModelStep is false after skip completes")
+    func preparingFalseAfterSkip() async throws {
+        let fixture = try makeCoreFixture(calendarAuthStatus: .denied)
+        defer { fixture.cleanup() }
+
+        let viewModel = OnboardingViewModel(core: fixture.core)
+        await viewModel.advance() // welcome -> permissions
+        await viewModel.skip() // -> modelDownload (prepareModelStep runs and finishes)
+
+        #expect(viewModel.isPreparingModelStep == false)
+    }
+
+    @Test("isPreparingModelStep is false after advance completes")
+    func preparingFalseAfterAdvance() async throws {
+        let fixture = try makeCoreFixture(
+            calendarAuthStatus: .authorized,
+            modelDownloaded: true
+        )
+        defer { fixture.cleanup() }
+
+        let viewModel = OnboardingViewModel(core: fixture.core)
+        await viewModel.advance() // welcome -> permissions
+        await viewModel.requestCalendar()
+        await viewModel.advance() // -> calendarSelection
+        await viewModel.advance() // -> modelDownload (prepareModelStep runs)
+
+        #expect(viewModel.isPreparingModelStep == false)
+        #expect(viewModel.currentStep == .modelDownload)
     }
 
     @Test("prepareModelStep runs from calendarSelection path too")

--- a/Packages/BiscottiKit/Tests/OnboardingUITests/OnboardingModelRowStateTests.swift
+++ b/Packages/BiscottiKit/Tests/OnboardingUITests/OnboardingModelRowStateTests.swift
@@ -1,0 +1,472 @@
+import BiscottiTestSupport
+import DataStore
+import Intelligence
+import LocalLLM
+import Testing
+@testable import OnboardingUI
+
+// MARK: - Transcription row-state mapping
+
+@Suite("OnboardingViewModel -- Transcription row state")
+@MainActor
+struct TranscriptionRowStateTests {
+    @Test("idle when not downloaded, sufficient disk")
+    func transcriptionIdle() async throws {
+        let fixture = try makeCoreFixture(calendarAuthStatus: .denied)
+        defer { fixture.cleanup() }
+        // Prevent FakeTranscriber from reporting models as ready
+        fixture.fakeEngine.backing.ensureModelsError = FakeTranscriberError.notReady
+
+        let viewModel = OnboardingViewModel(core: fixture.core)
+        await viewModel.advance() // welcome -> permissions
+        await viewModel.skip() // -> modelDownload (prepareModelStep runs)
+
+        let state = viewModel.transcriptionRowState()
+        #expect(state == .idle(sizeCaption: "~1.5 GB"))
+    }
+
+    @Test("ready when transcription already downloaded on entry")
+    func transcriptionReadyOnEntry() async throws {
+        let fixture = try makeCoreFixture(calendarAuthStatus: .denied)
+        defer { fixture.cleanup() }
+        // FakeTranscriber succeeds on modelsReady by default
+
+        let viewModel = OnboardingViewModel(core: fixture.core)
+        await viewModel.advance() // welcome -> permissions
+        await viewModel.skip() // -> modelDownload
+
+        #expect(viewModel.transcriptionDownloaded == true)
+        #expect(viewModel.transcriptionRowState() == .ready)
+    }
+
+    @Test("ready after explicit transcription download completes")
+    func transcriptionReadyAfterDownload() async throws {
+        let fixture = try makeCoreFixture(calendarAuthStatus: .denied)
+        defer { fixture.cleanup() }
+        fixture.fakeEngine.backing.ensureModelsError = FakeTranscriberError.notReady
+
+        let viewModel = OnboardingViewModel(core: fixture.core)
+        await viewModel.advance()
+        await viewModel.skip()
+
+        #expect(viewModel.transcriptionRowState() == .idle(sizeCaption: "~1.5 GB"))
+
+        // Clear the error so download succeeds
+        fixture.fakeEngine.backing.ensureModelsError = nil
+        await viewModel.startTranscriptionDownload()
+
+        #expect(viewModel.downloadComplete == true)
+        #expect(viewModel.transcriptionRowState() == .ready)
+    }
+
+    @Test("insufficientDisk when disk is low")
+    func transcriptionInsufficientDisk() async throws {
+        let fixture = try makeCoreFixture(calendarAuthStatus: .denied)
+        defer { fixture.cleanup() }
+        fixture.fakeEngine.backing.ensureModelsError = FakeTranscriberError.notReady
+
+        let viewModel = OnboardingViewModel(
+            core: fixture.core,
+            availableDiskBytes: { 1_048_576 } // 1 MB -- well below threshold
+        )
+        await viewModel.advance()
+        await viewModel.skip()
+
+        #expect(viewModel.transcriptionRowState() == .insufficientDisk)
+    }
+
+    // Note: transcription downloading state (.indeterminate) can't be
+    // captured in a unit test because FakeTranscriber completes immediately.
+    // The mapper code path is covered by reading the switch in
+    // transcriptionRowState(); the language row's downloading path exercises
+    // the equivalent pattern with direct ModelManager state injection.
+
+    @Test("failed when download fails")
+    func transcriptionFailed() async throws {
+        let fixture = try makeCoreFixture(calendarAuthStatus: .denied)
+        defer { fixture.cleanup() }
+        fixture.fakeEngine.backing.ensureModelsError = FakeTranscriberError.notReady
+
+        let viewModel = OnboardingViewModel(core: fixture.core)
+        await viewModel.advance()
+        await viewModel.skip()
+
+        // Attempt download with the error set
+        await viewModel.startTranscriptionDownload()
+
+        // The error message contains "failed"
+        #expect(viewModel.transcriptionRowState() == .failed(message: "Download failed. You can retry or skip."))
+    }
+}
+
+// MARK: - Language row-state mapping
+
+@Suite("OnboardingViewModel -- Language row state")
+@MainActor
+struct LanguageRowStateTests {
+    @Test("idle with size caption when no model downloaded")
+    func languageIdle() async throws {
+        let fixture = try makeCoreFixture(calendarAuthStatus: .denied)
+        defer { fixture.cleanup() }
+
+        let viewModel = OnboardingViewModel(core: fixture.core)
+        await viewModel.advance()
+        await viewModel.skip()
+
+        let state = viewModel.languageRowState()
+        // Target should be the recommended model; size depends on catalog
+        if case let .idle(sizeCaption) = state {
+            #expect(!sizeCaption.isEmpty)
+        } else {
+            Issue.record("Expected .idle state, got \(state)")
+        }
+    }
+
+    @Test("ready when language model is downloaded")
+    func languageReady() async throws {
+        let fixture = try makeCoreFixture(
+            calendarAuthStatus: .denied,
+            modelDownloaded: true
+        )
+        defer { fixture.cleanup() }
+
+        let viewModel = OnboardingViewModel(core: fixture.core)
+        await viewModel.advance()
+        await viewModel.skip()
+
+        #expect(viewModel.languageRowState() == .ready)
+    }
+
+    @Test("downloading shows determinate progress")
+    func languageDownloading() async throws {
+        let fixture = try makeCoreFixture(calendarAuthStatus: .denied)
+        defer { fixture.cleanup() }
+
+        let viewModel = OnboardingViewModel(core: fixture.core)
+        await viewModel.advance()
+        await viewModel.skip()
+
+        // Simulate an in-flight download for the target model
+        guard let targetID = viewModel.languageTargetModelID else {
+            Issue.record("No language target model ID")
+            return
+        }
+        fixture.modelManager.downloads[targetID] = .downloading(fraction: 0.42)
+
+        #expect(viewModel.languageRowState() == .downloading(.determinate(fraction: 0.42)))
+    }
+
+    @Test("downloading with nil fraction shows determinate nil")
+    func languageDownloadingNilFraction() async throws {
+        let fixture = try makeCoreFixture(calendarAuthStatus: .denied)
+        defer { fixture.cleanup() }
+
+        let viewModel = OnboardingViewModel(core: fixture.core)
+        await viewModel.advance()
+        await viewModel.skip()
+
+        guard let targetID = viewModel.languageTargetModelID else {
+            Issue.record("No language target model ID")
+            return
+        }
+        fixture.modelManager.downloads[targetID] = .downloading(fraction: nil)
+
+        #expect(viewModel.languageRowState() == .downloading(.determinate(fraction: nil)))
+    }
+
+    @Test("failed when download fails")
+    func languageFailed() async throws {
+        let fixture = try makeCoreFixture(calendarAuthStatus: .denied)
+        defer { fixture.cleanup() }
+
+        let viewModel = OnboardingViewModel(core: fixture.core)
+        await viewModel.advance()
+        await viewModel.skip()
+
+        guard let targetID = viewModel.languageTargetModelID else {
+            Issue.record("No language target model ID")
+            return
+        }
+        fixture.modelManager.downloads[targetID] = .failed(message: "Network error")
+
+        #expect(viewModel.languageRowState() == .failed(message: "Network error"))
+    }
+
+    @Test("insufficientDisk when target model blocked by disk")
+    func languageInsufficientDisk() async throws {
+        // Report only 1 byte of free disk so ModelSuitability blocks all models
+        let fixture = try makeCoreFixture(
+            calendarAuthStatus: .denied,
+            hardwareDiskBytes: 1
+        )
+        defer { fixture.cleanup() }
+
+        let viewModel = OnboardingViewModel(core: fixture.core)
+        await viewModel.advance()
+        await viewModel.skip()
+
+        #expect(viewModel.languageRowState() == .insufficientDisk)
+    }
+}
+
+// MARK: - Target model
+
+@Suite("OnboardingViewModel -- Language target model")
+@MainActor
+struct LanguageTargetModelTests {
+    @Test("target is recommended model when nothing downloaded")
+    func targetIsRecommended() throws {
+        let fixture = try makeCoreFixture(calendarAuthStatus: .denied)
+        defer { fixture.cleanup() }
+
+        let viewModel = OnboardingViewModel(core: fixture.core)
+        let recommended = fixture.modelManager.recommendedModelID()
+        #expect(viewModel.languageTargetModelID == recommended)
+        #expect(recommended != nil)
+    }
+
+    @Test("target is active model when one is downloaded")
+    func targetIsActive() async throws {
+        let fixture = try makeCoreFixture(
+            calendarAuthStatus: .denied,
+            modelDownloaded: true
+        )
+        defer { fixture.cleanup() }
+        await fixture.modelManager.refresh()
+
+        let viewModel = OnboardingViewModel(core: fixture.core)
+        let active = fixture.modelManager.activeModelID
+        #expect(active != nil)
+        #expect(viewModel.languageTargetModelID == active)
+    }
+
+    @Test("recommended display name is non-nil and non-empty")
+    func recommendedDisplayName() throws {
+        let fixture = try makeCoreFixture(calendarAuthStatus: .denied)
+        defer { fixture.cleanup() }
+
+        let viewModel = OnboardingViewModel(core: fixture.core)
+        let name = try #require(viewModel.recommendedLanguageDisplayName)
+        #expect(!name.isEmpty)
+    }
+
+    @Test("low-RAM Mac targets E2B (not 12B)")
+    func lowRAMTargetsE2B() throws {
+        // 12GB RAM: below the 15GB floor for 12B
+        let fixture = try makeCoreFixture(
+            calendarAuthStatus: .denied,
+            hardwareRAMBytes: 12_000_000_000
+        )
+        defer { fixture.cleanup() }
+
+        let viewModel = OnboardingViewModel(core: fixture.core)
+        #expect(viewModel.languageTargetModelID == "gemma-4-e2b")
+    }
+}
+
+// MARK: - Footer matrix (both models)
+
+@Suite("OnboardingViewModel -- Footer matrix (both models)")
+@MainActor
+struct FooterMatrixTests {
+    @Test("neither ready shows skip")
+    func neitherReadyShowsSkip() async throws {
+        let fixture = try makeCoreFixture(calendarAuthStatus: .denied)
+        defer { fixture.cleanup() }
+        fixture.fakeEngine.backing.ensureModelsError = FakeTranscriberError.notReady
+
+        let viewModel = OnboardingViewModel(core: fixture.core)
+        await viewModel.advance()
+        await viewModel.skip()
+
+        #expect(viewModel.transcriptionReady == false)
+        #expect(viewModel.languageReady == false)
+        #expect(viewModel.bothModelsReady == false)
+        #expect(viewModel.footerButton(for: .modelDownload) == .skip)
+    }
+
+    @Test("only transcription ready shows skip")
+    func onlyTranscriptionReadyShowsSkip() async throws {
+        let fixture = try makeCoreFixture(calendarAuthStatus: .denied)
+        defer { fixture.cleanup() }
+        // FakeTranscriber succeeds -> transcription ready; no language model
+
+        let viewModel = OnboardingViewModel(core: fixture.core)
+        await viewModel.advance()
+        await viewModel.skip()
+
+        #expect(viewModel.transcriptionReady == true)
+        #expect(viewModel.languageReady == false)
+        #expect(viewModel.footerButton(for: .modelDownload) == .skip)
+    }
+
+    @Test("only language ready shows skip")
+    func onlyLanguageReadyShowsSkip() async throws {
+        let fixture = try makeCoreFixture(
+            calendarAuthStatus: .denied,
+            modelDownloaded: true
+        )
+        defer { fixture.cleanup() }
+        fixture.fakeEngine.backing.ensureModelsError = FakeTranscriberError.notReady
+
+        let viewModel = OnboardingViewModel(core: fixture.core)
+        await viewModel.advance()
+        await viewModel.skip()
+
+        #expect(viewModel.transcriptionReady == false)
+        #expect(viewModel.languageReady == true)
+        #expect(viewModel.footerButton(for: .modelDownload) == .skip)
+    }
+
+    @Test("both ready shows continue")
+    func bothReadyShowsContinue() async throws {
+        let fixture = try makeCoreFixture(
+            calendarAuthStatus: .denied,
+            modelDownloaded: true
+        )
+        defer { fixture.cleanup() }
+        // FakeTranscriber succeeds -> transcription ready; model pre-downloaded
+
+        let viewModel = OnboardingViewModel(core: fixture.core)
+        await viewModel.advance()
+        await viewModel.skip()
+
+        #expect(viewModel.transcriptionReady == true)
+        #expect(viewModel.languageReady == true)
+        #expect(viewModel.bothModelsReady == true)
+        #expect(viewModel.footerButton(for: .modelDownload) == .continueButton)
+    }
+}
+
+// MARK: - On-entry preparation
+
+@Suite("OnboardingViewModel -- Model step preparation")
+@MainActor
+struct ModelStepPreparationTests {
+    @Test("prepareModelStep sets transcriptionDownloaded from probe")
+    func prepareSetsTxDownloaded() async throws {
+        let fixture = try makeCoreFixture(calendarAuthStatus: .denied)
+        defer { fixture.cleanup() }
+
+        let viewModel = OnboardingViewModel(core: fixture.core)
+        #expect(viewModel.transcriptionDownloaded == false)
+
+        await viewModel.advance() // welcome -> permissions
+        await viewModel.skip() // -> modelDownload (prepareModelStep runs)
+
+        // FakeTranscriber reports ready by default
+        #expect(viewModel.transcriptionDownloaded == true)
+    }
+
+    @Test("prepareModelStep sets transcriptionDownloaded false when not ready")
+    func prepareSetsTxNotDownloaded() async throws {
+        let fixture = try makeCoreFixture(calendarAuthStatus: .denied)
+        defer { fixture.cleanup() }
+        fixture.fakeEngine.backing.ensureModelsError = FakeTranscriberError.notReady
+
+        let viewModel = OnboardingViewModel(core: fixture.core)
+        await viewModel.advance()
+        await viewModel.skip()
+
+        #expect(viewModel.transcriptionDownloaded == false)
+    }
+
+    @Test("prepareModelStep refreshes ModelManager so downloaded model shows ready")
+    func prepareRefreshesModelManager() async throws {
+        let fixture = try makeCoreFixture(
+            calendarAuthStatus: .denied,
+            modelDownloaded: true
+        )
+        defer { fixture.cleanup() }
+
+        let viewModel = OnboardingViewModel(core: fixture.core)
+        await viewModel.advance()
+        await viewModel.skip()
+
+        // After refresh, the language model should be ready
+        #expect(viewModel.languageReady == true)
+    }
+
+    @Test("prepareModelStep runs from calendarSelection path too")
+    func prepareRunsFromCalendarPath() async throws {
+        let fixture = try makeCoreFixture(
+            calendarAuthStatus: .authorized,
+            modelDownloaded: true
+        )
+        defer { fixture.cleanup() }
+
+        let viewModel = OnboardingViewModel(core: fixture.core)
+        await viewModel.advance() // welcome -> permissions
+        await viewModel.requestCalendar()
+        await viewModel.advance() // -> calendarSelection
+        await viewModel.advance() // -> modelDownload (prepareModelStep runs)
+
+        #expect(viewModel.currentStep == .modelDownload)
+        #expect(viewModel.transcriptionDownloaded == true)
+        #expect(viewModel.languageReady == true)
+    }
+}
+
+// MARK: - Skip/advance from model download
+
+@Suite("OnboardingViewModel -- Skip/advance from model download")
+@MainActor
+struct ModelDownloadNavigationTests {
+    @Test("skip advances to done regardless of readiness")
+    func skipAdvancesToDone() async throws {
+        let fixture = try makeCoreFixture(calendarAuthStatus: .denied)
+        defer { fixture.cleanup() }
+        fixture.fakeEngine.backing.ensureModelsError = FakeTranscriberError.notReady
+
+        let viewModel = OnboardingViewModel(core: fixture.core)
+        await viewModel.advance() // welcome -> permissions
+        await viewModel.skip() // -> modelDownload
+
+        #expect(viewModel.bothModelsReady == false)
+        await viewModel.skip() // -> done
+        #expect(viewModel.currentStep == .done)
+    }
+
+    @Test("advance advances to done when both ready")
+    func advanceAdvancesToDone() async throws {
+        let fixture = try makeCoreFixture(
+            calendarAuthStatus: .denied,
+            modelDownloaded: true
+        )
+        defer { fixture.cleanup() }
+
+        let viewModel = OnboardingViewModel(core: fixture.core)
+        await viewModel.advance()
+        await viewModel.skip()
+
+        #expect(viewModel.bothModelsReady == true)
+        await viewModel.advance()
+        #expect(viewModel.currentStep == .done)
+    }
+}
+
+// MARK: - Format bytes helper
+
+@Suite("OnboardingViewModel -- formatBytes")
+@MainActor
+struct FormatBytesTests {
+    @Test("formats whole gigabytes without decimal")
+    func wholeGB() {
+        #expect(OnboardingViewModel.formatBytes(3_000_000_000) == "~3 GB")
+        #expect(OnboardingViewModel.formatBytes(7_000_000_000) == "~7 GB")
+    }
+
+    @Test("formats fractional gigabytes with one decimal")
+    func fractionalGB() {
+        #expect(OnboardingViewModel.formatBytes(3_200_000_000) == "~3.2 GB")
+        #expect(OnboardingViewModel.formatBytes(1_500_000_000) == "~1.5 GB")
+    }
+}
+
+// MARK: - Test helpers
+
+/// Error used to make FakeTranscriber's `ensureModelsDownloaded` fail,
+/// simulating models not being cached on disk.
+private enum FakeTranscriberError: Error {
+    case notReady
+}

--- a/Packages/BiscottiKit/Tests/OnboardingUITests/OnboardingModelRowStateTests.swift
+++ b/Packages/BiscottiKit/Tests/OnboardingUITests/OnboardingModelRowStateTests.swift
@@ -364,7 +364,7 @@ struct LanguageTargetModelTests {
 @Suite("OnboardingViewModel -- Footer matrix (both models)")
 @MainActor
 struct FooterMatrixTests {
-    @Test("neither ready shows skip")
+    @Test("neither ready nor downloading shows skip")
     func neitherReadyShowsSkip() async throws {
         let fixture = try makeCoreFixture(calendarAuthStatus: .denied)
         defer { fixture.cleanup() }
@@ -377,10 +377,11 @@ struct FooterMatrixTests {
         #expect(viewModel.transcriptionReady == false)
         #expect(viewModel.languageReady == false)
         #expect(viewModel.bothModelsReady == false)
+        #expect(viewModel.bothModelsStarted == false)
         #expect(viewModel.footerButton(for: .modelDownload) == .skip)
     }
 
-    @Test("only transcription ready shows skip")
+    @Test("only transcription ready (language not started) shows skip")
     func onlyTranscriptionReadyShowsSkip() async throws {
         let fixture = try makeCoreFixture(calendarAuthStatus: .denied)
         defer { fixture.cleanup() }
@@ -392,10 +393,11 @@ struct FooterMatrixTests {
 
         #expect(viewModel.transcriptionReady == true)
         #expect(viewModel.languageReady == false)
+        #expect(viewModel.bothModelsStarted == false)
         #expect(viewModel.footerButton(for: .modelDownload) == .skip)
     }
 
-    @Test("only language ready shows skip")
+    @Test("only language ready (transcription not started) shows skip")
     func onlyLanguageReadyShowsSkip() async throws {
         let fixture = try makeCoreFixture(
             calendarAuthStatus: .denied,
@@ -410,6 +412,7 @@ struct FooterMatrixTests {
 
         #expect(viewModel.transcriptionReady == false)
         #expect(viewModel.languageReady == true)
+        #expect(viewModel.bothModelsStarted == false)
         #expect(viewModel.footerButton(for: .modelDownload) == .skip)
     }
 
@@ -429,7 +432,199 @@ struct FooterMatrixTests {
         #expect(viewModel.transcriptionReady == true)
         #expect(viewModel.languageReady == true)
         #expect(viewModel.bothModelsReady == true)
+        #expect(viewModel.bothModelsStarted == true)
         #expect(viewModel.footerButton(for: .modelDownload) == .continueButton)
+    }
+
+    @Test("both downloading shows continue")
+    func bothDownloadingShowsContinue() async throws {
+        let fixture = try makeCoreFixture(calendarAuthStatus: .denied)
+        defer { fixture.cleanup() }
+        fixture.fakeEngine.backing.ensureModelsError = FakeTranscriberError.notReady
+
+        let viewModel = OnboardingViewModel(core: fixture.core)
+        await viewModel.advance()
+        await viewModel.skip()
+
+        // Simulate transcription downloading
+        viewModel.isDownloading = true
+
+        // Simulate language model downloading
+        guard let targetID = viewModel.languageTargetModelID else {
+            Issue.record("No language target model ID")
+            return
+        }
+        fixture.modelManager.downloads[targetID] = .downloading(fraction: 0.3)
+
+        #expect(viewModel.transcriptionStarted == true)
+        #expect(viewModel.languageStarted == true)
+        #expect(viewModel.bothModelsStarted == true)
+        #expect(viewModel.bothModelsReady == false)
+        #expect(viewModel.footerButton(for: .modelDownload) == .continueButton)
+    }
+
+    @Test("transcription ready + language downloading shows continue")
+    func transcriptionReadyLanguageDownloadingShowsContinue() async throws {
+        let fixture = try makeCoreFixture(calendarAuthStatus: .denied)
+        defer { fixture.cleanup() }
+        // FakeTranscriber succeeds -> transcription ready
+
+        let viewModel = OnboardingViewModel(core: fixture.core)
+        await viewModel.advance()
+        await viewModel.skip()
+
+        // Simulate language model downloading
+        guard let targetID = viewModel.languageTargetModelID else {
+            Issue.record("No language target model ID")
+            return
+        }
+        fixture.modelManager.downloads[targetID] = .downloading(fraction: 0.5)
+
+        #expect(viewModel.transcriptionReady == true)
+        #expect(viewModel.languageStarted == true)
+        #expect(viewModel.bothModelsStarted == true)
+        #expect(viewModel.footerButton(for: .modelDownload) == .continueButton)
+    }
+
+    @Test("transcription downloading + language ready shows continue")
+    func transcriptionDownloadingLanguageReadyShowsContinue() async throws {
+        let fixture = try makeCoreFixture(
+            calendarAuthStatus: .denied,
+            modelDownloaded: true
+        )
+        defer { fixture.cleanup() }
+        fixture.fakeEngine.backing.ensureModelsError = FakeTranscriberError.notReady
+
+        let viewModel = OnboardingViewModel(core: fixture.core)
+        await viewModel.advance()
+        await viewModel.skip()
+
+        // Simulate transcription downloading
+        viewModel.isDownloading = true
+
+        #expect(viewModel.transcriptionStarted == true)
+        #expect(viewModel.languageReady == true)
+        #expect(viewModel.bothModelsStarted == true)
+        #expect(viewModel.footerButton(for: .modelDownload) == .continueButton)
+    }
+}
+
+// MARK: - bothModelsStarted derivation
+
+@Suite("OnboardingViewModel -- bothModelsStarted")
+@MainActor
+struct BothModelsStartedTests {
+    @Test("neither started is false")
+    func neitherStarted() async throws {
+        let fixture = try makeCoreFixture(calendarAuthStatus: .denied)
+        defer { fixture.cleanup() }
+        fixture.fakeEngine.backing.ensureModelsError = FakeTranscriberError.notReady
+
+        let viewModel = OnboardingViewModel(core: fixture.core)
+        await viewModel.advance()
+        await viewModel.skip()
+
+        #expect(viewModel.transcriptionStarted == false)
+        #expect(viewModel.languageStarted == false)
+        #expect(viewModel.bothModelsStarted == false)
+    }
+
+    @Test("only transcription started is false")
+    func onlyTranscriptionStarted() async throws {
+        let fixture = try makeCoreFixture(calendarAuthStatus: .denied)
+        defer { fixture.cleanup() }
+        fixture.fakeEngine.backing.ensureModelsError = FakeTranscriberError.notReady
+
+        let viewModel = OnboardingViewModel(core: fixture.core)
+        await viewModel.advance()
+        await viewModel.skip()
+
+        // Simulate transcription downloading
+        viewModel.isDownloading = true
+
+        #expect(viewModel.transcriptionStarted == true)
+        #expect(viewModel.languageStarted == false)
+        #expect(viewModel.bothModelsStarted == false)
+    }
+
+    @Test("only language started is false")
+    func onlyLanguageStarted() async throws {
+        let fixture = try makeCoreFixture(calendarAuthStatus: .denied)
+        defer { fixture.cleanup() }
+        fixture.fakeEngine.backing.ensureModelsError = FakeTranscriberError.notReady
+
+        let viewModel = OnboardingViewModel(core: fixture.core)
+        await viewModel.advance()
+        await viewModel.skip()
+
+        // Simulate language model downloading
+        guard let targetID = viewModel.languageTargetModelID else {
+            Issue.record("No language target model ID")
+            return
+        }
+        fixture.modelManager.downloads[targetID] = .downloading(fraction: 0.1)
+
+        #expect(viewModel.transcriptionStarted == false)
+        #expect(viewModel.languageStarted == true)
+        #expect(viewModel.bothModelsStarted == false)
+    }
+
+    @Test("both downloading is true")
+    func bothDownloading() async throws {
+        let fixture = try makeCoreFixture(calendarAuthStatus: .denied)
+        defer { fixture.cleanup() }
+        fixture.fakeEngine.backing.ensureModelsError = FakeTranscriberError.notReady
+
+        let viewModel = OnboardingViewModel(core: fixture.core)
+        await viewModel.advance()
+        await viewModel.skip()
+
+        viewModel.isDownloading = true
+        guard let targetID = viewModel.languageTargetModelID else {
+            Issue.record("No language target model ID")
+            return
+        }
+        fixture.modelManager.downloads[targetID] = .downloading(fraction: 0.5)
+
+        #expect(viewModel.bothModelsStarted == true)
+    }
+
+    @Test("both ready is true")
+    func bothReady() async throws {
+        let fixture = try makeCoreFixture(
+            calendarAuthStatus: .denied,
+            modelDownloaded: true
+        )
+        defer { fixture.cleanup() }
+        // FakeTranscriber succeeds -> transcription ready; model pre-downloaded
+
+        let viewModel = OnboardingViewModel(core: fixture.core)
+        await viewModel.advance()
+        await viewModel.skip()
+
+        #expect(viewModel.bothModelsReady == true)
+        #expect(viewModel.bothModelsStarted == true)
+    }
+
+    @Test("one ready + one downloading is true")
+    func oneReadyOneDownloading() async throws {
+        let fixture = try makeCoreFixture(calendarAuthStatus: .denied)
+        defer { fixture.cleanup() }
+        // FakeTranscriber succeeds -> transcription ready
+
+        let viewModel = OnboardingViewModel(core: fixture.core)
+        await viewModel.advance()
+        await viewModel.skip()
+
+        guard let targetID = viewModel.languageTargetModelID else {
+            Issue.record("No language target model ID")
+            return
+        }
+        fixture.modelManager.downloads[targetID] = .downloading(fraction: 0.7)
+
+        #expect(viewModel.transcriptionReady == true)
+        #expect(viewModel.languageStarted == true)
+        #expect(viewModel.bothModelsStarted == true)
     }
 }
 

--- a/Packages/BiscottiKit/Tests/OnboardingUITests/OnboardingModelRowStateTests.swift
+++ b/Packages/BiscottiKit/Tests/OnboardingUITests/OnboardingModelRowStateTests.swift
@@ -336,14 +336,24 @@ struct LanguageTargetModelTests {
         #expect(viewModel.languageTargetModelID == active)
     }
 
-    @Test("recommended display name is non-nil and non-empty")
-    func recommendedDisplayName() throws {
+    @Test("target display name is non-nil and non-empty")
+    func targetDisplayName() throws {
         let fixture = try makeCoreFixture(calendarAuthStatus: .denied)
         defer { fixture.cleanup() }
 
         let viewModel = OnboardingViewModel(core: fixture.core)
-        let name = try #require(viewModel.recommendedLanguageDisplayName)
+        let name = try #require(viewModel.languageTargetDisplayName)
         #expect(!name.isEmpty)
+    }
+
+    @Test("target is recommended when no downloads or selection")
+    func targetIsRecommendedByDefault() throws {
+        let fixture = try makeCoreFixture(calendarAuthStatus: .denied)
+        defer { fixture.cleanup() }
+
+        let viewModel = OnboardingViewModel(core: fixture.core)
+        #expect(viewModel.languageTargetIsRecommended == true)
+        #expect(try viewModel.languageTargetDisplayName == LLMModelCatalog.model(id: #require(fixture.modelManager.recommendedModelID()))?.displayName)
     }
 
     @Test("low-RAM Mac targets E2B (not 12B)")
@@ -357,6 +367,133 @@ struct LanguageTargetModelTests {
 
         let viewModel = OnboardingViewModel(core: fixture.core)
         #expect(viewModel.languageTargetModelID == "gemma-4-e2b")
+    }
+
+    @Test("in-flight non-recommended download becomes the target")
+    func inflightNonRecommendedBecomesTarget() async throws {
+        let fixture = try makeCoreFixture(calendarAuthStatus: .denied)
+        defer { fixture.cleanup() }
+
+        let viewModel = OnboardingViewModel(core: fixture.core)
+        await viewModel.advance()
+        await viewModel.skip()
+
+        // The recommended model on 32GB is gemma-4-12b; inject a download
+        // for the non-recommended gemma-4-e2b.
+        let nonRecommendedID = "gemma-4-e2b"
+        #expect(nonRecommendedID != fixture.modelManager.recommendedModelID())
+
+        fixture.modelManager.downloads[nonRecommendedID] = .downloading(fraction: 0.35)
+
+        #expect(viewModel.languageTargetModelID == nonRecommendedID)
+        #expect(viewModel.languageTargetIsRecommended == false)
+        #expect(viewModel.languageTargetDisplayName == LLMModelCatalog.model(id: nonRecommendedID)?.displayName)
+        #expect(viewModel.languageRowState() == .downloading(.determinate(fraction: 0.35)))
+        // Language started should be true (download in flight)
+        #expect(viewModel.languageStarted == true)
+    }
+
+    @Test("in-flight non-recommended download makes bothModelsStarted true")
+    func inflightNonRecommendedBothStarted() async throws {
+        let fixture = try makeCoreFixture(calendarAuthStatus: .denied)
+        defer { fixture.cleanup() }
+        // FakeTranscriber succeeds -> transcription ready
+
+        let viewModel = OnboardingViewModel(core: fixture.core)
+        await viewModel.advance()
+        await viewModel.skip()
+
+        let nonRecommendedID = "gemma-4-e2b"
+        fixture.modelManager.downloads[nonRecommendedID] = .downloading(fraction: 0.5)
+
+        #expect(viewModel.transcriptionStarted == true)
+        #expect(viewModel.languageStarted == true)
+        #expect(viewModel.bothModelsStarted == true)
+    }
+
+    @Test("selected model (via DataStore) drives target when no download or active model")
+    func selectedModelDrivesTarget() async throws {
+        let fixture = try makeCoreFixture(calendarAuthStatus: .denied)
+        defer { fixture.cleanup() }
+
+        // Persist a non-recommended selection via the DataStore, then refresh
+        // ModelManager so it picks up the persisted value.
+        let nonRecommendedID = "gemma-4-e2b"
+        try await fixture.store.updateSettings { $0.selectedModelID = nonRecommendedID }
+        await fixture.modelManager.refresh()
+
+        // No model is downloaded, so activeModelID is nil. The target should
+        // fall through to the persisted selectedModelID (priority 4).
+        #expect(fixture.modelManager.activeModelID == nil)
+        #expect(fixture.modelManager.selectedModelID == nonRecommendedID)
+
+        let viewModel = OnboardingViewModel(core: fixture.core)
+        #expect(viewModel.languageTargetModelID == nonRecommendedID)
+        #expect(viewModel.languageTargetIsRecommended == false)
+    }
+
+    @Test("downloading wins over a stale failed entry")
+    func downloadingWinsOverFailed() async throws {
+        let fixture = try makeCoreFixture(calendarAuthStatus: .denied)
+        defer { fixture.cleanup() }
+
+        let viewModel = OnboardingViewModel(core: fixture.core)
+        await viewModel.advance()
+        await viewModel.skip()
+
+        // Simulate: one model failed (stale), another is downloading
+        fixture.modelManager.downloads["gemma-4-12b"] = .failed(message: "Stale error")
+        fixture.modelManager.downloads["gemma-4-e2b"] = .downloading(fraction: 0.6)
+
+        // The actively downloading model should win (priority 1 > priority 3)
+        #expect(viewModel.languageTargetModelID == "gemma-4-e2b")
+        #expect(viewModel.languageRowState() == .downloading(.determinate(fraction: 0.6)))
+        #expect(viewModel.languageStarted == true)
+    }
+
+    @Test("failed does not shadow an active model")
+    func failedDoesNotShadowActive() async throws {
+        let fixture = try makeCoreFixture(
+            calendarAuthStatus: .denied,
+            modelDownloaded: true
+        )
+        defer { fixture.cleanup() }
+        await fixture.modelManager.refresh()
+
+        let activeID = fixture.modelManager.activeModelID
+        #expect(activeID != nil)
+
+        let viewModel = OnboardingViewModel(core: fixture.core)
+        await viewModel.advance()
+        await viewModel.skip()
+
+        // Inject a failed download for a different model
+        let otherID = "gemma-4-e2b"
+        #expect(otherID != activeID)
+        fixture.modelManager.downloads[otherID] = .failed(message: "Network error")
+
+        // Active model (priority 2) should win over failed (priority 3)
+        #expect(viewModel.languageTargetModelID == activeID)
+        #expect(viewModel.languageRowState() == .ready)
+    }
+
+    @Test("failed target does not count as languageStarted")
+    func failedTargetNotStarted() async throws {
+        let fixture = try makeCoreFixture(calendarAuthStatus: .denied)
+        defer { fixture.cleanup() }
+
+        let viewModel = OnboardingViewModel(core: fixture.core)
+        await viewModel.advance()
+        await viewModel.skip()
+
+        // Inject a failed download -- target resolves to it (no active model)
+        let failedID = "gemma-4-e2b"
+        fixture.modelManager.downloads[failedID] = .failed(message: "Oops")
+
+        #expect(viewModel.languageTargetModelID == failedID)
+        // languageStarted intentionally treats only .downloading as started
+        #expect(viewModel.languageStarted == false)
+        #expect(viewModel.bothModelsStarted == false)
     }
 }
 

--- a/Packages/BiscottiKit/Tests/OnboardingUITests/OnboardingModelRowStateTests.swift
+++ b/Packages/BiscottiKit/Tests/OnboardingUITests/OnboardingModelRowStateTests.swift
@@ -962,6 +962,116 @@ struct FormatBytesTests {
     }
 }
 
+// MARK: - Footer caption
+
+@Suite("OnboardingViewModel -- Footer caption")
+@MainActor
+struct FooterCaptionTests {
+    @Test("caption shows when both models downloading (Continue visible, downloads active)")
+    func captionShowsWhenBothDownloading() async throws {
+        let fixture = try makeCoreFixture(calendarAuthStatus: .denied)
+        defer { fixture.cleanup() }
+        fixture.fakeEngine.backing.modelsPresentResult = false
+
+        let viewModel = OnboardingViewModel(core: fixture.core)
+        await viewModel.advance() // welcome -> permissions
+        await viewModel.skip() // -> modelDownload
+
+        // Simulate both downloading
+        viewModel.isDownloading = true
+        guard let targetID = viewModel.languageTargetModelID else {
+            Issue.record("No language target model ID")
+            return
+        }
+        fixture.modelManager.downloads[targetID] = .downloading(fraction: 0.3)
+
+        #expect(viewModel.bothModelsStarted == true)
+        #expect(viewModel.bothModelsReady == false)
+        #expect(viewModel.footerCaption == "Downloads will continue in the background")
+    }
+
+    @Test("caption shows when one ready and one downloading")
+    func captionShowsWhenOneReadyOneDownloading() async throws {
+        let fixture = try makeCoreFixture(calendarAuthStatus: .denied)
+        defer { fixture.cleanup() }
+        // FakeTranscriber succeeds -> transcription ready
+
+        let viewModel = OnboardingViewModel(core: fixture.core)
+        await viewModel.advance()
+        await viewModel.skip()
+
+        // Simulate language downloading (transcription already ready)
+        guard let targetID = viewModel.languageTargetModelID else {
+            Issue.record("No language target model ID")
+            return
+        }
+        fixture.modelManager.downloads[targetID] = .downloading(fraction: 0.5)
+
+        #expect(viewModel.transcriptionReady == true)
+        #expect(viewModel.languageStarted == true)
+        #expect(viewModel.bothModelsStarted == true)
+        #expect(viewModel.bothModelsReady == false)
+        #expect(viewModel.footerCaption == "Downloads will continue in the background")
+    }
+
+    @Test("caption blank when both models ready")
+    func captionBlankWhenBothReady() async throws {
+        let fixture = try makeCoreFixture(
+            calendarAuthStatus: .denied,
+            modelDownloaded: true
+        )
+        defer { fixture.cleanup() }
+
+        let viewModel = OnboardingViewModel(core: fixture.core)
+        await viewModel.advance()
+        await viewModel.skip()
+
+        #expect(viewModel.bothModelsReady == true)
+        #expect(viewModel.footerCaption == "")
+    }
+
+    @Test("caption blank when neither model started (Skip showing)")
+    func captionBlankWhenNeitherStarted() async throws {
+        let fixture = try makeCoreFixture(calendarAuthStatus: .denied)
+        defer { fixture.cleanup() }
+        fixture.fakeEngine.backing.modelsPresentResult = false
+
+        let viewModel = OnboardingViewModel(core: fixture.core)
+        await viewModel.advance()
+        await viewModel.skip()
+
+        #expect(viewModel.bothModelsStarted == false)
+        #expect(viewModel.footerCaption == "")
+    }
+
+    @Test("caption blank on non-model steps")
+    func captionBlankOnNonModelSteps() throws {
+        let fixture = try makeCoreFixture()
+        defer { fixture.cleanup() }
+
+        let viewModel = OnboardingViewModel(core: fixture.core)
+
+        // Welcome step
+        #expect(viewModel.currentStep == .welcome)
+        #expect(viewModel.footerCaption == "")
+    }
+
+    @Test("caption blank on permissions step")
+    func captionBlankOnPermissionsStep() async throws {
+        let fixture = try makeCoreFixture(
+            micStatus: .notDetermined,
+            calendarAuthStatus: .notDetermined
+        )
+        defer { fixture.cleanup() }
+
+        let viewModel = OnboardingViewModel(core: fixture.core)
+        await viewModel.advance() // welcome -> permissions
+
+        #expect(viewModel.currentStep == .permissions)
+        #expect(viewModel.footerCaption == "")
+    }
+}
+
 // MARK: - Test helpers
 
 /// Error used to make FakeTranscriber's `ensureModelsDownloaded` fail,

--- a/Packages/BiscottiKit/Tests/OnboardingUITests/OnboardingViewModelTests.swift
+++ b/Packages/BiscottiKit/Tests/OnboardingUITests/OnboardingViewModelTests.swift
@@ -145,7 +145,7 @@ struct OnboardingViewModelTests {
 
         #expect(model.currentStep == .modelDownload)
 
-        await model.startDownload()
+        await model.startTranscriptionDownload()
         // FakeTranscriber's ensureModelsDownloaded succeeds immediately
         #expect(model.downloadComplete == true)
         #expect(model.isDownloading == false)
@@ -266,7 +266,7 @@ struct OnboardingViewModelTests {
         #expect(model.currentStep == .modelDownload)
 
         // Mutate some state to verify reset clears it
-        await model.startDownload()
+        await model.startTranscriptionDownload()
         #expect(model.downloadComplete == true)
 
         // Reset
@@ -282,6 +282,9 @@ struct OnboardingViewModelTests {
         #expect(model.downloadStatus == nil)
         #expect(model.isDownloading == false)
         #expect(model.downloadComplete == false)
+        #expect(model.downloadFailed == false)
+        #expect(model.transcriptionDownloaded == false)
+        #expect(model.showVariantSheet == false)
         #expect(model.hasSufficientDisk == true)
     }
 }

--- a/Packages/BiscottiKit/Tests/OnboardingUITests/OnboardingViewModelTests.swift
+++ b/Packages/BiscottiKit/Tests/OnboardingUITests/OnboardingViewModelTests.swift
@@ -284,6 +284,7 @@ struct OnboardingViewModelTests {
         #expect(model.downloadComplete == false)
         #expect(model.downloadFailed == false)
         #expect(model.transcriptionDownloaded == false)
+        #expect(model.isPreparingModelStep == false)
         #expect(model.showVariantSheet == false)
         #expect(model.hasSufficientDisk == true)
     }

--- a/Packages/BiscottiKit/Tests/SettingsUITests/ManageModelsViewModelTests.swift
+++ b/Packages/BiscottiKit/Tests/SettingsUITests/ManageModelsViewModelTests.swift
@@ -1,0 +1,263 @@
+import AppCore
+import BiscottiTestSupport
+import Foundation
+import Intelligence
+import LocalLLM
+import Testing
+@testable import SettingsUI
+
+@Suite("ManageModelsViewModel")
+@MainActor
+struct ManageModelsViewModelTests {
+    // MARK: - modelChoices delegation
+
+    @Test("modelChoices delegates to ModelManager")
+    func modelChoicesDelegation() throws {
+        let fixture = try makeCoreFixture(modelDownloaded: true)
+        defer { fixture.cleanup() }
+
+        let viewModel = ManageModelsViewModel(core: fixture.core)
+        let choices = viewModel.modelChoices
+
+        // Should have all catalog models
+        #expect(choices.count == LLMModelCatalog.all.count)
+
+        // The first catalog model is downloaded
+        let firstChoice = choices.first
+        #expect(firstChoice?.isDownloaded == true)
+    }
+
+    @Test("modelChoices reflects blocked state for low-RAM Mac")
+    func modelChoicesBlockedState() throws {
+        // Build a fixture with 8 GB RAM so the 12B model is not runnable.
+        let fixture = try makeCoreFixture(
+            modelDownloaded: false,
+            hardwareRAMBytes: 8_000_000_000
+        )
+        defer { fixture.cleanup() }
+
+        let viewModel = ManageModelsViewModel(core: fixture.core)
+        let choices = viewModel.modelChoices
+
+        // With 8 GB RAM, the 12B model should be blocked (cannotRun).
+        let choice12b = choices.first { $0.model.id == "gemma-4-12b" }
+        #expect(choice12b?.runnable == false)
+        #expect(choice12b?.blockedReason == .cannotRun)
+
+        // The smaller E2B model should still be runnable.
+        let choiceE2b = choices.first { $0.model.id == "gemma-4-e2b" }
+        #expect(choiceE2b?.runnable == true)
+        #expect(choiceE2b?.blockedReason == nil)
+    }
+
+    @Test("modelChoices shows recommended badge on correct model")
+    func modelChoicesRecommended() throws {
+        let fixture = try makeCoreFixture(modelDownloaded: false)
+        defer { fixture.cleanup() }
+
+        let viewModel = ManageModelsViewModel(core: fixture.core)
+        let choices = viewModel.modelChoices
+
+        // With 32 GB RAM (default fixture), 12B should be recommended
+        let recommended = choices.filter(\.isRecommended)
+        #expect(recommended.count == 1)
+        #expect(recommended.first?.model.id == "gemma-4-12b")
+    }
+
+    @Test("modelChoices marks selected model correctly")
+    func modelChoicesSelected() async throws {
+        let fixture = try makeCoreFixture(modelDownloaded: true)
+        defer { fixture.cleanup() }
+
+        // Refresh to populate selection
+        await fixture.modelManager.refresh()
+
+        let viewModel = ManageModelsViewModel(core: fixture.core)
+        let choices = viewModel.modelChoices
+
+        let selected = choices.filter(\.isSelected)
+        #expect(selected.count == 1)
+        #expect(selected.first?.isDownloaded == true)
+    }
+
+    // MARK: - Action delegation
+
+    @Test("download delegates to ModelManager")
+    func downloadDelegation() async throws {
+        let fixture = try makeCoreFixture(modelDownloaded: false)
+        defer { fixture.cleanup() }
+
+        let viewModel = ManageModelsViewModel(core: fixture.core)
+
+        // Before download
+        #expect(fixture.modelManager.isModelAvailable == false)
+
+        // Download via the VM
+        let firstID = try #require(LLMModelCatalog.all.first?.id)
+        viewModel.download(id: firstID)
+
+        // Wait for the background Task to complete
+        try await Task.sleep(for: .milliseconds(50))
+
+        // Verify ModelManager received the download
+        #expect(fixture.modelManager.isModelAvailable == true)
+        #expect(fixture.modelManager.activeModelID == firstID)
+    }
+
+    @Test("choose delegates to ModelManager")
+    func chooseDelegation() async throws {
+        let fixture = try makeCoreFixture(modelDownloaded: false)
+        defer { fixture.cleanup() }
+
+        // Download both models
+        let ids = LLMModelCatalog.all.map(\.id)
+        for id in ids {
+            await fixture.modelManager.downloadModel(id: id)
+        }
+
+        // First model should be selected (auto-select on first download)
+        let firstID = try #require(ids.first)
+        #expect(fixture.modelManager.activeModelID == firstID)
+
+        // Choose the second model
+        let secondID = try #require(ids.last)
+        let viewModel = ManageModelsViewModel(core: fixture.core)
+        viewModel.choose(id: secondID)
+
+        // Wait for the background Task to complete
+        try await Task.sleep(for: .milliseconds(50))
+
+        #expect(fixture.modelManager.activeModelID == secondID)
+    }
+
+    // MARK: - Delete confirmation flow
+
+    @Test("requestDelete sets deleteTarget")
+    func requestDeleteSetsTarget() throws {
+        let fixture = try makeCoreFixture(modelDownloaded: true)
+        defer { fixture.cleanup() }
+
+        let viewModel = ManageModelsViewModel(core: fixture.core)
+        let choices = viewModel.modelChoices
+        let firstChoice = try #require(choices.first)
+
+        #expect(viewModel.deleteTarget == nil)
+
+        viewModel.requestDelete(choice: firstChoice)
+
+        #expect(viewModel.deleteTarget != nil)
+        #expect(viewModel.deleteTarget?.model.id == firstChoice.model.id)
+    }
+
+    @Test("confirmDelete calls ModelManager and clears target")
+    func confirmDeleteCallsManager() async throws {
+        let fixture = try makeCoreFixture(modelDownloaded: true)
+        defer { fixture.cleanup() }
+
+        await fixture.modelManager.refresh()
+
+        let viewModel = ManageModelsViewModel(core: fixture.core)
+        let choices = viewModel.modelChoices
+        let downloadedChoice = try #require(
+            choices.first { $0.isDownloaded }
+        )
+
+        // Stage the delete
+        viewModel.requestDelete(choice: downloadedChoice)
+        #expect(viewModel.deleteTarget != nil)
+
+        // Confirm the delete
+        viewModel.confirmDelete()
+
+        // Target should be cleared immediately
+        #expect(viewModel.deleteTarget == nil)
+
+        // Wait for the background Task to complete
+        try await Task.sleep(for: .milliseconds(50))
+
+        // Model should no longer be downloaded
+        let refreshedChoices = viewModel.modelChoices
+        let refreshed = refreshedChoices.first {
+            $0.model.id == downloadedChoice.model.id
+        }
+        #expect(refreshed?.isDownloaded == false)
+    }
+
+    @Test("confirmDelete with no target is a no-op")
+    func confirmDeleteNoTarget() throws {
+        let fixture = try makeCoreFixture(modelDownloaded: true)
+        defer { fixture.cleanup() }
+
+        let viewModel = ManageModelsViewModel(core: fixture.core)
+        #expect(viewModel.deleteTarget == nil)
+
+        // Should not crash or do anything
+        viewModel.confirmDelete()
+        #expect(viewModel.deleteTarget == nil)
+    }
+
+    @Test("clearing deleteTarget cancels delete")
+    func clearDeleteTargetCancels() throws {
+        let fixture = try makeCoreFixture(modelDownloaded: true)
+        defer { fixture.cleanup() }
+
+        let viewModel = ManageModelsViewModel(core: fixture.core)
+        let choices = viewModel.modelChoices
+        let firstChoice = try #require(choices.first)
+
+        viewModel.requestDelete(choice: firstChoice)
+        #expect(viewModel.deleteTarget != nil)
+
+        // Clear target (as if user cancelled)
+        viewModel.deleteTarget = nil
+        #expect(viewModel.deleteTarget == nil)
+
+        // Model should still be downloaded
+        let refreshedChoices = viewModel.modelChoices
+        let refreshed = refreshedChoices.first {
+            $0.model.id == firstChoice.model.id
+        }
+        #expect(refreshed?.isDownloaded == true)
+    }
+
+    // MARK: - isDownloading
+
+    @Test("isDownloading is false when no downloads in progress")
+    func isDownloadingFalse() throws {
+        let fixture = try makeCoreFixture(modelDownloaded: true)
+        defer { fixture.cleanup() }
+
+        let viewModel = ManageModelsViewModel(core: fixture.core)
+        #expect(viewModel.isDownloading == false)
+    }
+
+    @Test("isDownloading is true when a download is in progress")
+    func isDownloadingTrue() throws {
+        let fixture = try makeCoreFixture(modelDownloaded: false)
+        defer { fixture.cleanup() }
+
+        // Manually set a download state to simulate in-flight
+        let firstID = LLMModelCatalog.all.first?.id ?? ""
+        fixture.modelManager.downloads[firstID] = .downloading(fraction: 0.5)
+
+        let viewModel = ManageModelsViewModel(core: fixture.core)
+        #expect(viewModel.isDownloading == true)
+    }
+}
+
+// MARK: - ModelBlockedReason warning text
+
+@Suite("ModelBlockedReason")
+struct ModelBlockedReasonTests {
+    @Test("cannotRun warning text")
+    func cannotRunWarningText() {
+        let reason = ModelBlockedReason.cannotRun
+        #expect(reason.warningText == "This Mac can\u{2019}t run this model")
+    }
+
+    @Test("insufficientDisk warning text")
+    func insufficientDiskWarningText() {
+        let reason = ModelBlockedReason.insufficientDisk
+        #expect(reason.warningText == "Insufficient free space on disk")
+    }
+}

--- a/Packages/BiscottiKit/Tests/SettingsUITests/SettingsAIEnhancementsTests.swift
+++ b/Packages/BiscottiKit/Tests/SettingsUITests/SettingsAIEnhancementsTests.swift
@@ -3,6 +3,7 @@ import BiscottiTestSupport
 import Calendar
 import Foundation
 import Intelligence
+import LocalLLM
 import MeetingCatalog
 import MeetingDetection
 import Notifications
@@ -134,14 +135,13 @@ struct SettingsAIEnhancementsTests {
 
     // MARK: - Download state
 
-    @Test("modelDownload reflects Intelligence download state")
-    func downloadStateFromIntelligence() throws {
+    @Test("modelDownload shows notDownloaded when no model present")
+    func downloadStateFromModelManager() throws {
         let fixture = try makeCoreFixture(modelDownloaded: false)
         defer { fixture.cleanup() }
 
         let viewModel = SettingsViewModel(core: fixture.core)
 
-        // Initial state after init (Intelligence.refreshModelState runs in init)
         #expect(viewModel.modelDownload == .notDownloaded)
     }
 
@@ -153,12 +153,41 @@ struct SettingsAIEnhancementsTests {
         let viewModel = SettingsViewModel(core: fixture.core)
 
         #expect(viewModel.modelDownload == .downloaded)
+        #expect(viewModel.modelAvailable == true)
+    }
+
+    // MARK: - Start download
+
+    @Test("startModelDownload picks recommended model and delegates to ModelManager")
+    func startModelDownloadDelegates() async throws {
+        let fixture = try makeCoreFixture(modelDownloaded: false)
+        defer { fixture.cleanup() }
+
+        let viewModel = SettingsViewModel(core: fixture.core)
+        await viewModel.load()
+
+        #expect(viewModel.modelAvailable == false)
+
+        // Trigger download via SettingsViewModel
+        viewModel.startModelDownload()
+
+        // Wait for the background Task to complete
+        // The fake download completes synchronously, so a short yield suffices.
+        try await Task.sleep(for: .milliseconds(50))
+
+        // Verify ModelManager received the download and auto-selected
+        #expect(fixture.modelManager.isModelAvailable == true)
+
+        // The downloaded model should be the one recommended by ModelManager
+        let recommendedID = fixture.modelManager.recommendedModelID()
+        #expect(recommendedID != nil)
+        #expect(fixture.modelManager.activeModelID == recommendedID)
     }
 
     // MARK: - Load refreshes model state
 
-    @Test("load calls refreshModelState on Intelligence")
-    func loadCallsRefreshModelState() async throws {
+    @Test("load calls modelManager.refresh")
+    func loadCallsRefresh() async throws {
         let fixture = try makeCoreFixture(modelDownloaded: false)
         defer { fixture.cleanup() }
 
@@ -167,32 +196,17 @@ struct SettingsAIEnhancementsTests {
         // Initially not downloaded
         #expect(viewModel.modelAvailable == false)
 
-        // Simulate model appearing on disk
-        fixture.fakeModelProvider.downloaded = true
+        // Simulate model appearing on disk by marking it downloaded
+        // in the fake provider, then refresh via load()
+        try await fixture.fakeModelProvider.download(
+            #require(LLMModelCatalog.all.first?.id),
+            progress: { _, _ in }
+        )
 
-        // load() should call refreshModelState and pick up the change
+        // load() should call modelManager.refresh() and pick up the change
         await viewModel.load()
 
         #expect(viewModel.modelAvailable == true)
-        #expect(viewModel.modelDownload == .downloaded)
-    }
-
-    // MARK: - Download initiation
-
-    @Test("startModelDownload triggers download on Intelligence")
-    func startModelDownloadTriggersDownload() async throws {
-        let fixture = try makeCoreFixture(modelDownloaded: false)
-        defer { fixture.cleanup() }
-
-        let viewModel = SettingsViewModel(core: fixture.core)
-
-        #expect(viewModel.modelAvailable == false)
-
-        // Call downloadModel directly on Intelligence (synchronous test)
-        // FakeCoreModelProvider.download sets downloaded=true immediately
-        await fixture.intelligence.downloadModel()
-
-        #expect(fixture.fakeModelProvider.downloaded == true)
     }
 
     // MARK: - Toggle interaction with model state
@@ -255,9 +269,16 @@ private func buildAppCore(
         storageRoot: storageRoot, makeRecorder: { FakeRecorder() }
     )
     let catalog = BundledMeetingCatalog()
+    let fakeModelProvider = FakeCoreModelProvider(downloaded: false)
+    let fakeHardwareProbe = FakeCoreHardwareProbe()
+    let modelManager = ModelManager(
+        store: store,
+        models: fakeModelProvider,
+        hardware: fakeHardwareProbe
+    )
     let intelligence = Intelligence(
         store: store, llm: FakeCoreLLMRunner(),
-        models: FakeCoreModelProvider(downloaded: false),
+        modelManager: modelManager,
         settings: { AISettings(enabled: true) }
     )
     return AppCore(
@@ -267,7 +288,8 @@ private func buildAppCore(
         calendar: CalendarService(store: store, catalog: catalog, provider: FakeEventStore()),
         detector: MeetingDetector(catalog: catalog, source: FakeActivitySource()),
         notifications: NotificationService(provider: FakeTestNotificationCenter()),
-        intelligence: intelligence
+        intelligence: intelligence,
+        modelManager: modelManager
     )
 }
 

--- a/Packages/BiscottiKit/Tests/SettingsUITests/SettingsAIEnhancementsTests.swift
+++ b/Packages/BiscottiKit/Tests/SettingsUITests/SettingsAIEnhancementsTests.swift
@@ -133,55 +133,26 @@ struct SettingsAIEnhancementsTests {
         #expect(storedSettings.aiAnalysisEnabled == true)
     }
 
-    // MARK: - Download state
+    // MARK: - Active model display name
 
-    @Test("modelDownload shows notDownloaded when no model present")
-    func downloadStateFromModelManager() throws {
-        let fixture = try makeCoreFixture(modelDownloaded: false)
-        defer { fixture.cleanup() }
-
-        let viewModel = SettingsViewModel(core: fixture.core)
-
-        #expect(viewModel.modelDownload == .notDownloaded)
-    }
-
-    @Test("modelDownload shows downloaded when model present")
-    func downloadStateDownloaded() throws {
+    @Test("activeModelDisplayName returns display name when model active")
+    func activeModelDisplayNamePresent() throws {
         let fixture = try makeCoreFixture(modelDownloaded: true)
         defer { fixture.cleanup() }
 
         let viewModel = SettingsViewModel(core: fixture.core)
-
-        #expect(viewModel.modelDownload == .downloaded)
-        #expect(viewModel.modelAvailable == true)
+        #expect(viewModel.activeModelDisplayName != nil)
+        // The first catalog model is downloaded by the fixture
+        #expect(viewModel.activeModelDisplayName == LLMModelCatalog.all.first?.displayName)
     }
 
-    // MARK: - Start download
-
-    @Test("startModelDownload picks recommended model and delegates to ModelManager")
-    func startModelDownloadDelegates() async throws {
+    @Test("activeModelDisplayName returns nil when no model active")
+    func activeModelDisplayNameNil() throws {
         let fixture = try makeCoreFixture(modelDownloaded: false)
         defer { fixture.cleanup() }
 
         let viewModel = SettingsViewModel(core: fixture.core)
-        await viewModel.load()
-
-        #expect(viewModel.modelAvailable == false)
-
-        // Trigger download via SettingsViewModel
-        viewModel.startModelDownload()
-
-        // Wait for the background Task to complete
-        // The fake download completes synchronously, so a short yield suffices.
-        try await Task.sleep(for: .milliseconds(50))
-
-        // Verify ModelManager received the download and auto-selected
-        #expect(fixture.modelManager.isModelAvailable == true)
-
-        // The downloaded model should be the one recommended by ModelManager
-        let recommendedID = fixture.modelManager.recommendedModelID()
-        #expect(recommendedID != nil)
-        #expect(fixture.modelManager.activeModelID == recommendedID)
+        #expect(viewModel.activeModelDisplayName == nil)
     }
 
     // MARK: - Load refreshes model state

--- a/Packages/BiscottiKit/Tests/TranscriptionServiceTests/TranscriptionServiceTests.swift
+++ b/Packages/BiscottiKit/Tests/TranscriptionServiceTests/TranscriptionServiceTests.swift
@@ -556,6 +556,10 @@ private struct ReentrantShutdownFakeTranscriber: Transcribing, @unchecked Sendab
         FakeTranscriber.defaultResult
     }
 
+    func modelsPresent() async -> Bool {
+        true
+    }
+
     func shutdown() async {
         backing.shutdownCallCount += 1
         // Simulate the MainActor yield during actor hop by yielding, then
@@ -615,6 +619,10 @@ private struct BlockingFakeTranscriber: Transcribing, @unchecked Sendable {
         return FakeTranscriber.defaultResult
     }
 
+    func modelsPresent() async -> Bool {
+        true
+    }
+
     func shutdown() async {}
 }
 
@@ -632,22 +640,32 @@ struct TranscriptionModelReadinessTests {
         #expect(fix.fakeEngine.backing.ensureModelsCalled == true)
     }
 
-    @Test("modelsReady returns true when engine succeeds")
+    @Test("modelsArePresent returns true when engine reports present")
     @MainActor
-    func modelsReadyReturnsTrueAfterDownload() async throws {
+    func modelsArePresentReturnsTrue() async throws {
         let fix = try makeFixture()
-        let ready = await fix.service.modelsReady()
-        #expect(ready == true)
+        // FakeTranscriber defaults to modelsPresentResult = true
+        let present = await fix.service.modelsArePresent()
+        #expect(present == true)
+        #expect(fix.fakeEngine.backing.modelsPresentCalled == true)
     }
 
-    @Test("modelsReady returns false when engine throws")
+    @Test("modelsArePresent returns false when engine reports absent")
     @MainActor
-    func modelsReadyReturnsFalseOnError() async throws {
-        let fix = try makeFixture(
-            ensureModelsError: TranscriptionError.needsDownload
-        )
-        let ready = await fix.service.modelsReady()
-        #expect(ready == false)
+    func modelsArePresentReturnsFalse() async throws {
+        let fix = try makeFixture()
+        fix.fakeEngine.backing.modelsPresentResult = false
+        let present = await fix.service.modelsArePresent()
+        #expect(present == false)
+    }
+
+    @Test("modelsArePresent does NOT call ensureModelsDownloaded")
+    @MainActor
+    func modelsArePresentDoesNotDownload() async throws {
+        let fix = try makeFixture()
+        _ = await fix.service.modelsArePresent()
+        #expect(fix.fakeEngine.backing.ensureModelsCalled == false)
+        #expect(fix.fakeEngine.backing.ensureModelsCallCount == 0)
     }
 
     @Test("ensureModelsReady forwards status messages")
@@ -768,6 +786,10 @@ private struct BlockingOnDownloadFakeTranscriber: Transcribing, @unchecked Senda
         customVocabulary _: [String]
     ) async throws -> TranscriptResult {
         FakeTranscriber.defaultResult
+    }
+
+    func modelsPresent() async -> Bool {
+        true
     }
 
     func shutdown() async {}

--- a/Packages/LocalLLM/Sources/LocalLLM/LLMModel.swift
+++ b/Packages/LocalLLM/Sources/LocalLLM/LLMModel.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+/// A model descriptor from the curated catalog.
+///
+/// Each entry identifies a downloadable GGUF model with everything needed to
+/// locate, download, and display it. The catalog is the single source of truth
+/// for model identity and download coordinates; product policy (RAM gates,
+/// recommendation, UI copy) lives in the app layer, not here.
+public struct LLMModel: Sendable, Equatable, Identifiable {
+    /// Stable identifier persisted as the user's selection (e.g. `"gemma-4-12b"`).
+    public let id: String
+
+    /// Human-readable name shown in the UI (e.g. `"Gemma 4 12B"`).
+    public let displayName: String
+
+    /// Remote URL from which the GGUF file is downloaded.
+    public let downloadURL: URL
+
+    /// The on-disk filename (== `downloadURL.lastPathComponent`). Models coexist
+    /// in the shared cache directory distinguished by filename.
+    public let fileName: String
+
+    /// Approximate download size in bytes, used for the disk-space gate and
+    /// delete-confirmation copy. Uses 1 GB = 1_000_000_000 (SI).
+    public let approxDownloadBytes: Int64
+
+    public init(
+        id: String,
+        displayName: String,
+        downloadURL: URL,
+        fileName: String,
+        approxDownloadBytes: Int64
+    ) {
+        self.id = id
+        self.displayName = displayName
+        self.downloadURL = downloadURL
+        self.fileName = fileName
+        self.approxDownloadBytes = approxDownloadBytes
+    }
+}
+
+/// The curated catalog of available LLM models.
+///
+/// Adding a new model = adding one entry to ``all``. No UI or logic rewrites
+/// needed -- the rest of the system iterates over the catalog.
+public enum LLMModelCatalog {
+    // MARK: - Constants (SI: 1 GB = 1_000_000_000)
+
+    private static let oneGB: Int64 = 1_000_000_000
+
+    // MARK: - Catalog entries
+
+    /// All available models in display order (12B first, then E2B).
+    /// Display order is also used for fallback selection tie-breaks.
+    public static let all: [LLMModel] = [
+        LLMModel(
+            id: "gemma-4-12b",
+            displayName: "Gemma 4 12B",
+            downloadURL: URL(
+                string: "https://huggingface.co/unsloth/gemma-4-12b-it-GGUF/resolve/main/gemma-4-12b-it-UD-Q4_K_XL.gguf"
+            )!,
+            fileName: "gemma-4-12b-it-UD-Q4_K_XL.gguf",
+            approxDownloadBytes: 7 * oneGB
+        ),
+        LLMModel(
+            id: "gemma-4-e2b",
+            displayName: "Gemma 4 E2B",
+            downloadURL: URL(
+                string: "https://huggingface.co/unsloth/gemma-4-E2B-it-qat-GGUF/resolve/main/gemma-4-E2B-it-qat-UD-Q4_K_XL.gguf"
+            )!,
+            fileName: "gemma-4-E2B-it-qat-UD-Q4_K_XL.gguf",
+            approxDownloadBytes: 3 * oneGB
+        )
+    ]
+
+    /// Look up a catalog model by its stable identifier.
+    ///
+    /// Returns `nil` for unknown IDs (e.g. a stale persisted selection after a
+    /// model is removed from the catalog in a future version).
+    public static func model(id: String) -> LLMModel? {
+        all.first { $0.id == id }
+    }
+}

--- a/Packages/LocalLLM/Sources/LocalLLM/ModelInventory.swift
+++ b/Packages/LocalLLM/Sources/LocalLLM/ModelInventory.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+/// Disk-facing companion to ``ModelDownloader``.
+///
+/// Provides path resolution, presence checks, and deletion for catalog models
+/// within the shared cache directory. All operations are in-process (no XPC).
+/// The ``ModelDownloader`` handles network downloads; this type handles
+/// what's already on disk.
+public struct ModelInventory: Sendable {
+    /// The directory where model GGUF files are stored.
+    public let cacheDirectory: URL
+
+    /// Create an inventory backed by `cacheDirectory`.
+    ///
+    /// - Parameter cacheDirectory: The shared model cache directory
+    ///   (typically ``LocalLLMPaths/defaultModelCacheDir``).
+    public init(cacheDirectory: URL) {
+        self.cacheDirectory = cacheDirectory
+    }
+
+    /// The on-disk path for a catalog model within this inventory's cache directory.
+    ///
+    /// Consistent with ``ModelDownloader/download(from:progress:)`` -- both
+    /// resolve `cacheDirectory + model.fileName`, so a downloaded file is
+    /// found by both.
+    public func path(for model: LLMModel) -> URL {
+        cacheDirectory.appendingPathComponent(model.fileName)
+    }
+
+    /// Whether the model's GGUF file exists on disk as a non-empty regular file.
+    public func isDownloaded(_ model: LLMModel) -> Bool {
+        ModelDownloader.fileExistsAndNonEmpty(at: path(for: model))
+    }
+
+    /// Returns the subset of `catalog` models that are currently downloaded.
+    ///
+    /// Preserves the catalog's ordering (display order = fallback tie-break order).
+    public func downloadedModels(in catalog: [LLMModel]) -> [LLMModel] {
+        catalog.filter { isDownloaded($0) }
+    }
+
+    /// Removes a model's GGUF file and any stray `.partial` download artifact.
+    ///
+    /// Does not throw if the files are already absent (idempotent delete).
+    public func delete(_ model: LLMModel) throws {
+        let modelPath = path(for: model)
+        let partialPath = ModelDownloader.tempPath(for: modelPath)
+
+        try removeIfExists(at: modelPath)
+        try removeIfExists(at: partialPath)
+    }
+
+    // MARK: - Private
+
+    private func removeIfExists(at url: URL) throws {
+        let fileManager = FileManager.default
+        guard fileManager.fileExists(atPath: url.path) else { return }
+        try fileManager.removeItem(at: url)
+    }
+}

--- a/Packages/LocalLLM/Tests/LocalLLMTests/LLMModelCatalogTests.swift
+++ b/Packages/LocalLLM/Tests/LocalLLMTests/LLMModelCatalogTests.swift
@@ -1,0 +1,96 @@
+import Foundation
+import Testing
+@testable import LocalLLM
+
+@Suite("LLMModelCatalog")
+struct LLMModelCatalogTests {
+    @Test("Catalog contains exactly two models")
+    func catalogCount() {
+        #expect(LLMModelCatalog.all.count == 2)
+    }
+
+    @Test("Catalog IDs are distinct and non-empty")
+    func catalogIDsDistinctAndNonEmpty() {
+        let ids = LLMModelCatalog.all.map(\.id)
+        for id in ids {
+            #expect(!id.isEmpty, "Model ID must not be empty")
+        }
+        #expect(Set(ids).count == ids.count, "Model IDs must be unique")
+    }
+
+    @Test("Catalog display names are distinct and non-empty")
+    func catalogDisplayNames() {
+        let names = LLMModelCatalog.all.map(\.displayName)
+        for name in names {
+            #expect(!name.isEmpty)
+        }
+        #expect(Set(names).count == names.count, "Display names must be unique")
+    }
+
+    @Test("Catalog download URLs are distinct and well-formed HTTPS")
+    func catalogURLs() {
+        let urls = LLMModelCatalog.all.map(\.downloadURL)
+        for url in urls {
+            #expect(url.scheme == "https")
+            #expect(url.host != nil)
+        }
+        let urlStrings = urls.map(\.absoluteString)
+        #expect(Set(urlStrings).count == urlStrings.count, "Download URLs must be unique")
+    }
+
+    @Test("Catalog filenames are distinct and non-empty")
+    func catalogFilenames() {
+        let filenames = LLMModelCatalog.all.map(\.fileName)
+        for name in filenames {
+            #expect(!name.isEmpty)
+        }
+        #expect(Set(filenames).count == filenames.count, "Filenames must be unique")
+    }
+
+    @Test("Catalog approxDownloadBytes are positive for each model")
+    func catalogDownloadSizes() {
+        for model in LLMModelCatalog.all {
+            #expect(model.approxDownloadBytes > 0, "\(model.id) download size must be positive")
+        }
+    }
+
+    @Test("Display order is 12B then E2B")
+    func catalogOrder() {
+        let ids = LLMModelCatalog.all.map(\.id)
+        #expect(ids == ["gemma-4-12b", "gemma-4-e2b"])
+    }
+
+    @Test("model(id:) returns correct entry for known IDs")
+    func lookupKnown() {
+        let model12b = LLMModelCatalog.model(id: "gemma-4-12b")
+        #expect(model12b?.displayName == "Gemma 4 12B")
+        #expect(model12b?.id == "gemma-4-12b")
+
+        let modelE2b = LLMModelCatalog.model(id: "gemma-4-e2b")
+        #expect(modelE2b?.displayName == "Gemma 4 E2B")
+        #expect(modelE2b?.id == "gemma-4-e2b")
+    }
+
+    @Test("model(id:) returns nil for unknown ID")
+    func lookupUnknown() {
+        #expect(LLMModelCatalog.model(id: "nonexistent") == nil)
+        #expect(LLMModelCatalog.model(id: "") == nil)
+    }
+
+    @Test("12B catalog entry matches existing defaultModelURL")
+    func twelveBMatchesLegacyURL() {
+        let model12b = LLMModelCatalog.model(id: "gemma-4-12b")
+        #expect(model12b?.downloadURL == ModelDownloader.defaultModelURL)
+        #expect(model12b?.fileName == ModelDownloader.defaultModelURL.lastPathComponent)
+    }
+
+    @Test("Each model's fileName matches its downloadURL lastPathComponent")
+    func fileNameMatchesURL() {
+        for model in LLMModelCatalog.all {
+            #expect(
+                model.fileName == model.downloadURL.lastPathComponent,
+                "\(model.id) fileName must match downloadURL.lastPathComponent"
+            )
+        }
+    }
+}

--- a/Packages/LocalLLM/Tests/LocalLLMTests/ModelInventoryTests.swift
+++ b/Packages/LocalLLM/Tests/LocalLLMTests/ModelInventoryTests.swift
@@ -1,0 +1,215 @@
+import Foundation
+import Testing
+@testable import LocalLLM
+
+@Suite("ModelInventory")
+struct ModelInventoryTests {
+    /// Creates a fresh temp directory for each test.
+    private func makeTempDir() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("inventory-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    private func cleanup(_ dir: URL) {
+        try? FileManager.default.removeItem(at: dir)
+    }
+
+    /// A small test model descriptor (not a real download).
+    private var testModel: LLMModel {
+        LLMModel(
+            id: "test-model",
+            displayName: "Test Model",
+            downloadURL: URL(string: "https://example.com/test.gguf")!,
+            fileName: "test.gguf",
+            approxDownloadBytes: 100
+        )
+    }
+
+    private var otherModel: LLMModel {
+        LLMModel(
+            id: "other-model",
+            displayName: "Other Model",
+            downloadURL: URL(string: "https://example.com/other.gguf")!,
+            fileName: "other.gguf",
+            approxDownloadBytes: 200
+        )
+    }
+
+    // MARK: - path(for:)
+
+    @Test("path(for:) composes cacheDirectory + model.fileName")
+    func pathComposition() {
+        let dir = URL(fileURLWithPath: "/tmp/test-cache")
+        let inventory = ModelInventory(cacheDirectory: dir)
+        let path = inventory.path(for: testModel)
+        #expect(path == dir.appendingPathComponent("test.gguf"))
+    }
+
+    // MARK: - isDownloaded
+
+    @Test("isDownloaded returns true for non-empty regular file")
+    func isDownloadedTrue() throws {
+        let dir = try makeTempDir()
+        defer { cleanup(dir) }
+
+        let inventory = ModelInventory(cacheDirectory: dir)
+        let modelPath = inventory.path(for: testModel)
+        try Data([0x42, 0x43]).write(to: modelPath)
+
+        #expect(inventory.isDownloaded(testModel) == true)
+    }
+
+    @Test("isDownloaded returns false for missing file")
+    func isDownloadedMissing() throws {
+        let dir = try makeTempDir()
+        defer { cleanup(dir) }
+
+        let inventory = ModelInventory(cacheDirectory: dir)
+        #expect(inventory.isDownloaded(testModel) == false)
+    }
+
+    @Test("isDownloaded returns false for empty file")
+    func isDownloadedEmpty() throws {
+        let dir = try makeTempDir()
+        defer { cleanup(dir) }
+
+        let inventory = ModelInventory(cacheDirectory: dir)
+        FileManager.default.createFile(
+            atPath: inventory.path(for: testModel).path,
+            contents: Data()
+        )
+
+        #expect(inventory.isDownloaded(testModel) == false)
+    }
+
+    @Test("isDownloaded returns false for a directory at the model path")
+    func isDownloadedDirectory() throws {
+        let dir = try makeTempDir()
+        defer { cleanup(dir) }
+
+        let inventory = ModelInventory(cacheDirectory: dir)
+        try FileManager.default.createDirectory(
+            at: inventory.path(for: testModel),
+            withIntermediateDirectories: true
+        )
+
+        #expect(inventory.isDownloaded(testModel) == false)
+    }
+
+    // MARK: - downloadedModels(in:)
+
+    @Test("downloadedModels filters to only downloaded models")
+    func downloadedModelsFiltering() throws {
+        let dir = try makeTempDir()
+        defer { cleanup(dir) }
+
+        let inventory = ModelInventory(cacheDirectory: dir)
+
+        // Only testModel is "downloaded"
+        try Data([0x42]).write(to: inventory.path(for: testModel))
+
+        let catalog = [testModel, otherModel]
+        let downloaded = inventory.downloadedModels(in: catalog)
+
+        #expect(downloaded.count == 1)
+        #expect(downloaded.first?.id == testModel.id)
+    }
+
+    @Test("downloadedModels returns empty when nothing downloaded")
+    func downloadedModelsEmpty() throws {
+        let dir = try makeTempDir()
+        defer { cleanup(dir) }
+
+        let inventory = ModelInventory(cacheDirectory: dir)
+        let downloaded = inventory.downloadedModels(in: [testModel, otherModel])
+
+        #expect(downloaded.isEmpty)
+    }
+
+    @Test("downloadedModels preserves catalog order")
+    func downloadedModelsOrder() throws {
+        let dir = try makeTempDir()
+        defer { cleanup(dir) }
+
+        let inventory = ModelInventory(cacheDirectory: dir)
+
+        // Download both
+        try Data([0x42]).write(to: inventory.path(for: testModel))
+        try Data([0x42]).write(to: inventory.path(for: otherModel))
+
+        let catalog = [otherModel, testModel] // reversed order
+        let downloaded = inventory.downloadedModels(in: catalog)
+
+        #expect(downloaded.count == 2)
+        #expect(downloaded[0].id == otherModel.id)
+        #expect(downloaded[1].id == testModel.id)
+    }
+
+    // MARK: - delete
+
+    @Test("delete removes the model file and its .partial sibling")
+    func deleteRemovesFileAndPartial() throws {
+        let dir = try makeTempDir()
+        defer { cleanup(dir) }
+
+        let inventory = ModelInventory(cacheDirectory: dir)
+        let modelPath = inventory.path(for: testModel)
+        let partialPath = ModelDownloader.tempPath(for: modelPath)
+
+        // Create both files
+        try Data([0x42]).write(to: modelPath)
+        try Data([0x43]).write(to: partialPath)
+
+        #expect(FileManager.default.fileExists(atPath: modelPath.path))
+        #expect(FileManager.default.fileExists(atPath: partialPath.path))
+
+        try inventory.delete(testModel)
+
+        #expect(!FileManager.default.fileExists(atPath: modelPath.path))
+        #expect(!FileManager.default.fileExists(atPath: partialPath.path))
+    }
+
+    @Test("delete of a missing file does not throw")
+    func deleteMissingNoThrow() throws {
+        let dir = try makeTempDir()
+        defer { cleanup(dir) }
+
+        let inventory = ModelInventory(cacheDirectory: dir)
+
+        // Should not throw -- idempotent
+        try inventory.delete(testModel)
+    }
+
+    @Test("delete removes only the .partial when the main file is already gone")
+    func deletePartialOnly() throws {
+        let dir = try makeTempDir()
+        defer { cleanup(dir) }
+
+        let inventory = ModelInventory(cacheDirectory: dir)
+        let modelPath = inventory.path(for: testModel)
+        let partialPath = ModelDownloader.tempPath(for: modelPath)
+
+        // Only partial exists
+        try Data([0x43]).write(to: partialPath)
+        #expect(FileManager.default.fileExists(atPath: partialPath.path))
+
+        try inventory.delete(testModel)
+
+        #expect(!FileManager.default.fileExists(atPath: partialPath.path))
+    }
+
+    @Test("isDownloaded returns false after delete")
+    func isDownloadedAfterDelete() throws {
+        let dir = try makeTempDir()
+        defer { cleanup(dir) }
+
+        let inventory = ModelInventory(cacheDirectory: dir)
+        try Data([0x42]).write(to: inventory.path(for: testModel))
+
+        #expect(inventory.isDownloaded(testModel) == true)
+        try inventory.delete(testModel)
+        #expect(inventory.isDownloaded(testModel) == false)
+    }
+}

--- a/Packages/Transcription/Sources/Transcription/InProcessTranscriptionEngine.swift
+++ b/Packages/Transcription/Sources/Transcription/InProcessTranscriptionEngine.swift
@@ -117,8 +117,67 @@ public actor InProcessTranscriptionEngine: TranscriptionEngine {
         Self.log.debug("unloadModels: complete")
     }
 
+    public func modelsPresent() async -> Bool {
+        Self.log.debug("modelsPresent: checking disk")
+        let sttPresent = Self.whisperKitModelsPresent(
+            repo: resolvedSettings.sttModelRepo,
+            model: resolvedSettings.sttModel
+        )
+        let speakerPresent = Self.speakerKitModelsPresent()
+        Self.log.debug("modelsPresent: stt=\(sttPresent), speaker=\(speakerPresent)")
+        return sttPresent && speakerPresent
+    }
+
     public func status() async -> ModelStatus {
         await statusMachine.current
+    }
+}
+
+// MARK: - Read-only disk checks
+
+extension InProcessTranscriptionEngine {
+    /// Check if WhisperKit model files are present on disk at the expected
+    /// download location. Does NOT load, compile, or download anything.
+    ///
+    /// The Hub client writes models to:
+    ///   `downloadBase/models/<repo>/<model>/`
+    /// We check for at least one `.mlmodelc` directory inside that folder.
+    static func whisperKitModelsPresent(
+        repo: String,
+        model: String
+    ) -> Bool {
+        let modelDir = ModelStorage.modelsDirectory
+            .appendingPathComponent(repo, isDirectory: true)
+            .appendingPathComponent(model, isDirectory: true)
+        return directoryContainsMLModel(modelDir)
+    }
+
+    /// Check if SpeakerKit (Pyannote) model files are present on disk.
+    ///
+    /// SpeakerKit downloads to:
+    ///   `downloadBase/models/argmaxinc/speakerkit-coreml/`
+    /// We check for at least one `.mlmodelc` directory inside that folder
+    /// (or its subdirectories, since SpeakerKit nests models).
+    static func speakerKitModelsPresent() -> Bool {
+        let speakerDir = ModelStorage.modelsDirectory
+            .appendingPathComponent("argmaxinc/speakerkit-coreml", isDirectory: true)
+        return directoryContainsMLModel(speakerDir)
+    }
+
+    /// Returns `true` if `directory` (or any immediate subdirectory) contains
+    /// at least one `.mlmodelc` bundle.
+    private static func directoryContainsMLModel(_ directory: URL) -> Bool {
+        let fileManager = FileManager.default
+        guard fileManager.fileExists(atPath: directory.path) else { return false }
+        guard let enumerator = fileManager.enumerator(
+            at: directory,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        ) else { return false }
+        for case let url as URL in enumerator where url.pathExtension == "mlmodelc" {
+            return true
+        }
+        return false
     }
 }
 

--- a/Packages/Transcription/Sources/Transcription/Transcriber.swift
+++ b/Packages/Transcription/Sources/Transcription/Transcriber.swift
@@ -247,6 +247,26 @@ public actor Transcriber {
         }
     }
 
+    /// Returns `true` when the transcription models are already present on
+    /// disk and do NOT need downloading.
+    ///
+    /// This is a **read-only** probe: it checks the filesystem without
+    /// downloading, loading, or mutating any engine state.
+    public func modelsPresent() async -> Bool {
+        // For the .inProcess backend, use the existing engine directly.
+        // For .hosted, delegate to the static disk check (no XPC round-trip
+        // needed since model files are at a shared filesystem path).
+        if let existing = engine {
+            return await existing.modelsPresent()
+        }
+        // No engine yet (hosted, pre-connection). Use the static check.
+        let settings = MethodResolver.resolve(method)
+        return InProcessTranscriptionEngine.whisperKitModelsPresent(
+            repo: settings.sttModelRepo,
+            model: settings.sttModel
+        ) && InProcessTranscriptionEngine.speakerKitModelsPresent()
+    }
+
     /// Check if the backend is available and responsive.
     ///
     /// For `.inProcess`, returns true if the engine status is `.ready`.

--- a/Packages/Transcription/Sources/Transcription/TranscriptionEngine.swift
+++ b/Packages/Transcription/Sources/Transcription/TranscriptionEngine.swift
@@ -36,6 +36,15 @@ public protocol TranscriptionEngine: Sendable {
     /// models will be re-loaded on the next call.
     func unloadModels() async
 
+    /// Returns `true` when the transcription models are already present on
+    /// disk and do NOT need to be downloaded.
+    ///
+    /// This is a **read-only** probe -- it must not download, load, or
+    /// otherwise mutate model state. It exists so callers (e.g. the
+    /// onboarding screen) can check readiness without triggering a
+    /// multi-GB download.
+    func modelsPresent() async -> Bool
+
     /// The current model lifecycle status.
     func status() async -> ModelStatus
 }

--- a/Packages/Transcription/Sources/Transcription/XPCEngineAdapter.swift
+++ b/Packages/Transcription/Sources/Transcription/XPCEngineAdapter.swift
@@ -101,6 +101,24 @@ final class XPCEngineAdapter: TranscriptionEngine, @unchecked Sendable {
         }
     }
 
+    func modelsPresent() async -> Bool {
+        // The XPC adapter delegates to the static disk check on
+        // InProcessTranscriptionEngine. Model files live at a shared
+        // filesystem path (ModelStorage), so the client process can
+        // check without involving the XPC worker.
+        //
+        // Note: this resolves the *current* method's model repo/name
+        // via MethodResolver. If a future transcription method ships
+        // with a different model name, the method would need to be
+        // plumbed in (the Transcriber actor already stores its method
+        // and could pass it through).
+        let settings = MethodResolver.resolve(.current)
+        return InProcessTranscriptionEngine.whisperKitModelsPresent(
+            repo: settings.sttModelRepo,
+            model: settings.sttModel
+        ) && InProcessTranscriptionEngine.speakerKitModelsPresent()
+    }
+
     func status() async -> ModelStatus {
         // The XPC adapter cannot directly query the worker's status machine.
         // Status is managed by the Transcriber actor that wraps this adapter.

--- a/Packages/Transcription/Tests/TranscriptionTests/TranscriberTestHelpers.swift
+++ b/Packages/Transcription/Tests/TranscriptionTests/TranscriberTestHelpers.swift
@@ -14,12 +14,19 @@ actor StubTranscriptionEngine: TranscriptionEngine {
     var processAudioCallCount = 0
     var ensureModelsCallCount = 0
     var unloadCallCount = 0
+    var modelsPresentCallCount = 0
+    var modelsPresentResult = true
 
     func ensureModelsDownloaded(status: @escaping @Sendable (String) -> Void) async throws {
         ensureModelsCallCount += 1
         if let error = ensureModelsError { throw error }
         status("Downloading test model")
         status("Models ready")
+    }
+
+    func modelsPresent() async -> Bool {
+        modelsPresentCallCount += 1
+        return modelsPresentResult
     }
 
     func processAudio(

--- a/architecture.md
+++ b/architecture.md
@@ -61,6 +61,7 @@ L4  App glue        Biscotti.app  ·  BiscottiTranscriber.xpc
 L3b Window shell    AppShellUI  (window + sidebar + navigation; hosts the screens)
 L3a Screens         HomeUI · RecordingUI · MeetingDetailUI · MeetingListUI
                     MenuBarUI · OnboardingUI · SettingsUI            (+ DesignSystem)
+    Shared UI       ModelManagementUI  (used by SettingsUI + OnboardingUI)
 L2  Coordination    AppCore  (the headless "background app" engine)
 L1  Services        Recording · MeetingDetection · TranscriptionService · Calendar · Notifications · Vocabulary
 L0  Foundation      DataStore · Permissions · RemoteConfig · DesignSystem · Intelligence

--- a/specs/projects/llm_model_selection/architecture.md
+++ b/specs/projects/llm_model_selection/architecture.md
@@ -1,0 +1,439 @@
+---
+status: complete
+---
+
+# Architecture: LLM Model Selection
+
+## 0. Strategy & Layering
+
+The `LocalLLM` package is **already multi-model-capable** below the app: `LLMService.withConnection(model: URL)`,
+`LLMLoadRequest(modelPath:)`, the `BiscottiLLM.xpc` service, and `GemmaChatTemplate` all accept an
+arbitrary GGUF path, and both Gemma 4 variants share the template. **No XPC or engine changes.** The
+single-model assumption lives entirely in four app-layer spots, which this project replaces:
+
+| Layer | Today | After |
+|---|---|---|
+| `LocalLLM` | one `defaultModelURL` / `modelPath` | a **catalog** of `LLMModel`s + a disk **inventory** (list/path/delete). `defaultModelURL` kept for the CLI. |
+| `DataStore` | — | new persisted `selectedModelID` setting |
+| `Intelligence` | `Intelligence` owns single `download` state + `ModelProviding.modelURL` | new **`ModelManager`** owns per-model state, selection, suitability; `Intelligence` resolves the **active model** at analysis time |
+| `SettingsUI` | conditional inline download row | permanent "AI Language Model" row + **Manage Models sheet** |
+
+**Layering rule:** `LocalLLM` stays free of product policy — it knows *which files exist and how to
+fetch/delete them*. **Hardware thresholds, recommendation, disk gating, and UI copy live in the app
+layer** (`Intelligence`/`SettingsUI`).
+
+Single architecture doc (no `components/`): the surface is moderate and cohesive.
+
+---
+
+## 1. Data Model
+
+### 1.1 Persisted setting (`DataStore`)
+
+Add one field to the existing settings singleton (mirrors `aiAnalysisEnabled` exactly):
+
+- `AppSettings.selectedModelID: String = ""` (SwiftData `@Model` stored property; plain `String`, no
+  `[String]`-materialization issue — lightweight migration adds it with default `""`).
+- `AppSettingsData.selectedModelID: String` (the `Sendable` DTO; default `""` in `init`).
+- Map it in `DataStore.settings()` (read) and `updateSettings()` (read-into-DTO + write-back).
+
+`""` = "no explicit choice yet" (drives the migration/fallback in §4).
+
+### 1.2 Catalog descriptor (`LocalLLM`)
+
+```swift
+public struct LLMModel: Sendable, Equatable, Identifiable {
+    public let id: String            // stable, persisted: "gemma-4-12b", "gemma-4-e2b"
+    public let displayName: String   // "Gemma 4 12B"
+    public let downloadURL: URL
+    public let fileName: String      // == downloadURL.lastPathComponent; on-disk name
+    public let approxDownloadBytes: Int64  // for the disk gate + delete-confirmation copy
+}
+
+public enum LLMModelCatalog {
+    public static let all: [LLMModel]            // [12B, E2B] in display order
+    public static func model(id: String) -> LLMModel?
+}
+```
+
+Catalog data:
+
+| id | displayName | downloadURL | fileName | approxDownloadBytes |
+|---|---|---|---|---|
+| `gemma-4-12b` | Gemma 4 12B | `…/gemma-4-12b-it-GGUF/resolve/main/gemma-4-12b-it-UD-Q4_K_XL.gguf` | `gemma-4-12b-it-UD-Q4_K_XL.gguf` | 7 GB |
+| `gemma-4-e2b` | Gemma 4 E2B | `…/gemma-4-E2B-it-qat-GGUF/resolve/main/gemma-4-E2B-it-qat-UD-Q4_K_XL.gguf` | `gemma-4-E2B-it-qat-UD-Q4_K_XL.gguf` | 3 GB |
+
+(GB = 1_000_000_000 for the disk gate; exact-byte precision is unnecessary.)
+
+### 1.3 App-layer per-model policy & copy (`Intelligence`)
+
+A small static table keyed by `LLMModel.id` (kept out of `LocalLLM`):
+
+```swift
+enum ModelPolicy {
+    static func description(id: String) -> String   // UI marketing copy (functional spec §2)
+    static func minRAMBytesToRun(id: String) -> UInt64  // 12B: 15 GB; default: 0
+    static func approxRAMUsageBytes(id: String) -> Int64 // for copy only (8 GB / 4 GB)
+}
+```
+
+### 1.4 UI value type (`Intelligence`, consumed by `SettingsUI`)
+
+Assembled per render; not persisted:
+
+```swift
+public struct ModelChoice: Sendable, Identifiable, Equatable {
+    public let model: LLMModel
+    public let description: String
+    public let isRecommended: Bool
+    public let runnable: Bool                 // canRun (RAM floor met)
+    public let hasEnoughDiskToDownload: Bool  // free space >= approxDownloadBytes
+    public let isDownloaded: Bool
+    public let isSelected: Bool               // == active selection
+    public let downloadState: ModelDownloadState
+    public var id: String { model.id }
+    public var blockedReason: ModelBlockedReason?  // .cannotRun | .insufficientDisk | nil
+}
+
+public enum ModelBlockedReason: Sendable, Equatable { case cannotRun, insufficientDisk }
+```
+
+The UI maps `ModelChoice` → the row-state matrix (ui_design §2.2): `.cannotRun` → greyed + "This
+Mac can't run this model"; `.insufficientDisk` → disabled Download + "Insufficient free space on
+disk"; else by `downloadState` + `isSelected`.
+
+---
+
+## 2. Component Breakdown
+
+### 2.1 `LocalLLM` — `ModelInventory` (new, in-process; the "list downloaded models" API)
+
+Disk-facing companion to `ModelDownloader` (which already does network + arbitrary-URL download).
+No XPC.
+
+```swift
+public struct ModelInventory: Sendable {
+    public init(cacheDirectory: URL)                       // LocalLLMPaths.defaultModelCacheDir
+    public func path(for model: LLMModel) -> URL           // cacheDirectory + model.fileName
+    public func isDownloaded(_ model: LLMModel) -> Bool     // ModelDownloader.fileExistsAndNonEmpty
+    public func downloadedModels(in catalog: [LLMModel]) -> [LLMModel]
+    public func delete(_ model: LLMModel) throws            // remove file + sibling ".partial"
+}
+```
+
+- `path(for:)` is consistent with `ModelDownloader.download(from: model.downloadURL)` (both resolve
+  `cacheDirectory + fileName`), so a downloaded file is found by both.
+- `ModelDownloader` is unchanged except keeping `defaultModelURL`/`modelPath` for the CLI; the app
+  calls `download(from: model.downloadURL, progress:)`.
+
+### 2.2 `Intelligence` — `HardwareProbing` (new) + `ModelSuitability` (new, pure)
+
+```swift
+public protocol HardwareProbing: Sendable {
+    var physicalMemoryBytes: UInt64 { get }                // ProcessInfo.physicalMemory
+    func availableDiskBytes(at url: URL) -> Int64?         // volumeAvailableCapacityForImportantUsageKey
+}
+public struct LiveHardwareProbe: HardwareProbing { /* reads real hardware */ }
+
+enum ModelSuitability {
+    static func canRun(_ m: LLMModel, ram: UInt64) -> Bool          // ram >= minRAMBytesToRun(m.id)
+    static func hasEnoughDisk(_ m: LLMModel, freeBytes: Int64?) -> Bool  // freeBytes == nil ? true : free >= approxDownloadBytes
+    static func recommendedModelID(catalog: [LLMModel], ram: UInt64) -> String?  // §3
+}
+```
+
+- Pure functions → fully unit-testable with fabricated RAM/disk values. No real hardware in tests.
+- `hasEnoughDisk` returns **true when free space is unknown** (`nil`) — never falsely block a
+  download on a failed capacity read; the downloader's size validation is the backstop.
+
+### 2.3 `Intelligence` — `ModelManager` (new; `@MainActor @Observable`)
+
+The in-process owner of all model state, **replacing** `Intelligence`'s current `download`,
+`downloadModel`, `refreshModelState`, `isModelDownloaded`, and the `ModelProviding.modelURL`
+single-model coupling. Observed by Settings (parallels how `Intelligence.download` is observed
+today).
+
+```swift
+@MainActor @Observable
+public final class ModelManager {
+    // Observable state
+    public package(set) var downloads: [String: ModelDownloadState] = [:]  // per model id
+    public private(set) var selectedModelID: String = ""                   // cached mirror of the setting
+
+    // Dependencies (injected; fakes in tests)
+    private let store: DataStore
+    private let models: any ModelProviding     // LocalLLM-backed: catalog + inventory + downloader
+    private let hardware: any HardwareProbing
+
+    public init(store: DataStore, models: any ModelProviding, hardware: any HardwareProbing)
+
+    // Reads / derived
+    public var isModelAvailable: Bool          // activeModelID != nil
+    public var activeModelID: String?          // §4.2 resolution against `downloads` + `selectedModelID`
+    public func activeModelURL() -> URL?       // models.url(for: activeModelID) when downloaded
+    public func modelChoices() -> [ModelChoice]  // assemble catalog × downloads × selection × suitability
+
+    // Lifecycle / actions
+    public func refresh() async                // recompute downloads from disk; load + (migration) persist selection
+    public func downloadModel(id: String) async   // one-at-a-time guard; drives downloads[id]
+    public func deleteModel(id: String) async     // inventory.delete; recompute selection (§4.3)
+    public func selectModel(id: String) async     // guard runnable+downloaded; persist selectedModelID
+}
+```
+
+`ModelProviding` (the injected abstraction) is **reworked** from single- to multi-model:
+
+```swift
+public protocol ModelProviding: Sendable {
+    var catalog: [LLMModel] { get }
+    func url(for id: String) -> URL?
+    func isDownloaded(_ id: String) -> Bool
+    func downloadedModelIDs() -> [String]
+    func download(_ id: String, progress: @Sendable @escaping (Int64, Int64?) -> Void) async throws
+    func delete(_ id: String) throws
+}
+```
+
+`LiveModelProvider` wraps `LLMModelCatalog.all` + `ModelInventory(cacheDirectory:)` + `ModelDownloader(cacheDirectory:)`
+(all sharing `LocalLLMPaths.defaultModelCacheDir`). Test fakes implement the protocol in-memory.
+
+### 2.4 `Intelligence` — analysis path (modified)
+
+`Intelligence` drops its `models`/`download` members and instead holds `modelManager: ModelManager`.
+
+- Guards in `runAutoEnhancements` / `runAnalysis`: replace `guard models.isDownloaded()` with
+  `guard let modelURL = modelManager.activeModelURL() else { …no-op… }`.
+- `runAnalysisSession` passes that URL into the session (see §2.5).
+- `isModelDownloaded` → `modelManager.isModelAvailable` (used by the toggle gate).
+
+### 2.5 `Intelligence` — `LLMRunning.withSession` gains an explicit model (modified)
+
+So the runner is told *which* GGUF to load (it no longer owns a `ModelProviding`):
+
+```swift
+public protocol LLMRunning: Sendable {
+    func withSession<T: Sendable>(
+        model: URL,
+        config: EngineConfig,
+        _ body: @Sendable (any LLMSession) async throws -> T
+    ) async throws -> T
+}
+```
+
+- `LiveLLMRunner`: drop `modelProvider`; `init()` takes nothing; `withSession` forwards `model` to
+  `LLMService.withConnection(model:)`.
+- `Intelligence.runAnalysisSession`: `try await llm.withSession(model: modelURL, config: .modelOnly) { … }`.
+- All `LLMRunning` fakes in tests update to the new signature (they can ignore `model`).
+
+### 2.6 `SettingsUI` — row + sheet (modified/new)
+
+- **`SettingsView.aiEnhancementsSection`**: remove the conditional `modelDownloadRow`; add a
+  permanent `aiLanguageModelRow` and a `.sheet(isPresented: $showManageModels) { ManageModelsSheet(viewModel:) }`.
+  The "AI Analysis & Summary" toggle keeps `.disabled(!viewModel.isModelAvailable)`.
+- **`aiLanguageModelRow`** (ui_design §1): title "AI Language Model" + subtitle; trailing = active
+  model display name (secondary text) + `Manage`, or `Download…` when none.
+- **`ManageModelsSheet`** (new view) + **`ModelRowView`** (new subview): render
+  `viewModel.modelChoices` per the state matrix; `Done` to dismiss; `.confirmationDialog` for delete.
+- **`SettingsViewModel`** (modified):
+  - Remove `modelDownload`/`modelAvailable` single-model accessors.
+  - Add `isModelAvailable: Bool { core.modelManager.isModelAvailable }`,
+    `activeModelDisplayName: String?` (looks up `LLMModelCatalog.model(id:)?.displayName`).
+  - `load()` calls `await core.modelManager.refresh()` (replaces `refreshModelState()`).
+- **`ManageModelsViewModel`** (new, thin; `@MainActor @Observable`): holds `core`; exposes
+  `var modelChoices: [ModelChoice] { core.modelManager.modelChoices() }` and actions
+  `download(id:)`/`delete(id:)`/`choose(id:)` delegating to `core.modelManager`; owns the
+  delete-confirmation `@State` target. Kept thin for testability/parity with existing VMs.
+
+### 2.7 `AppCore` (modified wiring)
+
+- Add `public let modelManager: ModelManager` to `AppCore` (and its init).
+- `buildIntelligence` becomes `buildModelAndIntelligence`: construct `LiveModelProvider()` +
+  `LiveHardwareProbe()` → `ModelManager(store:models:hardware:)`; construct `LiveLLMRunner()`;
+  `Intelligence(store:, llm:, modelManager:, settings:)`. Return both; assign to `AppCore`.
+- `AppCore.onLaunch()` (existing) triggers `Task { await modelManager.refresh() }` so migration
+  selection is resolved/persisted at startup.
+- `PreviewAppCore`/test factories construct a `ModelManager` with in-memory fakes.
+
+---
+
+## 3. Recommendation & Suitability Logic (the algorithms)
+
+All in `ModelSuitability` (pure), driven by `hardware.physicalMemoryBytes` and
+`hardware.availableDiskBytes`:
+
+- **canRun(model):** `ram >= ModelPolicy.minRAMBytesToRun(model.id)`.
+  `minRAMBytesToRun`: `gemma-4-12b → 15 GB`, everything else → `0`.
+- **recommendedModelID(catalog, ram):** if `ram >= 24 GB` and the catalog contains a runnable
+  `gemma-4-12b` → `"gemma-4-12b"`; otherwise the smallest always-runnable model → `"gemma-4-e2b"`.
+  (Explicit two-model rule; the documented extension point when models are added. Never returns a
+  non-runnable model.)
+- **hasEnoughDisk(model, freeBytes):** `freeBytes == nil ? true : freeBytes >= model.approxDownloadBytes`.
+
+Thresholds: `15 GB` and `24 GB` use `1_000_000_000` GB. Centralize as named constants in
+`ModelPolicy`/`ModelSuitability`.
+
+---
+
+## 4. Selection, Active Model & Migration (the state machine)
+
+### 4.1 The setting
+
+`selectedModelID` (persisted, §1.1). `ModelManager.selectedModelID` is the cached mirror, loaded in
+`refresh()` and updated by `selectModel`. `ModelManager` is `@MainActor` and the **sole writer**, so
+the cache is authoritative after first `refresh()`.
+
+### 4.2 Active model resolution (`activeModelID`)
+
+Computed against the current `downloads` (disk truth) + `selectedModelID`:
+
+1. If `selectedModelID` names a **downloaded** catalog model → that id.
+2. Else the **first downloaded** model in `LLMModelCatalog.all` order → its id.
+3. Else → `nil`.
+
+`activeModelURL()` = `models.url(for: activeModelID)` (the on-disk path) when present.
+
+### 4.3 Transitions
+
+- **`refresh()`** (startup + Settings appear): rebuild `downloads` from `ModelInventory`; load
+  `selectedModelID` from settings. **Migration:** if the loaded selection is empty or names a
+  non-downloaded model, but step-2 resolves a downloaded model, **persist** that id
+  (`store.updateSettings { $0.selectedModelID = id }`) and update the cache. → Existing 12B users
+  silently keep 12B; no auto-download ever happens here.
+- **`downloadModel(id:)`**: guard `canRun` + `hasEnoughDisk` + **no other download in flight**
+  (one-at-a-time, §6). Drive `downloads[id]` through `.downloading(fraction:)` → `.downloaded` /
+  `.failed`. **On success**, if the current selection is empty or names a non-downloaded model →
+  `selectModel(id:)` (auto-select first/recovered model).
+- **`selectModel(id:)`**: guard the model is `canRun` **and** downloaded; persist + cache.
+- **`deleteModel(id:)`**: `inventory.delete`; set `downloads[id] = .notDownloaded`. If the deleted id
+  was selected → recompute: first remaining downloaded model (catalog order) → `selectModel(that)`;
+  if none remain → persist `selectedModelID = ""`.
+
+### 4.4 Analysis-time use
+
+`Intelligence` reads `modelManager.activeModelURL()` (cached, synchronous, `@MainActor`). A switch
+takes effect on the **next** run; an in-flight run keeps its already-opened session. No-active-model
+→ silent no-op (unchanged behavior).
+
+---
+
+## 5. Error Handling
+
+- **Download failure** → `downloads[id] = .failed(message:)` via the existing
+  `shortDescription(error)` helper (`LocalLLMError`/underlying). Row shows error + Retry; no partial
+  file remains (existing temp-cleanup). `CancellationError` → `.notDownloaded`.
+- **Delete failure** (rare) → log; leave `downloads[id]` as `.downloaded` (the file is still there);
+  the row reverts to the downloaded state. Non-fatal.
+- **Disk capacity read returns nil** → treated as "enough" (don't false-block); download proceeds and
+  is validated by Content-Length.
+- **Guarded no-ops**: `selectModel`/`downloadModel` on a non-runnable model do nothing (UI prevents
+  reaching them anyway). Defensive only.
+- Logging via the existing `os.Logger` conventions where the surrounding code already logs.
+
+---
+
+## 6. Concurrency
+
+- `ModelManager` is `@MainActor`; all mutations of `downloads`/`selectedModelID` are main-actor
+  isolated. Progress callbacks marshal to the main actor exactly as `Intelligence.downloadModel`
+  does today (the `LastFraction` throttle moves into `ModelManager`).
+- **One download at a time:** `downloadModel` returns early if any `downloads.values` is
+  `.downloading`. The UI disables other rows' Download buttons while one is in flight.
+- The actual network download runs in the `ModelDownloader`/`URLSession` task off the main actor;
+  only state updates hop back to `@MainActor`.
+
+---
+
+## 7. Testing Strategy
+
+All via the package test suites (`mcp__hooks-mcp__test`); no heavy/AI tests; no real hardware.
+
+**`LocalLLM` (LocalLLMTests):**
+- `LLMModelCatalog`: ids/URLs/filenames are distinct and non-empty; `model(id:)` lookups.
+- `ModelInventory`: `path(for:)` derivation; `isDownloaded` true/false against temp files (regular
+  file > 0 bytes vs directory vs missing); `downloadedModels(in:)` filtering; `delete` removes the
+  file **and** a sibling `.partial`; delete of a missing file does not throw fatally.
+
+**`Intelligence` (BiscottiKit Intelligence tests):**
+- `ModelSuitability` (table-driven, pure): `canRun(12B)` at 8/14/15/16/24/64 GB and `canRun(E2B)`
+  always true; `recommendedModelID` flips at the 24 GB boundary and never returns a non-runnable id;
+  `hasEnoughDisk` boundaries incl. `nil` free → true.
+- `ModelManager` (fake `ModelProviding` + fake `HardwareProbing` + in-memory `DataStore`):
+  - Active-model resolution & **migration**: empty selection + 12B-only downloaded → active = 12B and
+    `selectedModelID` persisted to "gemma-4-12b".
+  - First successful download auto-selects when no valid selection.
+  - Delete selected with another downloaded present → selection falls back; delete last → cleared
+    (`isModelAvailable == false`).
+  - `selectModel` on non-runnable/not-downloaded → ignored.
+  - One-at-a-time: second `downloadModel` while one is `.downloading` → no-op.
+  - `modelChoices()` produces correct `blockedReason`/flags across a RAM/disk/downloaded/selected
+    matrix (incl. 12B `.cannotRun` at 8 GB; `.insufficientDisk` when free < size).
+- `Intelligence`: updated for `withSession(model:)` + `modelManager` injection; verify the active
+  model URL is the one passed to the (fake) runner; no-op when no active model.
+
+**`DataStore`:** settings round-trip persists/reads `selectedModelID`; default is `""`.
+
+**`SettingsUI`:** `SettingsViewModel.activeModelDisplayName`/`isModelAvailable` mapping;
+`ManageModelsViewModel` action delegation and `modelChoices` pass-through (with a fake/preview core).
+
+**Manual tests:** this touches `Packages/LocalLLM` → mark existing `llm_*` steps `not-run` in
+`ManualTestApp/Results/manual_test_results.json` (recordable steps only) per the repo rule.
+**New E2B coverage** in the "Local LLM" tab: a `.action` to download the E2B model, a `.action` to
+run the **multi-turn (KV-cache reuse)** inference through `BiscottiLLM.xpc` on E2B (the single most
+demanding path — full suite not repeated), and a `.humanQuestion` observation. Add those recordable
+IDs to the results JSON as `not-run`; update `ScriptShapeTests` for the new steps. The shape steps
+live in `ManualTestKit/Scripts/LocalLLMScript.swift`; wiring (real XPC calls using `LLMModelCatalog`/
+`ModelInventory` for the E2B path) in `ManualTestApp/Sources/WiredScripts.swift`.
+
+---
+
+## 8. File-Level Change List
+
+**`Packages/LocalLLM/Sources/LocalLLM/`**
+- `LLMModel.swift` (new): `LLMModel` + `LLMModelCatalog`.
+- `ModelInventory.swift` (new): path/isDownloaded/downloadedModels/delete.
+- `ModelDownloader.swift`: unchanged (keep `defaultModelURL`/`modelPath` for CLI).
+
+**ManualTestApp (Phase 1)**
+- `Packages/BiscottiKit/Sources/ManualTestKit/Scripts/LocalLLMScript.swift`: append E2B
+  download + multi-turn-inference `.action`s + observation `.humanQuestion`.
+- `ManualTestApp/Sources/WiredScripts.swift`: wire the new E2B steps (download via E2B descriptor;
+  multi-turn KV-reuse generate using the E2B model URL).
+- `ManualTestApp/Results/manual_test_results.json`: add new recordable IDs as `not-run`; mark
+  existing `llm_*` recordable steps `not-run`.
+- `Packages/BiscottiKit/Tests/ManualTestKitTests/ScriptShapeTests.swift`: update for the new steps.
+
+**`Packages/BiscottiKit/Sources/DataStore/`**
+- `Models/AppSettings.swift`: add `selectedModelID` stored prop + init param.
+- `DataStore+ReadModels.swift`: add to `AppSettingsData` (+ init), `settings()`, `updateSettings()`.
+
+**`Packages/BiscottiKit/Sources/Intelligence/`**
+- `HardwareProbing.swift` (new): protocol + `LiveHardwareProbe`.
+- `ModelSuitability.swift` (new): pure logic + `ModelPolicy` (copy/RAM table) + thresholds.
+- `ModelManager.swift` (new): `ModelManager`, `ModelChoice`, `ModelBlockedReason`; move
+  `LastFraction` here.
+- `ModelProviding.swift`: rework to multi-model protocol.
+- `LiveModelProvider.swift`: implement multi-model over catalog + inventory + downloader.
+- `LLMRunning.swift` + `LiveLLMRunning.swift`: add `model: URL` to `withSession`; drop
+  `modelProvider` from `LiveLLMRunner`.
+- `Intelligence.swift`: swap `models`/`download` for `modelManager`; update guards + session call;
+  remove the model-download methods now owned by `ModelManager`.
+- `EnhancementStatus.swift`: `ModelDownloadState` unchanged (reused per-model).
+
+**`Packages/BiscottiKit/Sources/AppCore/AppCore.swift` + `AppCore+Live.swift`**
+- Add `modelManager` to `AppCore`; build it in the live factory; `onLaunch` → `refresh()`.
+
+**`Packages/BiscottiKit/Sources/SettingsUI/`**
+- `SettingsView.swift`: permanent `aiLanguageModelRow`; remove `modelDownloadRow`; add sheet.
+- `SettingsViewModel.swift`: new model accessors; `load()` → `modelManager.refresh()`.
+- `ManageModelsSheet.swift` (new) + `ModelRowView` + `ManageModelsViewModel.swift` (new).
+
+**Tests:** add/adjust per §7 across `LocalLLMTests`, `IntelligenceTests`, `DataStoreTests`,
+`SettingsUITests`; update existing `LLMRunning` fakes to the new signature; PreviewAppCore builds a
+`ModelManager`.
+
+---
+
+## 9. Out of Scope (unchanged from functional spec)
+
+Download resume / checksums / general download manager (Project 10); UI cancel of in-flight
+downloads; custom user-supplied model URLs; per-model runtime tuning; transcription-model selection.

--- a/specs/projects/llm_model_selection/functional_spec.md
+++ b/specs/projects/llm_model_selection/functional_spec.md
@@ -1,0 +1,283 @@
+---
+status: complete
+---
+
+# Functional Spec: LLM Model Selection
+
+## 1. Goal & Context
+
+Today Biscotti ships a single hard-coded local LLM — **Gemma 4 12B QAT** — used for all AI
+analysis (summary, speaker-name inference, title). The 12B model needs ~8 GB RAM and is slow on
+M1/M2 Macs, and won't run at all on low-RAM machines.
+
+This project lets the user **choose between multiple local LLMs**, **smart-suggests** an appropriate
+one for their hardware, and **prevents** choosing a model the machine can't run. Two models ship
+initially (12B and a smaller E2B), but the design is explicitly built to grow to more.
+
+Both models are Gemma 4, so they share the same chat template / message structure — no changes are
+needed below the app layer (`LocalLLM`'s `GemmaChatTemplate`, the XPC service, and
+`LLMService.withConnection(model:)` already accept any GGUF path).
+
+## 2. Model Catalog
+
+The system is driven by a **catalog** of model descriptors. Initially two entries; adding a model
+later = adding one descriptor (no UI or logic rewrites). Each descriptor carries:
+
+| Field | 12B | E2B |
+|---|---|---|
+| `id` (stable, persisted) | `gemma-4-12b` | `gemma-4-e2b` |
+| Display name | `Gemma 4 12B` | `Gemma 4 E2B` |
+| Description (UI copy) | "Intelligent, but slower and larger. Requires 7 GB of disk and uses 8 GB RAM." | "Small and fast, but not as intelligent. Requires 3 GB of disk and uses 4 GB of RAM." |
+| Download URL | `https://huggingface.co/unsloth/gemma-4-12b-it-GGUF/resolve/main/gemma-4-12b-it-UD-Q4_K_XL.gguf` (existing) | `https://huggingface.co/unsloth/gemma-4-E2B-it-qat-GGUF/resolve/main/gemma-4-E2B-it-qat-UD-Q4_K_XL.gguf` (new) |
+| On-disk filename | `gemma-4-12b-it-UD-Q4_K_XL.gguf` | `gemma-4-E2B-it-qat-UD-Q4_K_XL.gguf` |
+| Required disk (download size, free-space gate) | 7 GB | 3 GB |
+| Required-to-run RAM floor | 15 GB | none (runs on any supported Mac) |
+
+- The two filenames differ, so both models **coexist on disk** in the existing cache directory
+  (`~/Library/Application Support/Biscotti/llms/`). No migration of existing files needed.
+- Catalog **display order** is: 12B, then E2B (used for fallback selection tie-breaks and sheet
+  row order).
+- The "required disk" / "required RAM" numbers in the description copy are the values used by the
+  gates below — single source of truth per descriptor.
+
+## 3. Hardware Suitability & Recommendation
+
+Three independent, per-model facts are computed from hardware. **Only physical RAM and free disk
+space are read** — there is **no chip-generation or Intel/Apple-Silicon detection** (builds are
+Apple-silicon-only, and brand-string chip parsing is fragile and unworthy of the complexity).
+
+### 3.1 Can-run (hard gate)
+
+A model is **runnable** on this Mac iff its RAM floor is met:
+
+- **12B is runnable iff** physical RAM ≥ **15 GB**.
+- **E2B is runnable** on any supported Mac.
+
+If a model is **not runnable**, it appears in the Manage sheet **greyed-out and disabled**, with the
+warning **"This Mac can't run this model"**. It cannot be downloaded or selected. (This is the
+single, confirmed rule that supersedes the looser "don't show on 8 GB" note — an 8 GB Mac is < 15 GB,
+so 12B is greyed there.)
+
+### 3.2 Recommendation (soft hint)
+
+Exactly **one** model is marked **"Recommended"** via a badge:
+
+- If RAM ≥ **24 GB** → recommend **12B**.
+- Otherwise → recommend **E2B**.
+
+The recommendation never points at a non-runnable model (recommending 12B requires ≥ 24 GB ≥ 15 GB,
+so it is always runnable when recommended). E2B is always runnable.
+
+### 3.3 Disk-space gate
+
+A model's **Download** action is disabled when **free disk space < the model's required disk size**,
+with the warning **"Insufficient free space on disk"**. (Free space is measured the same way the
+rest of the app does — `volumeAvailableCapacityForImportantUsageKey` on the home volume.) Already-
+downloaded models are unaffected by this gate.
+
+### 3.4 Hardware detection requirements
+
+The app must detect, at runtime, only:
+
+- **Physical RAM** in bytes (`ProcessInfo.physicalMemory`, already used elsewhere).
+- **Free disk space** on the home volume (`volumeAvailableCapacityForImportantUsageKey`, already
+  used elsewhere).
+
+No chip-generation, architecture, or Intel detection is performed. These reads are abstracted behind
+a protocol so the suitability rules (can-run, recommendation, disk gate) are unit-testable with fake
+hardware/disk profiles.
+
+## 4. Selection & Persistence
+
+### 4.1 The setting
+
+A new persisted setting **`selectedModelID: String`** is added to `AppSettings` (default `""`). It
+records the user's chosen model by stable `id`.
+
+### 4.2 Active model (what the AI actually uses)
+
+The **active model** — the GGUF loaded for all AI analysis — is resolved as:
+
+1. If `selectedModelID` names a model that is **downloaded** → that model.
+2. Else, the **first downloaded model in catalog order** (if any).
+3. Else → **none** (no active model; AI features are unavailable).
+
+When step 2 resolves a model because the stored selection was empty or stale, the app
+**persists** that id back into `selectedModelID` (so the sheet's "Default" label and the settings
+row are stable). This also provides **seamless migration**: existing users who already downloaded
+12B have an empty selection, so on first launch the active model resolves to the downloaded 12B and
+selection is persisted — behavior is unchanged for them.
+
+### 4.3 When selection changes
+
+- **First successful download while no valid selection exists** (selection empty or names a
+  non-downloaded model) → the just-downloaded model becomes selected automatically.
+- **"Choose model"** on a downloaded, runnable model → sets `selectedModelID` to it.
+- **Deleting the selected model** → selection is recomputed: the first remaining downloaded model
+  (catalog order) becomes selected; if none remain, selection is cleared (`""`).
+
+A model can only be selected if it is **downloaded** and **runnable**.
+
+## 5. Settings — "AI Language Model" Row (always visible)
+
+The current behavior — a download row that only appears when no model is on disk — is **replaced**
+by a **permanent row** in the existing **AI Enhancements** section:
+
+- **Title:** "AI Language Model"
+- **Subtitle:** "The AI model used to summarize meetings"
+- **Trailing content, by state:**
+  - **Active model exists** → the model's display name in **grey/secondary text** (same visual
+    treatment as granted-permission rows, e.g. "Gemma 4 12B") **+ a "Manage" button** that opens the
+    Manage Models sheet.
+  - **No model downloaded** → a **"Download…" button** that opens the Manage Models sheet.
+  - *(Transient, low priority)* While a download is in progress and no model is yet active, the row
+    may show "Downloading… N%" alongside the Manage button. Acceptable to show "Download…"/ "Manage"
+    only; the sheet is the authoritative place for progress.
+
+The existing **"AI Analysis & Summary" toggle** keeps its current gating: it is **disabled while no
+model is available** (no active model). Its label/description are unchanged.
+
+The old inline `modelDownloadRow` (progress/retry shown directly in the AI section) is **removed** —
+all downloading now happens inside the Manage Models sheet.
+
+## 6. Manage Models Sheet
+
+A sheet (same presentation pattern as existing Settings sheets) titled e.g. **"AI Language Model"**,
+listing every catalog model as a row. Designed to scale to N models.
+
+### 6.1 Row anatomy
+
+Each row shows:
+
+- **Model name** (primary) — with a **"Recommended"** badge on the recommended model.
+- **Description** (secondary copy from the catalog).
+- **A primary action** depending on download state (Download / Delete / progress).
+- **A selection control** depending on selection state (Default label / Choose model).
+- **A warning** when the model is blocked (can't-run or insufficient-disk).
+
+### 6.2 Per-row state matrix
+
+For each model, the row renders one coherent state:
+
+| Condition | Row appearance |
+|---|---|
+| **Not runnable** (12B on RAM < 15 GB) | Greyed-out/disabled; warning **"This Mac can't run this model"**; no Download/Choose actions. |
+| **Runnable, not downloaded, insufficient disk** | **Download** button **disabled**; warning **"Insufficient free space on disk"**. |
+| **Runnable, not downloaded, enough disk** | **Download** button (enabled). |
+| **Downloading** | Progress (determinate `ProgressView` + "Downloading… N%", or indeterminate when no Content-Length). |
+| **Download failed** | Error message + **Retry**. |
+| **Downloaded, not selected** | **Delete** button **+ "Choose model"** button. |
+| **Downloaded, selected** | **Delete** button **+ "Default"** label (grey). |
+
+### 6.3 Actions
+
+- **Download** → starts the download for that model (see §7). Progress shows inline in the row.
+- **Delete** → removes that model's GGUF from disk (see §7), then updates selection per §4.3.
+- **Choose model** → makes that model the selected/default (§4.3).
+- The sheet is dismissable (Done/Close); dismissing **does not** cancel an in-flight download — it
+  continues in the background and is reflected when the sheet is reopened.
+
+### 6.4 Concurrency
+
+**Only one download runs at a time.** While any model is downloading, the **Download** action on
+other not-downloaded rows is **disabled** (the in-flight row shows progress). Delete/Choose on other
+rows remain available. This avoids saturating bandwidth/disk with concurrent multi-GB downloads.
+
+## 7. Download & Delete Behavior
+
+### 7.1 Download
+
+- Reuses the existing downloader (temp-file → atomic move, skip-if-present, Content-Length size
+  validation, no resume). The only change is **which URL/filename** is used (per descriptor) instead
+  of the single hard-coded default.
+- Progress is reported and throttled exactly as today (update on ≥ 1% movement).
+- On success: the file lands in the shared cache dir; if no valid selection existed, this model
+  becomes selected (§4.3).
+- On failure: row shows the error with **Retry**. (Failure leaves no partial file — existing temp-
+  cleanup behavior.)
+- Errors are surfaced as today (short message from `LocalLLMError`/underlying error).
+
+### 7.2 Delete
+
+- Removes the model's GGUF file (and any stray `.partial`) from the cache directory.
+- A lightweight **confirmation** precedes deletion (e.g. "Delete Gemma 4 12B? You can download it
+  again anytime."), since it discards a multi-GB download.
+- After deletion, selection is recomputed (§4.3). If the deleted model was the active one and no
+  other model is downloaded, AI features become unavailable until another model is downloaded (the
+  AI toggle disables, the settings row reverts to "Download…").
+- Deleting a model that is **mid-analysis** is out of scope to specially handle — analyses run from
+  an already-opened session; a new analysis simply uses the new active model (or no-ops if none).
+
+## 8. AI Analysis Integration
+
+- All AI analysis paths (`runAutoEnhancements`, manual `runAnalysis`) must load the **active
+  model's** GGUF rather than the hard-coded default. The active model id comes from settings and is
+  resolved to a file URL via the catalog at session start.
+- The existing guard "no model on disk → no-op" becomes "**no active model → no-op**" (unchanged
+  user-visible behavior: AI silently does nothing when nothing is available).
+- Switching the selected model takes effect on the **next** analysis run; an in-flight run completes
+  with the model it started with.
+- No prompt/template changes: both models use the same Gemma 4 chat template, tokens, and the
+  existing context-sizing logic.
+
+## 9. Library (`LocalLLM`) API Additions
+
+Per the overview's "might need an API to list downloaded models" — added **in-process** (no XPC):
+
+- A **catalog** of model descriptors (id, display name, download URL, filename, download size).
+- A way to resolve a descriptor's **on-disk path** in the shared cache dir, and to check **whether
+  each catalog model is downloaded** (the "list downloaded models" capability is: for each catalog
+  entry, does its file exist and is non-empty — reusing `fileExistsAndNonEmpty`).
+- The downloader already accepts an arbitrary source URL; multi-model support uses per-descriptor
+  URL + filename rather than the single `defaultModelURL`/`modelPath`. The existing
+  `defaultModelURL` may remain (for the CLI) but the app no longer assumes a single model.
+- A **delete** capability for a model file (used by the sheet).
+
+App-level product policy — hardware thresholds, recommendation, disk gate, UI copy — lives in the
+app layer (BiscottiKit/SettingsUI), **not** in `LocalLLM`, to keep the library free of product
+policy.
+
+## 10. Edge Cases
+
+- **Existing user, 12B already downloaded:** empty selection resolves to downloaded 12B and is
+  persisted; nothing visibly changes. The sheet shows 12B as Default + Delete, E2B as Download.
+- **Selected model file deleted out-of-band** (user removes it in Finder): on next settings load /
+  AI run, active model falls back to another downloaded model or none; selection is re-persisted.
+- **Recommended model is 12B** (e.g. 24 GB Mac): no conflict; 12B is both runnable and recommended.
+- **Borderline middle band** (e.g. 16 GB Mac): 12B is **runnable** (≥ 15 GB) but **E2B is
+  recommended** (fails the ≥ 24 GB rule). Both are selectable; the badge guides without forcing.
+- **No internet during download:** download fails with an error + Retry; no partial file remains.
+- **Insufficient disk that becomes sufficient** (user frees space) and reopens sheet: the Download
+  button re-enables (state is recomputed when the sheet appears / on relevant changes).
+- **Both models downloaded, user deletes the non-selected one:** selection unchanged; row flips to
+  Download.
+- **Future model added to catalog:** appears as a new row automatically; recommendation/gates apply
+  via its descriptor; no code changes in the sheet/row.
+
+## 11. Out of Scope
+
+- Download **resume**, checksum/SHA verification, and a general download manager (tracked for
+  Project 10 — unchanged by this work).
+- **Cancelling** an in-flight download from the UI (the underlying code tolerates cancellation, but
+  no Cancel button is added now).
+- Arbitrary **user-supplied** model URLs / custom models (catalog is curated).
+- Per-model **runtime tuning** (context size, GPU layers) beyond what exists — both Gemma 4 variants
+  use current defaults.
+- Changing transcription models (this project is the **LLM** model only).
+
+## 12. Constraints & Notes
+
+- **Apple-silicon-only, macOS 15+** (per repo conventions). Builds are not shipped for Intel, so no
+  architecture detection is needed — RAM is the only gate.
+- **Manual-test staleness:** this project touches `Packages/LocalLLM`. Per the repo rule, the
+  `llm_*` manual-test steps must be marked `not-run` so the manual-test gate flags them for a human
+  hardware re-run.
+- **Manual-test coverage (new):** the ManualTestApp "Local LLM" tab gains **E2B validation** — one
+  step to **download** the Gemma 4 E2B model and one step to run the **multi-turn (KV-cache reuse)**
+  inference through `BiscottiLLM.xpc` on E2B, plus an observation. This is the single most demanding
+  path for a maximum-compatibility check of the new GGUF; the rest of the suite is **not** repeated
+  for E2B. The app-level selection UI (settings row + sheet) is validated by running the real app,
+  not this harness.
+- No new third-party dependencies; hardware detection uses `ProcessInfo.physicalMemory` and
+  `volumeAvailableCapacityForImportantUsageKey` from Foundation only.
+```

--- a/specs/projects/llm_model_selection/implementation_plan.md
+++ b/specs/projects/llm_model_selection/implementation_plan.md
@@ -38,7 +38,7 @@ Ordered, dependency-first. Each phase compiles green and is reviewable on its ow
   auto-select on first download, delete→fallback/clear, select-guard, one-at-a-time, `modelChoices`
   matrix, Intelligence passes the active URL / no-ops when none. (Arch §2.3–2.7, §4, §5, §6.)
 
-- [ ] **Phase 5 — SettingsUI row + Manage Models sheet.** Permanent `aiLanguageModelRow` (replaces the
+- [x] **Phase 5 — SettingsUI row + Manage Models sheet.** Permanent `aiLanguageModelRow` (replaces the
   conditional download row); `ManageModelsSheet` + `ModelRowView` (per-state matrix, Recommended
   badge, Default/Choose, Download/Delete, warnings, progress); `ManageModelsViewModel` + delete
   confirmation; update `SettingsViewModel` (`isModelAvailable`/`activeModelDisplayName`, `load()` →

--- a/specs/projects/llm_model_selection/implementation_plan.md
+++ b/specs/projects/llm_model_selection/implementation_plan.md
@@ -24,7 +24,7 @@ Ordered, dependency-first. Each phase compiles green and is reviewable on its ow
   `AppSettings`, `AppSettingsData`, and the `settings()`/`updateSettings()` mapping. Test: round-trip
   + default. *Additive, small.* (Arch §1.1.)
 
-- [ ] **Phase 3 — Hardware + suitability (pure, additive).** `HardwareProbing` + `LiveHardwareProbe`
+- [x] **Phase 3 — Hardware + suitability (pure, additive).** `HardwareProbing` + `LiveHardwareProbe`
   (RAM + free disk only), `ModelPolicy` (per-id RAM floor + UI copy + RAM-usage copy), and
   `ModelSuitability` (`canRun`, `recommendedModelID`, `hasEnoughDisk`; 15 GB / 24 GB constants).
   Table-driven tests across RAM/disk boundaries. *No breakage.* (Arch §2.2, §3.)

--- a/specs/projects/llm_model_selection/implementation_plan.md
+++ b/specs/projects/llm_model_selection/implementation_plan.md
@@ -20,7 +20,7 @@ Ordered, dependency-first. Each phase compiles green and is reviewable on its ow
   Tests: catalog distinctness/lookup, inventory path/presence/filter/delete (incl. `.partial`).
   *Touches `Packages/LocalLLM` → mark existing `llm_*` manual steps `not-run`.* (Arch §1.2, §2.1, §7.)
 
-- [ ] **Phase 2 — DataStore `selectedModelID`.** Add the persisted `selectedModelID: String = ""` to
+- [x] **Phase 2 — DataStore `selectedModelID`.** Add the persisted `selectedModelID: String = ""` to
   `AppSettings`, `AppSettingsData`, and the `settings()`/`updateSettings()` mapping. Test: round-trip
   + default. *Additive, small.* (Arch §1.1.)
 

--- a/specs/projects/llm_model_selection/implementation_plan.md
+++ b/specs/projects/llm_model_selection/implementation_plan.md
@@ -1,0 +1,45 @@
+---
+status: complete
+---
+
+# Implementation Plan: LLM Model Selection
+
+Ordered, dependency-first. Each phase compiles green and is reviewable on its own. Details live in
+`functional_spec.md`, `ui_design.md`, and `architecture.md` (§8 has the file-by-file change list).
+
+## Phases
+
+- [x] **Phase 1 — LocalLLM catalog + inventory (+ E2B manual test).** Add `LLMModel` +
+  `LLMModelCatalog` (the two Gemma 4 descriptors, incl. the new E2B URL) and `ModelInventory`
+  (in-process `path`/`isDownloaded`/`downloadedModels`/`delete`). Keep
+  `ModelDownloader.defaultModelURL`/`modelPath` for the CLI. **ManualTestApp:** extend the Local LLM
+  tab (`LocalLLMScript.swift` + `WiredScripts.swift`) with **E2B coverage = one download step + one
+  multi-turn (KV-cache reuse) inference step + observation** through `BiscottiLLM.xpc` on the E2B
+  model (the single most demanding path — not the full suite repeated); add the new recordable step
+  IDs to `manual_test_results.json` as `not-run`; update `ScriptShapeTests` for the new steps.
+  Tests: catalog distinctness/lookup, inventory path/presence/filter/delete (incl. `.partial`).
+  *Touches `Packages/LocalLLM` → mark existing `llm_*` manual steps `not-run`.* (Arch §1.2, §2.1, §7.)
+
+- [ ] **Phase 2 — DataStore `selectedModelID`.** Add the persisted `selectedModelID: String = ""` to
+  `AppSettings`, `AppSettingsData`, and the `settings()`/`updateSettings()` mapping. Test: round-trip
+  + default. *Additive, small.* (Arch §1.1.)
+
+- [ ] **Phase 3 — Hardware + suitability (pure, additive).** `HardwareProbing` + `LiveHardwareProbe`
+  (RAM + free disk only), `ModelPolicy` (per-id RAM floor + UI copy + RAM-usage copy), and
+  `ModelSuitability` (`canRun`, `recommendedModelID`, `hasEnoughDisk`; 15 GB / 24 GB constants).
+  Table-driven tests across RAM/disk boundaries. *No breakage.* (Arch §2.2, §3.)
+
+- [ ] **Phase 4 — ModelManager + integration (breaking core).** Rework `ModelProviding` to
+  multi-model + `LiveModelProvider`; add `ModelManager` (+ `ModelChoice`/`ModelBlockedReason`, move
+  `LastFraction`); add `model: URL` to `LLMRunning.withSession` and drop `modelProvider` from
+  `LiveLLMRunner`; rewire `Intelligence` (active-model guards + session call, remove its
+  download-state members); wire `ModelManager` into `AppCore` (+ `onLaunch` refresh, PreviewAppCore).
+  Update existing `LLMRunning`/`ModelProviding` fakes. Tests: active-model resolution + migration,
+  auto-select on first download, delete→fallback/clear, select-guard, one-at-a-time, `modelChoices`
+  matrix, Intelligence passes the active URL / no-ops when none. (Arch §2.3–2.7, §4, §5, §6.)
+
+- [ ] **Phase 5 — SettingsUI row + Manage Models sheet.** Permanent `aiLanguageModelRow` (replaces the
+  conditional download row); `ManageModelsSheet` + `ModelRowView` (per-state matrix, Recommended
+  badge, Default/Choose, Download/Delete, warnings, progress); `ManageModelsViewModel` + delete
+  confirmation; update `SettingsViewModel` (`isModelAvailable`/`activeModelDisplayName`, `load()` →
+  `refresh()`). Tests: VM mapping + action delegation. (functional spec §5–7, ui_design, arch §2.6.)

--- a/specs/projects/llm_model_selection/implementation_plan.md
+++ b/specs/projects/llm_model_selection/implementation_plan.md
@@ -29,7 +29,7 @@ Ordered, dependency-first. Each phase compiles green and is reviewable on its ow
   `ModelSuitability` (`canRun`, `recommendedModelID`, `hasEnoughDisk`; 15 GB / 24 GB constants).
   Table-driven tests across RAM/disk boundaries. *No breakage.* (Arch §2.2, §3.)
 
-- [ ] **Phase 4 — ModelManager + integration (breaking core).** Rework `ModelProviding` to
+- [x] **Phase 4 — ModelManager + integration (breaking core).** Rework `ModelProviding` to
   multi-model + `LiveModelProvider`; add `ModelManager` (+ `ModelChoice`/`ModelBlockedReason`, move
   `LastFraction`); add `model: URL` to `LLMRunning.withSession` and drop `modelProvider` from
   `LiveLLMRunner`; rewire `Intelligence` (active-model guards + session call, remove its

--- a/specs/projects/llm_model_selection/phase_plans/phase_1.md
+++ b/specs/projects/llm_model_selection/phase_plans/phase_1.md
@@ -1,0 +1,56 @@
+---
+status: complete
+---
+
+# Phase 1: LocalLLM Catalog + Inventory (+ E2B Manual Test)
+
+## Overview
+
+Adds the model catalog (`LLMModel` + `LLMModelCatalog`) and disk inventory (`ModelInventory`) to the
+`LocalLLM` package, providing the multi-model data model and the "list/check/delete downloaded
+models" capability. Also extends the ManualTestApp Local LLM tab with E2B-specific coverage (download
++ multi-turn KV-cache reuse inference on E2B through BiscottiLLM.xpc). Existing `llm_*` manual-test
+steps are marked `not-run` per the staleness rule.
+
+## Steps
+
+1. **Create `LLMModel.swift`** in `Packages/LocalLLM/Sources/LocalLLM/`:
+   - `public struct LLMModel: Sendable, Equatable, Identifiable` with fields: `id: String`,
+     `displayName: String`, `downloadURL: URL`, `fileName: String`, `approxDownloadBytes: Int64`.
+   - `public enum LLMModelCatalog` with:
+     - `public static let all: [LLMModel]` containing the 12B and E2B descriptors (in display order).
+     - `public static func model(id: String) -> LLMModel?` for lookup.
+
+2. **Create `ModelInventory.swift`** in `Packages/LocalLLM/Sources/LocalLLM/`:
+   - `public struct ModelInventory: Sendable` with `init(cacheDirectory: URL)`.
+   - `public func path(for model: LLMModel) -> URL` (cacheDirectory + model.fileName).
+   - `public func isDownloaded(_ model: LLMModel) -> Bool` (delegates to
+     `ModelDownloader.fileExistsAndNonEmpty`).
+   - `public func downloadedModels(in catalog: [LLMModel]) -> [LLMModel]` (filters by isDownloaded).
+   - `public func delete(_ model: LLMModel) throws` (removes file + sibling `.partial`).
+
+3. **Extend LocalLLMScript.swift** with three new E2B steps appended before the reclamation check:
+   - `.action(id: "llm_e2b_download", ...)` -- download the E2B model.
+   - `.action(id: "llm_e2b_kv_reuse", ...)` -- multi-turn KV-cache reuse inference on E2B through
+     BiscottiLLM.xpc.
+   - `.humanQuestion(id: "llm_e2b_kv_reuse_quality", ...)` -- observation.
+
+4. **Wire E2B steps in WiredScripts.swift**: add cases for `llm_e2b_download` (download from E2B
+   catalog entry's URL) and `llm_e2b_kv_reuse` (connect to BiscottiLLM.xpc with the E2B model path,
+   run two extending generates for KV-cache reuse validation).
+
+5. **Update `manual_test_results.json`**: mark all existing `llm_*` recordable steps as `not-run`;
+   add `llm_e2b_download`, `llm_e2b_kv_reuse`, `llm_e2b_kv_reuse_quality` as `not-run`.
+
+6. **Update ScriptShapeTests.swift**: bump Local LLM step count to 24 (21 + 3 new); add the three
+   new step IDs to the canonical set.
+
+## Tests
+
+- `LLMModelCatalogTests`: catalog `all` has exactly 2 models; IDs are distinct and non-empty;
+  `model(id:)` returns the correct entry; `model(id:)` returns nil for unknown ID; URLs are distinct
+  and well-formed; filenames are distinct and non-empty; `approxDownloadBytes` > 0 for each.
+- `ModelInventoryTests`: `path(for:)` composes cacheDirectory + fileName; `isDownloaded` true for
+  non-empty file, false for missing/empty/directory; `downloadedModels(in:)` filtering works;
+  `delete` removes the file and its `.partial` sibling; `delete` of a missing file does not throw.
+- `ScriptShapeTests` (updated): Local LLM step count = 24, IDs include the 3 new E2B steps.

--- a/specs/projects/llm_model_selection/phase_plans/phase_2.md
+++ b/specs/projects/llm_model_selection/phase_plans/phase_2.md
@@ -1,0 +1,35 @@
+---
+status: complete
+---
+
+# Phase 2: DataStore `selectedModelID`
+
+## Overview
+
+Add the persisted `selectedModelID: String = ""` field to the DataStore settings layer. This is the
+single new setting that later phases (ModelManager, selection logic) will read and write. The field
+follows the exact same pattern as `aiAnalysisEnabled` -- a stored property on the SwiftData `@Model`,
+a matching field on the `Sendable` DTO, and mapping in both `settings()` and `updateSettings()`.
+
+## Steps
+
+1. **`AppSettings.swift`** -- add `public var selectedModelID: String = ""` stored property and a
+   corresponding `selectedModelID: String = ""` parameter in `init(...)`.
+
+2. **`DataStore+ReadModels.swift` (`AppSettingsData`)** -- add `public var selectedModelID: String`
+   field with default `""` in the DTO struct and its `init`.
+
+3. **`DataStore+ReadModels.swift` (`settings()`)** -- map `existing.selectedModelID` into the
+   `AppSettingsData` initializer call.
+
+4. **`DataStore+ReadModels.swift` (`updateSettings()`)** -- map the field in both directions:
+   read `model.selectedModelID` into the DTO, and write `dto.selectedModelID` back to `model`.
+
+5. **`SettingsAndQueryTests.swift`** -- add a test that verifies the default is `""` and a
+   round-trip through `updateSettings` persists and reads back a non-empty value.
+
+## Tests
+
+- `selectedModelIDDefaultsToEmpty`: read settings from a fresh store, assert
+  `selectedModelID == ""`.
+- `selectedModelIDRoundTrip`: write `"gemma-4-e2b"` via `updateSettings`, read back, assert equal.

--- a/specs/projects/llm_model_selection/phase_plans/phase_3.md
+++ b/specs/projects/llm_model_selection/phase_plans/phase_3.md
@@ -1,0 +1,53 @@
+---
+status: complete
+---
+
+# Phase 3: Hardware + suitability (pure, additive)
+
+## Overview
+
+Add hardware probing and model suitability logic to the Intelligence module. This is
+pure/additive -- no existing APIs change, no breaking changes. Three new files:
+
+1. `HardwareProbing.swift` -- protocol + `LiveHardwareProbe` for RAM and free disk reads.
+2. `ModelPolicy.swift` -- per-model-id product policy: RAM floor, UI description copy, RAM-usage copy.
+3. `ModelSuitability.swift` -- pure functions: `canRun`, `recommendedModelID`, `hasEnoughDisk`.
+
+All suitability logic is unit-testable via a fake `HardwareProbing` conformer.
+
+## Steps
+
+1. Create `Packages/BiscottiKit/Sources/Intelligence/HardwareProbing.swift`:
+   - `public protocol HardwareProbing: Sendable` with `physicalMemoryBytes: UInt64` and
+     `func availableDiskBytes(at url: URL) -> Int64?`.
+   - `public struct LiveHardwareProbe: HardwareProbing` using `ProcessInfo.processInfo.physicalMemory`
+     and `URL.resourceValues(forKeys:).volumeAvailableCapacityForImportantUsage`.
+
+2. Create `Packages/BiscottiKit/Sources/Intelligence/ModelPolicy.swift`:
+   - `public enum ModelPolicy` with static functions:
+     - `description(id:) -> String` -- UI marketing copy per functional spec section 2.
+     - `minRAMBytesToRun(id:) -> UInt64` -- 12B: 15 GB; everything else: 0.
+     - `approxRAMUsageDescription(id:) -> String` -- "8 GB" for 12B, "4 GB" for E2B, etc.
+   - Named constants for the thresholds: `ramFloor12B = 15_000_000_000`,
+     `recommendationRAMThreshold = 24_000_000_000`.
+
+3. Create `Packages/BiscottiKit/Sources/Intelligence/ModelSuitability.swift`:
+   - `public enum ModelSuitability` with static functions:
+     - `canRun(_ model: LLMModel, ram: UInt64) -> Bool`
+     - `recommendedModelID(catalog: [LLMModel], ram: UInt64) -> String?`
+     - `hasEnoughDisk(_ model: LLMModel, freeBytes: Int64?) -> Bool`
+
+4. Write table-driven tests in a new `ModelSuitabilityTests.swift` in IntelligenceTests.
+
+## Tests
+
+- `canRun_12B_at_various_RAM`: 8 GB -> false, 14 GB -> false, 15 GB -> true, 16 GB -> true, 24 GB -> true, 64 GB -> true
+- `canRun_E2B_always_true`: 8 GB, 16 GB, 64 GB -> all true
+- `recommendedModelID_below_24GB`: returns "gemma-4-e2b"
+- `recommendedModelID_at_24GB`: returns "gemma-4-12b"
+- `recommendedModelID_above_24GB`: returns "gemma-4-12b"
+- `recommendedModelID_never_non_runnable`: verify cannot recommend a model that fails canRun
+- `hasEnoughDisk_nil_freeBytes_returns_true`: never block on unknown
+- `hasEnoughDisk_boundaries`: exact size -> true, one byte below -> false, well above -> true
+- `ModelPolicy.description_known_ids`: non-empty for both known IDs
+- `ModelPolicy.minRAMBytesToRun_12B_vs_E2B`: 12B has floor, E2B is 0

--- a/specs/projects/llm_model_selection/phase_plans/phase_4.md
+++ b/specs/projects/llm_model_selection/phase_plans/phase_4.md
@@ -1,0 +1,134 @@
+---
+status: complete
+---
+
+# Phase 4: ModelManager + Integration (Breaking Core)
+
+## Overview
+
+This phase replaces the single-model assumption in the app layer. It reworks
+`ModelProviding` to a multi-model protocol with `LiveModelProvider`, introduces
+`ModelManager` as the central owner of model state (selection, downloads,
+suitability), adds an explicit `model: URL` parameter to `LLMRunning.withSession`,
+rewires `Intelligence` to delegate all model concerns to `ModelManager`, and wires
+`ModelManager` into `AppCore`. All existing users (12B already downloaded) are
+seamlessly migrated via the write-back in `ModelManager.refresh()`.
+
+## Steps
+
+### 1. Rework `ModelProviding` to multi-model protocol
+
+File: `Packages/BiscottiKit/Sources/Intelligence/ModelProviding.swift`
+
+Replace the single-model protocol with:
+```swift
+public protocol ModelProviding: Sendable {
+    var catalog: [LLMModel] { get }
+    func url(for id: String) -> URL?
+    func isDownloaded(_ id: String) -> Bool
+    func downloadedModelIDs() -> [String]
+    func download(_ id: String, progress: @Sendable @escaping (Int64, Int64?) -> Void) async throws
+    func delete(_ id: String) throws
+}
+```
+
+### 2. Rework `LiveModelProvider` to implement multi-model protocol
+
+File: `Packages/BiscottiKit/Sources/Intelligence/LiveModelProvider.swift`
+
+Wrap `LLMModelCatalog.all` + `ModelInventory` + `ModelDownloader` (all sharing
+`LocalLLMPaths.defaultModelCacheDir`).
+
+### 3. Add `model: URL` to `LLMRunning.withSession`
+
+File: `Packages/BiscottiKit/Sources/Intelligence/LLMRunning.swift`
+
+Add explicit `model: URL` parameter so the runner is told which GGUF to load.
+
+### 4. Drop `modelProvider` from `LiveLLMRunner`
+
+File: `Packages/BiscottiKit/Sources/Intelligence/LiveLLMRunning.swift`
+
+`init()` takes nothing; `withSession` forwards the new `model` param to
+`LLMService.withConnection(model:)`.
+
+### 5. Create `ModelManager`
+
+File: `Packages/BiscottiKit/Sources/Intelligence/ModelManager.swift` (new)
+
+`@MainActor @Observable` class with:
+- `downloads: [String: ModelDownloadState]`, `selectedModelID: String`
+- Dependencies: `DataStore`, `ModelProviding`, `HardwareProbing`
+- Reads: `isModelAvailable`, `activeModelID`, `activeModelURL()`, `modelChoices()`
+- Actions: `refresh()`, `downloadModel(id:)`, `deleteModel(id:)`, `selectModel(id:)`
+- `LastFraction` moved from Intelligence
+
+Also defines `ModelChoice` and `ModelBlockedReason`.
+
+### 6. Rewire `Intelligence`
+
+File: `Packages/BiscottiKit/Sources/Intelligence/Intelligence.swift`
+
+- Drop `models: any ModelProviding` and `download: ModelDownloadState` members.
+- Add `modelManager: ModelManager` dependency.
+- Replace `models.isDownloaded()` guards with `modelManager.activeModelURL()`.
+- Pass the model URL into `llm.withSession(model:url, ...)`.
+- Remove `isModelDownloaded`, `refreshModelState()`, `downloadModel()`, `LastFraction`.
+
+### 7. Wire `ModelManager` into `AppCore`
+
+Files: `AppCore.swift`, `AppCore+Live.swift`
+
+- Add `public let modelManager: ModelManager` to `AppCore`.
+- `buildIntelligence` -> `buildModelAndIntelligence`: construct `LiveModelProvider`,
+  `LiveHardwareProbe`, `ModelManager`, `LiveLLMRunner` (no args), `Intelligence`.
+- `onLaunch()` triggers `modelManager.refresh()`.
+
+### 8. Update `PreviewAppCore`
+
+File: `PreviewAppCore.swift`
+
+Construct a `ModelManager` with in-memory fakes. Update preview fakes to the new
+`ModelProviding`/`LLMRunning` signatures.
+
+### 9. Update `SettingsViewModel` bridging
+
+File: `SettingsViewModel.swift`
+
+- `modelDownload` -> reads from `core.modelManager.downloads` (pick active model's state).
+- `modelAvailable` -> `core.modelManager.isModelAvailable`.
+- `load()` calls `core.modelManager.refresh()` instead of `refreshModelState()`.
+- `startModelDownload()` -> delegates to `core.modelManager`.
+
+### 10. Update `BiscottiTestSupport` fakes
+
+File: `CoreFixture.swift`
+
+- Update `FakeCoreModelProvider` to implement the new multi-model `ModelProviding`.
+- Update `FakeCoreLLMRunner` to accept the new `model: URL` signature.
+- Construct a `ModelManager` with fakes and pass it to `AppCore` + `Intelligence`.
+
+### 11. Update `SettingsView` (minimal)
+
+File: `SettingsView.swift`
+
+Update `modelDownloadRow` to use the new ViewModel accessors. No sheet yet (Phase 5).
+
+## Tests
+
+### Intelligence tests (ModelManager)
+- `testActiveModelResolutionMigration`: empty selection + 12B downloaded -> active = 12B, selectedModelID persisted
+- `testAutoSelectOnFirstDownload`: download E2B when no selection -> auto-selects E2B
+- `testDeleteSelectedFallsBack`: delete selected with another downloaded -> falls back
+- `testDeleteLastClearsSelection`: delete only downloaded model -> isModelAvailable = false
+- `testSelectModelGuard`: select non-runnable/non-downloaded -> no-op
+- `testOneDownloadAtATime`: second download while one in flight -> no-op
+- `testModelChoicesMatrix`: correct blockedReason/flags across RAM/disk/downloaded/selected combos
+- `testIntelligencePassesActiveURL`: active model URL is passed to withSession
+- `testIntelligenceNoOpsWhenNoModel`: no active model -> no session opened
+
+### Updated existing tests
+- All `FakeLLMRunner`/`FakeModelProvider` updated to new signatures
+- All `Intelligence` orchestration tests updated for `modelManager` injection
+- `SettingsAIEnhancementsTests` updated for `ModelManager`-based API
+- `CoreFixture` updated for `ModelManager` construction

--- a/specs/projects/llm_model_selection/phase_plans/phase_5.md
+++ b/specs/projects/llm_model_selection/phase_plans/phase_5.md
@@ -1,0 +1,71 @@
+---
+status: complete
+---
+
+# Phase 5: SettingsUI Row + Manage Models Sheet
+
+## Overview
+
+Replace the conditional inline model download row with a permanent "AI Language Model" row and a
+new Manage Models sheet. The row shows the active model name + Manage button (or Download... when
+none). The sheet lists all catalog models with per-state rendering (Recommended badge,
+Download/Delete, Default/"Choose model", warnings, progress, Retry). A new ManageModelsViewModel
+owns delete confirmation and action delegation to ModelManager. SettingsViewModel gains
+`isModelAvailable`/`activeModelDisplayName` derived properties.
+
+## Steps
+
+1. **Add `activeModelDisplayName` to `SettingsViewModel`.**
+   - Computed property: `LLMModelCatalog.model(id: core.modelManager.activeModelID ?? "")?.displayName`.
+   - Add `isModelAvailable` computed (already exists as `modelAvailable`; rename for consistency, keep old as alias or replace).
+
+2. **Create `ManageModelsViewModel` (`ManageModelsSheet.swift` or separate file).**
+   - `@MainActor @Observable`, holds `core: AppCore`.
+   - `var modelChoices: [ModelChoice]` delegates to `core.modelManager.modelChoices()`.
+   - Actions: `download(id:)`, `delete(id:)`, `choose(id:)` delegate to `core.modelManager`.
+   - Delete confirmation state: `var deleteTarget: ModelChoice?` (triggers `.confirmationDialog`).
+   - `confirmDelete()` calls `core.modelManager.deleteModel(id:)` and clears target.
+   - `var isDownloading: Bool` — true when any model is `.downloading`.
+
+3. **Create `ManageModelsSheet` view.**
+   - Sheet with fixed ~480pt width, title "AI Language Model", subtitle, Done button.
+   - Lists `viewModel.modelChoices` as `ModelRowView` instances.
+   - `.confirmationDialog` for delete confirmation.
+
+4. **Create `ModelRowView`.**
+   - Renders the per-state matrix from `ModelChoice`:
+     - Not runnable → greyed, warning "This Mac can't run this model"
+     - Runnable, not downloaded, insufficient disk → Download disabled, warning
+     - Runnable, not downloaded, enough disk → Download button
+     - Downloading → Progress (determinate/indeterminate)
+     - Failed → Error + Retry
+     - Downloaded, not selected → Delete + "Choose model"
+     - Downloaded, selected → Delete + Default indicator
+   - Recommended badge (sage capsule).
+
+5. **Replace `modelDownloadRow` with `aiLanguageModelRow` in `SettingsView`.**
+   - Remove the `if !viewModel.modelAvailable { modelDownloadRow }` block.
+   - Remove the `modelDownloadRow` computed property.
+   - Add permanent `aiLanguageModelRow`:
+     - Title "AI Language Model", subtitle "The AI model used to summarize meetings"
+     - Trailing: active model name (grey) + Manage button, or Download... button
+   - Add `@State private var showManageModels = false` and `.sheet` presentation.
+   - Toggle keeps `.disabled(!viewModel.modelAvailable)`.
+
+6. **Clean up `SettingsViewModel`.**
+   - Remove `modelDownload` (no longer used by the view; download state lives in the sheet).
+   - Keep `modelAvailable` / add `activeModelDisplayName`.
+   - Keep `startModelDownload()` (used by the Download... button in the settings row, which opens the sheet — actually the Download... button just opens the sheet; remove `startModelDownload` if unused).
+
+## Tests
+
+- `ManageModelsViewModelTests`:
+  - `modelChoices delegates to ModelManager`: verify pass-through.
+  - `download delegates to ModelManager`: verify id forwarded.
+  - `delete sets deleteTarget and confirmDelete calls ModelManager`: verify two-step flow.
+  - `choose delegates to ModelManager`: verify id forwarded.
+  - `isDownloading reflects ModelManager state`: true when any download in progress.
+- `SettingsViewModelTests` (additions):
+  - `activeModelDisplayName returns display name when model active`.
+  - `activeModelDisplayName returns nil when no model active`.
+  - `modelAvailable reflects ModelManager state`.

--- a/specs/projects/llm_model_selection/project_overview.md
+++ b/specs/projects/llm_model_selection/project_overview.md
@@ -1,0 +1,50 @@
+---
+status: draft
+---
+
+# LLM Model Selection
+
+We want to add the option to select multiple LLMs. Gemma 4 12B QAT is great, but requires
+8-9GB RAM, and is quite slow on M1/M2 Macs.
+
+We should smart-suggest an appropriate model:
+- If >=24GB RAM, and M3+ processor, default to Gemma 4 12B QAT (current).
+- Otherwise use Gemma 4 E2B.
+
+Notes:
+- Fully disallow the 12B model on 8GB RAM machines. It won't run. Don't show it as an option.
+- Both are Gemma 4, so should share the same tokens/structure for messages.
+
+New model URL:
+`https://huggingface.co/unsloth/gemma-4-E2B-it-qat-GGUF/resolve/main/gemma-4-E2B-it-qat-UD-Q4_K_XL.gguf`
+
+## UI
+
+- In settings, our "Download Model" row which currently hides becomes a permanent row, always shown.
+  - Title: "AI Language Model"
+  - Subtitle: "The AI model used to summarize meetings"
+  - If a model is downloaded and selected, show its name in grey text like we do for other
+    approved permissions ("Gemma 4 12B" or "Gemma 4 E2B"), and a "Manage" button which opens the
+    manage-model sheet.
+  - If no model is downloaded, show a "Download…" button which opens the manage-model sheet.
+- Manage models sheet
+  - A sheet that lets you download models and pick the default.
+  - Sheet UI lists models in rows.
+    - Model name
+    - Description
+    - "Download" button if not downloaded, or "Delete" if downloaded.
+    - "Default" label if selected, or "Choose model" button if downloaded and not selected.
+    - "Recommended" badge on the recommended one (see logic above).
+  - Example:
+    - Gemma 4 12B
+      - Intelligent, but slower and larger. Requires 7GB of disk and uses 8GB RAM.
+    - Gemma 4 E2B
+      - Small and fast, but not as intelligent. Requires 3GB of disk and uses 4GB of RAM.
+  - Save their selected model to a setting.
+  - Disable the 12B model on Intel Macs, or if they have <15GB RAM. Grey it out, with the warning
+    "This Mac can't run this model".
+  - Disable Download of either if free disk space is lower than how much it needs (with an
+    "Insufficient free space on disk" warning message).
+  - Design with the idea we may add more models over time (two for now, but that's temporary).
+- LLM library
+  - Might need to add an API to list downloaded models. Can be in-process, not XPC.

--- a/specs/projects/llm_model_selection/ui_design.md
+++ b/specs/projects/llm_model_selection/ui_design.md
@@ -1,0 +1,231 @@
+---
+status: complete
+---
+
+# UI Design: LLM Model Selection
+
+Two surfaces: (1) the **always-visible row** in Settings → AI Enhancements, and (2) the new
+**Manage Models sheet**. Both reuse existing design-system patterns — no new visual language.
+
+Design-system anchors (from `DesignSystem.Tokens` / existing views):
+- Secondary/grey text: `.font(Tokens.metadataFont).foregroundStyle(Tokens.secondaryText)` (same as
+  granted-permission text and all subtitles).
+- Small actions: `Button(…).buttonStyle(.bordered).controlSize(.small)`.
+- Capsule chip (for badges/warnings): the `requiresCalendarAccessBadge` pattern — a `Capsule`
+  fill + caption text + optional SF Symbol.
+- Warning accent: `.warningOchre` / `Tokens.warningChipFill` + `Tokens.warningChipText`.
+- Positive accent: `.sage`.
+- Sheet: `.sheet(isPresented:)`, fixed width, `Tokens.spacing*` padding, `@Environment(\.dismiss)`
+  (same as `AlertsHelpSheet`).
+
+---
+
+## 1. Settings Row — "AI Language Model"
+
+Lives in the **AI Enhancements** section, directly under the "AI Analysis & Summary" toggle +
+description. It is **always shown** (replaces the conditional `modelDownloadRow`). Same horizontal
+shape as the permission rows: label/subtitle on the left, trailing status + action on the right.
+
+**State A — an active model exists** (downloaded + selected):
+
+```
+┌─ AI Enhancements ───────────────────────  AI runs locally on your Mac. ─┐
+│  ◉ AI Analysis & Summary                                            [on] │
+│    Generate a title and summary from the transcript, and guess …         │
+│                                                                          │
+│  AI Language Model                              Gemma 4 12B   [ Manage ] │
+│  The AI model used to summarize meetings                                 │
+└──────────────────────────────────────────────────────────────────────── ┘
+```
+
+- `Gemma 4 12B` = active model's display name in **grey/secondary** text (the granted-permission
+  treatment).
+- `Manage` = `.bordered`, `.controlSize(.small)` → opens the Manage Models sheet.
+
+**State B — no model downloaded:**
+
+```
+│  AI Language Model                                          [ Download… ] │
+│  The AI model used to summarize meetings                                 │
+```
+
+- No grey model name. A single `Download…` button (`.bordered`, `.small`) opens the sheet (the sheet
+  is where the actual download happens).
+- The "AI Analysis & Summary" toggle remains **disabled** in this state (unchanged behavior).
+
+**(Optional, low priority) State C — downloading, none active yet:** the trailing area may read
+`Downloading… 62%` in grey with the `Manage` button beside it. Acceptable to ship A/B only and let
+the sheet own progress.
+
+---
+
+## 2. Manage Models Sheet
+
+Presented from the row's `Manage`/`Download…` button. Fixed-width sheet (~**480 pt**), vertically
+sized to content, scrollable if the catalog grows. Built as a **list of model rows** so adding a
+catalog entry just adds a row.
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  AI Language Model                                            │
+│  Choose the model used to summarize your meetings. It runs    │
+│  entirely on your Mac.                                        │
+│                                                              │
+│  ┌────────────────────────────────────────────────────────┐ │
+│  │ Gemma 4 12B   ⬤ Recommended                 ✓ Default   │ │
+│  │ Intelligent, but slower and larger.          [ Delete ] │ │
+│  │ Requires 7 GB of disk and uses 8 GB RAM.                │ │
+│  └────────────────────────────────────────────────────────┘ │
+│  ┌────────────────────────────────────────────────────────┐ │
+│  │ Gemma 4 E2B                              [ Choose Model ]│ │
+│  │ Small and fast, but not as intelligent.      [ Delete ] │ │
+│  │ Requires 3 GB of disk and uses 4 GB of RAM.             │ │
+│  └────────────────────────────────────────────────────────┘ │
+│                                                              │
+│                                                    [ Done ]  │
+└──────────────────────────────────────────────────────────────┘
+```
+
+- **Header:** title "AI Language Model" + one-line grey subtitle ("…runs entirely on your Mac.").
+- **Footer:** a single `Done` button (trailing) dismisses; dismiss never cancels an in-flight
+  download.
+- **Rows** are lightly separated cards (a subtle divider or grouped-form styling; match the app's
+  grouped `Form` look used elsewhere in Settings).
+
+### 2.1 Row anatomy
+
+```
+┌────────────────────────────────────────────────────────────┐
+│ <Model name>  <Recommended badge?>      <selection control> │  ← line 1
+│ <Description line 1>                     <primary action>   │  ← line 2
+│ <Description line 2 / warning / progress>                   │  ← line 3
+└────────────────────────────────────────────────────────────┘
+```
+
+- **Left column:** name (primary weight) + optional **Recommended** badge on line 1; the two-line
+  description in grey below; **warning** or **progress** replaces/*follows* the description when
+  relevant.
+- **Right column:** the **selection control** (top) and the **primary file action** (below),
+  trailing-aligned. When a state has only one control, it sits alone.
+
+### 2.2 Badges & indicators
+
+- **Recommended badge:** a small `Capsule` chip with a **positive/sage** fill and "Recommended"
+  caption (mirrors the `requiresCalendarAccessBadge` construction, sage instead of ochre). Exactly
+  one row ever shows it.
+- **Default (selected) indicator:** a `checkmark.circle.fill` in `.sage` + "Default" text
+  (secondary). Clear, non-buttony — it communicates "this is the one in use."
+- **Choose Model:** `.bordered`, `.small` button (shown only when downloaded + runnable + not
+  selected).
+- **Delete:** `.bordered`, `.small`; placed below the selection control. (Could use a subtle
+  destructive tint, e.g. red text, but standard bordered is fine.)
+- **Download:** `.bordered`, `.small`.
+
+### 2.3 Per-state row mockups
+
+**Runnable · not downloaded · enough disk** (E2B recommended example):
+
+```
+│ Gemma 4 E2B   ⬤ Recommended                     [ Download ] │
+│ Small and fast, but not as intelligent.                      │
+│ Requires 3 GB of disk and uses 4 GB of RAM.                  │
+```
+
+**Downloading** (determinate; indeterminate spinner when no Content-Length):
+
+```
+│ Gemma 4 12B                                                  │
+│ Intelligent, but slower and larger.                          │
+│ ▓▓▓▓▓▓▓▓░░░░░░  Downloading… 62%                              │
+```
+
+**Download failed:**
+
+```
+│ Gemma 4 12B                                                  │
+│ Intelligent, but slower and larger.                          │
+│ Download failed: <reason>                          [ Retry ] │
+```
+
+**Downloaded · selected (Default):**
+
+```
+│ Gemma 4 12B   ⬤ Recommended                       ✓ Default  │
+│ Intelligent, but slower and larger.                [ Delete ]│
+│ Requires 7 GB of disk and uses 8 GB RAM.                     │
+```
+
+**Downloaded · not selected:**
+
+```
+│ Gemma 4 E2B                                  [ Choose Model ]│
+│ Small and fast, but not as intelligent.            [ Delete ]│
+│ Requires 3 GB of disk and uses 4 GB of RAM.                  │
+```
+
+**Not runnable** (12B on < 15 GB Mac) — whole row greyed/disabled; warning chip replaces actions:
+
+```
+│ Gemma 4 12B                                       (disabled) │
+│ Intelligent, but slower and larger.                          │
+│ ⚠ This Mac can't run this model                              │
+```
+
+**Runnable · not downloaded · insufficient disk** — Download disabled, warning shown:
+
+```
+│ Gemma 4 12B   ⬤ Recommended                  [ Download ](off)│
+│ Intelligent, but slower and larger.                          │
+│ ⚠ Insufficient free space on disk                            │
+```
+
+- Warnings (`⚠ …`) render in the warning accent (`.warningOchre` text or the warning chip),
+  occupying the description's third line so row height stays stable.
+
+### 2.4 Concurrency affordance
+
+While one model downloads, other not-downloaded rows show their `Download` button **disabled**
+(greyed) — no extra explanatory text needed; the in-flight row's progress makes the reason obvious.
+
+---
+
+## 3. Delete Confirmation
+
+A standard macOS confirmation (`.confirmationDialog` or `.alert`) before destroying a multi-GB file:
+
+```
+Delete Gemma 4 12B?
+This frees about 7 GB. You can download it again anytime.
+                                          [ Cancel ]  [ Delete ]
+```
+
+- `Delete` is destructive-styled; `Cancel` is default.
+- On confirm, the file is removed and selection recomputes (functional spec §4.3).
+
+---
+
+## 4. UX Rationale
+
+- **Discoverability:** the model row is now permanent, so the choice is always visible — not hidden
+  until a download state. The `Manage` button is the obvious entry point.
+- **Progressive disclosure:** the Settings row stays minimal (name + Manage); all complexity
+  (sizes, recommendation, download/delete, blocked states) lives in the sheet, surfaced only when
+  the user opts in.
+- **Low cognitive load / guidance without forcing:** the single **Recommended** badge nudges the
+  right choice; blocked models are visibly explained ("This Mac can't run this model") rather than
+  silently missing, so the user understands *why*.
+- **Platform conventions:** grouped `Form` rows, bordered small buttons, a standard sheet, and a
+  destructive confirmation — all already used elsewhere in the app; nothing novel to learn.
+
+---
+
+## 5. Accessibility & Copy
+
+- All buttons have clear text labels; the Recommended badge and Default indicator pair an icon with
+  text (never icon-only).
+- Warning text is real text (not color-only), so meaning survives without color perception.
+- Exact copy strings (single source — match the functional spec catalog):
+  - Row title/subtitle: "AI Language Model" / "The AI model used to summarize meetings".
+  - Sheet subtitle: "Choose the model used to summarize your meetings. It runs entirely on your Mac."
+  - Warnings: "This Mac can't run this model" / "Insufficient free space on disk".
+  - Descriptions: per-model copy from the catalog (functional spec §2).

--- a/specs/projects/onboarding_download_models/architecture.md
+++ b/specs/projects/onboarding_download_models/architecture.md
@@ -1,0 +1,253 @@
+---
+status: complete
+---
+
+# Architecture: Onboarding — Download Models (V2)
+
+A contained refactor of the `.modelDownload` step in the `OnboardingUI` module of `BiscottiKit`,
+plus a small cleanup that extracts the Manage Models sheet into a shared module. All model logic
+(recommendation, download, inventory, suitability, disk) is consumed from the existing
+`ModelManager` (Intelligence) and `TranscriptionService` — none of it is reimplemented.
+
+Everything fits in this doc; no separate `/components` designs.
+
+## 1. New shared module + dependency changes (`Packages/BiscottiKit/Package.swift`)
+
+Extract the Manage Models sheet into a new **`ModelManagementUI`** module so both `SettingsUI` and
+`OnboardingUI` can present it without a UI→UI sibling edge.
+
+- **New product/target `ModelManagementUI`** — dependencies: `AppCore`, `DesignSystem`,
+  `Intelligence`, `.product(name: "LocalLLM", package: "LocalLLM")`. (These are exactly what the
+  sheet already imports.) Add the matching `.library(name: "ModelManagementUI", …)` product.
+- **New test target `ModelManagementUITests`** — dependencies: `ModelManagementUI`, `AppCore`,
+  `BiscottiTestSupport`, `Intelligence`, `LocalLLM` (where the moved `ManageModelsViewModelTests` land).
+- **`SettingsUI` target** — add dependency `"ModelManagementUI"`. Keep `Intelligence`/`LocalLLM`
+  (still used by `SettingsViewModel`). Its `ManageModelsSheet.swift` file is **moved out** (§2).
+- **`OnboardingUI` target** — add dependencies: `"ModelManagementUI"`, `"Intelligence"`,
+  `.product(name: "LocalLLM", package: "LocalLLM")`. (Keeps existing: AppCore, Calendar, DataStore,
+  DesignSystem, Permissions, TranscriptionService.)
+- **`OnboardingUITests` target** — add `"Intelligence"`, `.product(name: "LocalLLM", package:
+  "LocalLLM")` so VM/state tests build with the model types. (`ModelManagementUI` only if a test
+  constructs the sheet — not needed for the VM/state tests.)
+- **App**: no `App/project.yml` change — `ModelManagementUI` is a transitive product via
+  `AppShellUI → SettingsUI`/`OnboardingUI`, so SPM links it automatically.
+
+## 2. Extract the sheet (`SettingsUI/ManageModelsSheet.swift` → `ModelManagementUI/`)
+
+- **Move** `ManageModelsSheet.swift` to `Sources/ModelManagementUI/ManageModelsSheet.swift`. It
+  contains `ManageModelsViewModel` (already `public`), `ManageModelsSheet`, `ModelRowView`, and the
+  `ModelBlockedReason.warningText` extension. Imports are unchanged
+  (`AppCore`/`DesignSystem`/`Intelligence`/`LocalLLM`/`SwiftUI`).
+- Make `ManageModelsSheet` `public` with a `public init` (it's now consumed cross-module).
+  `ModelRowView` and the `warningText` extension stay internal to `ModelManagementUI`.
+- **Move** the test file `Tests/SettingsUITests/ManageModelsViewModelTests.swift` →
+  `Tests/ModelManagementUITests/ManageModelsViewModelTests.swift` (imports already are AppCore /
+  BiscottiTestSupport / Intelligence / LocalLLM — add `import ModelManagementUI`).
+- **`SettingsUI/SettingsView.swift`** — `import ModelManagementUI` (still builds the sheet exactly as
+  today). `SettingsViewModel.swift` only references the sheet in a comment — no code change.
+- No behavior change anywhere; Settings presents the identical sheet.
+
+## 3. Scaffold width (`OnboardingUI/OnboardingScaffold.swift`, `OnboardingView.swift`)
+
+- `OnboardingScaffold` gains `var contentMaxWidth: CGFloat = 520` and applies
+  `.frame(maxWidth: contentMaxWidth)` instead of the hard-coded 520.
+- `OnboardingView` passes `contentMaxWidth: viewModel.currentStep == .modelDownload ? 560 : 520`.
+- All other steps are visually unchanged (still 520).
+
+## 4. `OnboardingViewModel` changes (`OnboardingUI/OnboardingViewModel.swift`)
+
+New imports: `Intelligence`, `LocalLLM`.
+
+### 4.1 AppCore exposure (for the sheet)
+- Add `public var appCore: AppCore { core }` (read-only), mirroring `SettingsViewModel.appCore`, so
+  the view can build `ManageModelsViewModel(core: viewModel.appCore)`.
+
+### 4.2 Sheet presentation state
+- `public var showVariantSheet: Bool = false`.
+
+### 4.3 Transcription row (extend existing fields; no new subsystem)
+- Keep existing `isDownloading`, `downloadStatus`, `downloadComplete`, `hasSufficientDisk`.
+- Add `public private(set) var transcriptionDownloaded: Bool = false` — set from the on-entry probe.
+- Rename `startDownload()` → `startTranscriptionDownload()` (update call sites + tests).
+- `var transcriptionReady: Bool { transcriptionDownloaded || downloadComplete }`.
+- Disk: retarget the existing check to the transcription class size. Keep
+  `requiredDiskSpaceMB` (≈1500 for ~1.5 GB; pick the value already used, currently 2000 — confirm or
+  set to 1500) and expose `var transcriptionInsufficientDisk: Bool { !hasSufficientDisk }`.
+
+### 4.4 Language row (derived entirely from `core.modelManager`)
+- `var languageTargetModelID: String? { core.modelManager.activeModelID ?? core.modelManager.recommendedModelID() }`
+  — what the easy-path Download pulls and what the idle row describes.
+- `var recommendedLanguageDisplayName: String?` — `LLMModelCatalog.model(id: recommendedModelID())?.displayName`.
+- `var languageReady: Bool { core.modelManager.isModelAvailable }`.
+- `func startLanguageDownload() { Task { await core.modelManager.downloadModel(id: targetID) } }`
+  (guarded by `languageTargetModelID`; `downloadModel` itself enforces runnable/disk/one-at-a-time).
+- The in-flight LLM download + per-variant disk/blocked come from `core.modelManager.downloads` and
+  `core.modelManager.modelChoices()` (look up the target id's `ModelChoice`).
+
+### 4.5 Row-state computation (the unit-test surface)
+Define an internal enum in `OnboardingUI` used by both rows:
+
+```swift
+enum RowDownloadProgress: Equatable {
+    case indeterminate(status: String?)   // transcription
+    case determinate(fraction: Double?)   // language (nil → spinner fallback)
+}
+enum ModelRowState: Equatable {
+    case idle(sizeCaption: String)
+    case insufficientDisk
+    case downloading(RowDownloadProgress)
+    case ready
+    case failed(message: String)
+}
+```
+
+VM provides two computed mappers (pure functions of observable state, so SwiftUI re-renders when
+`downloads`/status change):
+- `func transcriptionRowState() -> ModelRowState`
+  - ready if `transcriptionReady`; else insufficientDisk if `transcriptionInsufficientDisk`;
+    else downloading(`.indeterminate(status: downloadStatus)`) if `isDownloading`;
+    else failed if a transcription failure flag is set; else `.idle(sizeCaption: "~1.5 GB")`.
+- `func languageRowState() -> ModelRowState`
+  - Let `choice = modelChoices().first(where: { $0.id == languageTargetModelID })`.
+  - ready if `languageReady`; else if `downloads[targetID]` is `.downloading(f)` →
+    `.downloading(.determinate(fraction: f))`; else if `.failed(m)` → `.failed(m)`;
+    else if `choice?.blockedReason == .insufficientDisk` → `.insufficientDisk`;
+    else `.idle(sizeCaption: sizeString(choice.model.approxDownloadBytes))`.
+
+### 4.6 Footer & readiness
+- `var bothModelsReady: Bool { transcriptionReady && languageReady }`.
+- `footerButton(for: .modelDownload)` → `bothModelsReady ? .continueButton : .skip`
+  (replaces the `downloadComplete ?` check).
+
+### 4.7 On-entry preparation
+- Add `private func prepareModelStep() async`:
+  - `await core.modelManager.refresh()` (idempotent; reflects on-disk truth).
+  - `transcriptionDownloaded = await core.transcription.modelsReady()`.
+  - `checkDiskSpace()`.
+- In `proceed()`, replace the two `checkDiskSpace()` calls (before entering `.modelDownload`) with
+  `await prepareModelStep()`.
+- `resetForReplay()` resets the new fields (`transcriptionDownloaded = false`, `showVariantSheet = false`).
+
+## 5. View changes (`OnboardingUI`)
+
+### 5.1 `OnboardingStepViews.swift` — rewrite `modelDownloadStep`
+- Title unchanged; lead → "One-time download. AI runs locally — nothing leaves your Mac."
+- Body → the new `ModelCard` (below) instead of `downloadContent`.
+- Footer → existing `footerButton` (now driven by `bothModelsReady`).
+- `import ModelManagementUI`; `.sheet(isPresented: $viewModel.showVariantSheet) { ManageModelsSheet(viewModel: ManageModelsViewModel(core: viewModel.appCore)) }`.
+- Remove the old `downloadContent` (single Download Now button / COMPLETE tag).
+
+### 5.2 New view(s), in a new file `OnboardingUI/ModelDownloadCard.swift`
+(The `RowDownloadProgress`/`ModelRowState` enums are VM output — define them alongside the view model
+in the VM-logic phase, e.g. a small `ModelRowState.swift`; these views consume them.)
+- `ModelCard` — `VStack(spacing: 0)` of the two rows + `InsetDivider(leadingInset: 48)`, `.homeCard()`,
+  `.frame(maxWidth: 560)`. (Chrome identical to `permissionCard`.)
+- `ModelDownloadRow` — icon tile (same metrics as `PermissionRow`) + name + why + optional
+  recommendation line (language only) + trailing `DownloadControl`. Top-aligned (`.top`). Either a
+  small purpose-built view or `PermissionRow` reuse if its generics fit the third line — prefer the
+  least code; keep metrics identical.
+- `DownloadControl` — switches on `ModelRowState`:
+  - `.idle(caption)` → `DownloadPill` + caption (`.biscottiMono(11)`, `.inkTertiary`).
+  - `.downloading(.indeterminate(status))` → reuse today's 240×3 sliding sage bar + status text.
+  - `.downloading(.determinate(fraction))` → determinate sage capsule bar (fraction) + "Downloading… NN%";
+    nil fraction → indeterminate bar + "Downloading…".
+  - `.ready` → `GrantedTag("READY")`.
+  - `.insufficientDisk` → warning ("Insufficient free space on disk"), no pill.
+  - `.failed(message)` → error text + Retry (calls the row's onDownload).
+- `RecommendationLine` — grey "Recommended · \(name)" + plain "See all options ›"
+  (`chevron.right`) → sets `showVariantSheet = true`. No icon.
+
+### 5.3 Generalize `GrantPill` (`OnboardingUI/PermissionRow.swift`)
+- Change `GrantPill` to accept a title + optional leading SF Symbol, defaulting to the current
+  behavior so existing call sites (`GrantPill { ... }`) keep compiling:
+  ```swift
+  struct GrantPill: View {
+      var title: String = "Grant"
+      var systemImage: String? = nil
+      let action: () -> Void
+      // Button { action() } label: { HStack { optional Image; Text(title) } }.buttonStyle(JoinRecordButtonStyle())
+  }
+  ```
+  The download pill uses `GrantPill(title: "Download", systemImage: "arrow.down.circle") { ... }`.
+  (`GrantedTag` already supports a custom label — pass "READY".)
+
+## 6. Reuse map (what is consumed, not built)
+
+| Need | Source (existing) |
+|---|---|
+| Recommended variant id / display name | `ModelManager.recommendedModelID()`, `LLMModelCatalog.model(id:)` |
+| Active/selected language model | `ModelManager.activeModelID`, `isModelAvailable` |
+| Start/track LLM download | `ModelManager.downloadModel(id:)`, `downloads[id]` (`ModelDownloadState`) |
+| Per-variant disk/runnable/blocked | `ModelManager.modelChoices()` → `ModelChoice.blockedReason` |
+| Variant sheet ("See all options") | `ModelManagementUI.ManageModelsSheet` + `ManageModelsViewModel` (extracted, made public) |
+| Transcription download/status | `TranscriptionService.ensureModelsReady(status:)` |
+| Transcription readiness probe | `TranscriptionService.modelsReady()` |
+| Card chrome / divider | `DesignSystem` `.homeCard()`, `InsetDivider` |
+| Icon tile metrics | copy from `PermissionRow` |
+| Pills / tags / bars | `GrantPill` (generalized), `GrantedTag("READY")`, existing sage bar idiom |
+
+## 7. Testing
+
+`OnboardingUITests` (uses `BiscottiTestSupport` fakes for `AppCore`/`ModelManager`/transcription):
+- **Row-state mapping** — table-driven over inputs (transcription downloaded/ downloading/ disk;
+  language: not-downloaded/ downloading(fraction)/ downloaded/ blocked-disk/ failed; low-RAM forcing
+  E2B target) → expected `transcriptionRowState()` / `languageRowState()`.
+- **Footer** — `bothModelsReady` / `footerButton(.modelDownload)` across the matrix
+  (neither ready → skip; one ready → skip; both ready → continue).
+- **Target model** — `languageTargetModelID` = recommended when nothing downloaded; = active when a
+  model is downloaded/selected.
+- **On-entry prepare** — entering `.modelDownload` sets `transcriptionDownloaded` from the
+  transcription fake and refreshes `ModelManager` (downloaded fake → row ready, footer continue).
+- **Skip/advance** — both advance to `.done` regardless of readiness.
+- Existing onboarding tests updated for the `startDownload` → `startTranscriptionDownload` rename and
+  the footer rule change.
+
+Build/lint via `hooks-mcp` (`build`, `test`, `lint`); never raw `swift`/`xcodebuild` in-sandbox.
+
+## 8. File-by-file change list
+
+**Add (extraction — §1/§2)**
+- `Packages/BiscottiKit/Sources/ModelManagementUI/ManageModelsSheet.swift` — **moved** from SettingsUI;
+  `ManageModelsSheet` made `public` (+ `public init`).
+- `Packages/BiscottiKit/Tests/ModelManagementUITests/ManageModelsViewModelTests.swift` — **moved** from
+  `SettingsUITests` (+ `import ModelManagementUI`).
+
+**Modify**
+- `Packages/BiscottiKit/Package.swift` — new `ModelManagementUI` library product + target and
+  `ModelManagementUITests` target; `SettingsUI` += `ModelManagementUI`; `OnboardingUI` +=
+  `ModelManagementUI`, `Intelligence`, `LocalLLM`; `OnboardingUITests` += `Intelligence`, `LocalLLM`.
+- `Packages/BiscottiKit/Sources/SettingsUI/SettingsView.swift` — `import ModelManagementUI`.
+- `Packages/BiscottiKit/Sources/OnboardingUI/OnboardingScaffold.swift` — add `contentMaxWidth` param.
+- `Packages/BiscottiKit/Sources/OnboardingUI/OnboardingView.swift` — pass 560 for `.modelDownload`.
+- `Packages/BiscottiKit/Sources/OnboardingUI/OnboardingViewModel.swift` — §4 (state, computed,
+  prepare, footer, rename).
+- `Packages/BiscottiKit/Sources/OnboardingUI/OnboardingStepViews.swift` — rewrite `modelDownloadStep`,
+  attach the sheet, remove old `downloadContent`.
+- `Packages/BiscottiKit/Sources/OnboardingUI/PermissionRow.swift` — generalize `GrantPill`.
+
+**Add**
+- `Packages/BiscottiKit/Sources/OnboardingUI/ModelRowState.swift` — `RowDownloadProgress` /
+  `ModelRowState` enums (VM-logic phase).
+- `Packages/BiscottiKit/Sources/OnboardingUI/ModelDownloadCard.swift` — `ModelCard`,
+  `ModelDownloadRow`, `DownloadControl`, `RecommendationLine` (screen-rewrite phase).
+- `Packages/BiscottiKit/Tests/OnboardingUITests/…` — row-state/footer/target/prepare tests
+  (new file or extend existing).
+
+**No change** (consumed as-is): `Intelligence/ModelManager.swift`, `ModelSuitability`, `ModelPolicy`,
+`LocalLLM/*`, `TranscriptionService` (beyond using `ensureModelsReady`/`modelsReady`), the Settings
+AI row.
+
+## 9. Risks / notes
+
+- **Layering**: the extraction yields a clean DAG — `ModelManagementUI` is a shared leaf UI module;
+  `SettingsUI` and `OnboardingUI` both depend on it (no UI→UI sibling edge). If the repo's top-level
+  `architecture.md` documents the module DAG, add `ModelManagementUI` there during/after the build.
+- **Observation**: row-state mappers read `core.modelManager.downloads` etc.; since both view models
+  are `@Observable`, SwiftUI tracks those reads and re-renders on download progress. Verify the
+  language bar animates during a real download in the manual pass.
+- **Disk constant**: confirm the transcription disk requirement (the current `requiredDiskSpaceMB =
+  2000` vs the ~1.5 GB copy). Align the gate with the copy.
+- **No manual-test staleness impact**: this project touches `Packages/BiscottiKit` UI only — not
+  `Packages/Transcription`, `Packages/AudioCapture`, or `Packages/LocalLLM` — so the
+  `manual_test_results.json` gate is unaffected. (On-hardware verification of the screen is still
+  worthwhile but not gated.)

--- a/specs/projects/onboarding_download_models/functional_spec.md
+++ b/specs/projects/onboarding_download_models/functional_spec.md
@@ -1,0 +1,187 @@
+---
+status: complete
+---
+
+# Functional Spec: Onboarding — Download Models (V2)
+
+A **delta** project. It rewrites the body of the onboarding `.modelDownload` step so the user can
+download **both** model classes (transcription + language) from one screen, reusing the existing
+download/recommendation/inventory machinery and the existing **Manage Models** sheet. Everything
+else in onboarding (window, scaffold, progress header, footer mechanics, other steps) is unchanged.
+
+## 1. Scope
+
+**In scope** — the `.modelDownload` step only:
+- Replace the single "Download Now" button (transcription-only) with a **two-row model card**:
+  one row for **Transcription & Speaker ID**, one for the **Language Model**.
+- Wire the language row to the existing `ModelManager` (recommend / download / track / readiness).
+- A **"See all options"** affordance that presents the **existing** Manage Models sheet.
+- Footer: show **Skip** until both classes are ready, then **Continue** (extends the existing
+  "skip-until-complete" rule from transcription-only to both classes).
+- Lead copy + visual structure updates per the design spec (see `ui_design.md`).
+
+**Out of scope** (unchanged):
+- The Settings AI Language Model row and the Manage Models sheet's own behavior (beyond making the
+  sheet reachable from onboarding).
+- The rest of the onboarding flow and the `OnboardingScaffold` / `ProgressHeader` / `BrandFooter`.
+- Mid-download cancellation. Skip abandons the step; in-flight downloads continue in the background
+  and finish (existing behavior — both subsystems own their own tasks).
+- Numeric byte-level progress for the **transcription** download (see Decision D1).
+- New product behavior in `ModelManager`, `ModelSuitability`, `ModelPolicy`, the catalog, or the
+  transcription pipeline. This project consumes them as-is.
+
+## 2. The two model classes
+
+| Class | Backing | Approx size | Download/state source |
+|---|---|---|---|
+| **Transcription & Speaker ID** | Whisper V3 Turbo (WhisperKit) | ~1.5 GB | `core.transcription.ensureModelsReady(status:)` + `modelsReady()` |
+| **Language Model** | Gemma 4 E2B or 12B (recommended per hardware) | ~3 GB (E2B) / ~7 GB (12B) | `core.modelManager` (`downloadModel`, `downloads`, `recommendedModelID`, `activeModelID`, `isModelAvailable`) |
+
+The two downloads are **independent and concurrent** — they live in different subsystems, so starting
+one never blocks the other. (Within the language class, `ModelManager` already enforces one variant
+download at a time; that's fine — only one LLM is ever needed.)
+
+## 3. Transcription row
+
+Three states, driven by the existing transcription machinery (no new plumbing):
+
+- **Idle** (not downloaded, enough disk): a **Download** control + size caption "~1.5 GB". Tapping
+  calls `startTranscriptionDownload()` → `core.transcription.ensureModelsReady`.
+- **Downloading**: an **indeterminate** sage progress bar + the status text the engine emits
+  (e.g. "Downloading speech-to-text model"). No %/MB caption — the engine provides only string
+  status (Decision **D1**).
+- **Ready** (downloaded): the **READY** tag (the existing `GrantedTag`, labeled "READY"). No caption.
+- **Blocked — insufficient disk**: Download disabled + an "Insufficient free space on disk" warning,
+  when free disk is below the transcription requirement (~1.5 GB; reuse the existing onboarding disk
+  check, retargeted to this class).
+- **Failed**: status text "Download failed. You can retry or skip." and the Download control returns
+  so the user can retry (existing behavior).
+
+Readiness on entry: when the step appears, probe `core.transcription.modelsReady()` so an
+already-cached transcription model shows **READY** immediately (e.g. on onboarding replay).
+
+## 4. Language row
+
+State derives entirely from `ModelManager` (no new model state):
+
+- **Target model** (what the easy-path Download pulls and what the row describes) =
+  `activeModelID` if a language model is already downloaded/selected, else `recommendedModelID()`.
+  `recommendedModelID()` always returns at least E2B, so there is always a valid target.
+- **Recommendation line** (idle only): a quiet grey line — `"Recommended · <displayName of
+  recommendedModelID()>"` — plus a **"See all options ›"** link that presents the Manage Models
+  sheet. No icon/chip (the row's `sparkles` tile already carries the AI cue). Per the design.
+- **Idle** (no language model downloaded, none in flight): **Download** control + size caption =
+  the target model's `approxDownloadBytes` (e.g. "~3.2 GB"). Tapping calls
+  `core.modelManager.downloadModel(id:)` with the target id.
+- **Downloading** (any LLM download in flight): a **determinate** sage progress bar + percentage,
+  using the in-flight model's `downloads[id] == .downloading(fraction)`. If `fraction` is nil
+  (server omitted Content-Length), fall back to an indeterminate bar + "Downloading…".
+- **Ready** (`isModelAvailable == true`): the **READY** tag. No caption, no recommendation line.
+- **Blocked — insufficient disk** for the target model (`ModelChoice.blockedReason ==
+  .insufficientDisk`): Download disabled + "Insufficient free space on disk" warning. (The user can
+  still open "See all options" to pick a smaller variant.)
+- **Failed** (`downloads[id] == .failed`): error text + Retry, mirroring the sheet's behavior.
+
+Note on low-RAM Macs: 12B is non-runnable and `recommendedModelID()` returns E2B, so the easy-path
+Download pulls E2B; the disabled 12B appears only inside the "See all options" sheet. No
+onboarding-specific RAM logic — all of it lives in `ModelSuitability`/`ModelManager` already.
+
+## 5. "See all options" — reuse the existing sheet
+
+"See all options" presents the **existing** `ManageModelsSheet` (the same one Settings opens), built
+with a `ManageModelsViewModel(core:)`. It already renders both variants, the Recommended badge,
+per-variant download/delete/choose, the low-RAM disabling of 12B, and per-variant disk warnings.
+
+Reuse is by **extracting the sheet into a shared `ModelManagementUI` module** that both `SettingsUI`
+and `OnboardingUI` depend on (Decision **D3**). The sheet types (`ManageModelsSheet`,
+`ManageModelsViewModel`, `ModelRowView`) only depend on `AppCore`/`DesignSystem`/`Intelligence`/
+`LocalLLM` — nothing SettingsUI-specific — so the move is a clean, mechanical refactor with no
+behavior change. **No fork, no reimplementation.** Downloads or selections made inside the sheet flow
+through the shared `ModelManager`, so the language row reflects them automatically on dismiss (it goes
+to downloading/ready as appropriate).
+
+## 6. Footer — Skip until both ready, then Continue
+
+- While **either** class is not ready: show only **Skip** ("Skip for now" per design copy; advances
+  to `.done`). No top-level primary button — downloads are triggered inside the card rows.
+- When **both** are ready (`transcriptionReady && core.modelManager.isModelAvailable`): swap to the
+  primary **Continue** button (advances to `.done`).
+- Both Skip and Continue advance to `.done`. Skipping leaves models un-downloaded; the app fetches
+  them on first use (existing behavior — unchanged). This extends the step's existing
+  skip-until-complete rule (`footerButton(for: .modelDownload)`), changing "complete" from
+  "transcription downloaded" to "both classes ready".
+
+## 7. Entering the step / state sync
+
+When the `.modelDownload` step is entered (and on replay reset), the view model prepares row state:
+- `await core.modelManager.refresh()` so `downloads`/selection reflect on-disk truth (idempotent;
+  also runs at app launch).
+- `transcriptionReady = await core.transcription.modelsReady()`.
+- Recompute the per-row disk checks.
+
+This makes already-downloaded models show **READY** without re-downloading, and surfaces the correct
+footer (Continue if both already present).
+
+## 8. Edge cases
+
+- **Already downloaded (one or both):** rows show READY; footer reflects `bothReady` (Continue if both).
+- **Insufficient disk:** per-row warning + disabled Download, scoped to that class's size. The other
+  class is unaffected (independent checks).
+- **Low-RAM Mac:** language easy-path targets E2B; 12B disabled only inside the sheet. No block on the
+  language row itself (E2B is always runnable).
+- **Download failure:** per-row failed state with Retry; the other row and the footer are unaffected.
+- **Concurrent downloads:** both may run at once (different subsystems). Footer stays on Skip until
+  both complete.
+- **Skip mid-download:** advances to `.done`; in-flight downloads continue and finish in the
+  background (no cancellation). On a later visit (or in Settings) they show as ready.
+- **Reduced Motion:** honor `accessibilityReduceMotion` — instant state swaps, no springs/pulsing
+  (matches the existing onboarding transition handling).
+- **Variant changed in sheet then dismissed without downloading:** the row stays idle; the
+  recommendation line continues to show `recommendedModelID()` (the easy-path target). Choosing to
+  *download* in the sheet moves the row to downloading/ready via the shared `ModelManager`.
+
+## 9. Decisions log (design-spec vs. shipped-code conflicts)
+
+The design spec came from a design agent unaware of the code. Where it conflicted, these are the
+resolutions (the human can flip any of them):
+
+- **D1 — Transcription progress is indeterminate (no MB/%).** The design wanted a determinate bar +
+  "412 MB / 1.5 GB" for both rows. The transcription engine (`Transcribing` seam) emits only string
+  status, not byte counts. Rather than thread byte-level progress through the sensitive Transcription
+  package, the **transcription row uses an indeterminate bar + status text**, while the **language row
+  shows a real determinate bar + %** (it has byte fractions via `ModelManager`). Honest to each
+  subsystem; minimal code. *(Recommended; chosen.)*
+- **D2 — Card width 560 (widen the scaffold for this step).** Per the design, the card is **560**.
+  The shipped `OnboardingScaffold` caps centered content at `maxWidth: 520`, so the scaffold gains a
+  `contentMaxWidth` parameter (default 520) and `OnboardingView` passes **560 for the
+  `.modelDownload` step only**. Other steps are unchanged at 520. *(Chosen by human.)*
+- **D3 — Reuse the sheet by extracting a shared `ModelManagementUI` module.** "See all options"
+  presents the existing `ManageModelsSheet`, moved (with `ManageModelsViewModel` + `ModelRowView` +
+  its tests) out of `SettingsUI` into a new shared `ModelManagementUI` module that both `SettingsUI`
+  and `OnboardingUI` depend on. Clean DAG (no UI→UI sibling edge); the sheet only ever needed
+  `AppCore`/`DesignSystem`/`Intelligence`/`LocalLLM`, so the move is mechanical and behavior-preserving.
+  *(Chosen by human — small refactor, good cleanup.)*
+- **D4 — "READY" label.** Per the design, the done tag reads **READY** (the transcription step
+  previously used "COMPLETE"). Adopted.
+- **D5 — Naming.** Code uses the step name `.modelDownload` and the type `OnboardingViewModel`
+  (an `@Observable`, not the design's illustrative `OnboardingModel`/`@ObservedObject`). We keep the
+  shipped names; the design's code snippets are illustrative only.
+
+## 10. Acceptance criteria
+
+- Title stays "Download Local AI Models"; lead becomes "One-time download. AI runs locally —
+  nothing leaves your Mac."
+- One card with two rows (transcription, language) divided by an inset hairline, matching the
+  Grant-access card chrome, width 560 (scaffold content column widened to 560 for this step only).
+- Transcription row: `waveform` tile, Whisper copy, Download + "~1.5 GB" (idle) → indeterminate bar +
+  status text → READY.
+- Language row: `sparkles` tile, summaries/matching/titles copy, grey "Recommended · <model>" + bold
+  grey "See all options ›", Download + size caption (idle) → determinate bar + % → READY.
+- No icon next to "Recommended".
+- "See all options" opens the existing Manage Models sheet; choices/downloads there reflect back in
+  the language row.
+- Downloads are independent + concurrent; size caption sits below the Download control.
+- Footer shows only Skip until both classes are READY, then Continue. Both advance to `.done`.
+- Already-downloaded models show READY on entry (no re-download); footer reflects that.
+- Per-row insufficient-disk warning + disabled Download when applicable.
+- Reduced Motion: no springs/pulsing; instant swaps.

--- a/specs/projects/onboarding_download_models/implementation_plan.md
+++ b/specs/projects/onboarding_download_models/implementation_plan.md
@@ -47,7 +47,7 @@ module).
     phase; the new footer rule may transiently sit on "Skip" until Phase 3 wires the language row —
     acceptable at a phase boundary.)
 
-- [ ] **Phase 3 — Screen rewrite + sheet wiring.** Replace the step body with the two-row card and
+- [x] **Phase 3 — Screen rewrite + sheet wiring.** Replace the step body with the two-row card and
   present the extracted sheet.
   - Add `OnboardingUI/ModelDownloadCard.swift`: `ModelCard` (560-wide, `.homeCard()`, inset divider),
     `ModelDownloadRow` (icon tile + name + why + optional recommendation line, top-aligned),

--- a/specs/projects/onboarding_download_models/implementation_plan.md
+++ b/specs/projects/onboarding_download_models/implementation_plan.md
@@ -26,7 +26,7 @@ module).
   - *Green via `hooks-mcp` build + test + lint.* Settings behavior is unchanged — this CR is just the
     move. If the repo's top-level `architecture.md` documents the module DAG, add `ModelManagementUI`.
 
-- [ ] **Phase 2 — OnboardingUI view-model logic + reuse seams (no screen rewrite).** Wire the data path
+- [x] **Phase 2 — OnboardingUI view-model logic + reuse seams (no screen rewrite).** Wire the data path
   with the screen still rendering its old body so the package stays green.
   - `Package.swift`: add `ModelManagementUI`, `Intelligence`, `LocalLLM` to `OnboardingUI`; add
     `Intelligence`, `LocalLLM` to `OnboardingUITests`.

--- a/specs/projects/onboarding_download_models/implementation_plan.md
+++ b/specs/projects/onboarding_download_models/implementation_plan.md
@@ -1,0 +1,67 @@
+---
+status: complete
+---
+
+# Implementation Plan: Onboarding — Download Models (V2)
+
+Three phases, each compiling green and reviewable on its own. Details live in `functional_spec.md`,
+`ui_design.md`, and `architecture.md` (§8 has the file-by-file list). Decisions D1–D5 are locked in
+`functional_spec.md` §9 (D1 asymmetric progress, D2 width 560, D3 extract a shared `ModelManagementUI`
+module).
+
+## Phases
+
+- [x] **Phase 1 — Extract `ModelManagementUI` (pure refactor, no behavior change).** Move the Manage
+  Models sheet out of `SettingsUI` into a new shared module so both Settings and onboarding can use it.
+  - `Package.swift`: add the `ModelManagementUI` library product + target (deps `AppCore`,
+    `DesignSystem`, `Intelligence`, `LocalLLM`) and a `ModelManagementUITests` target (deps
+    `ModelManagementUI`, `AppCore`, `BiscottiTestSupport`, `Intelligence`, `LocalLLM`); add
+    `ModelManagementUI` to `SettingsUI`'s deps.
+  - Move `Sources/SettingsUI/ManageModelsSheet.swift` → `Sources/ModelManagementUI/ManageModelsSheet.swift`;
+    make `ManageModelsSheet` `public` (+ `public init`). `ManageModelsViewModel` already public;
+    `ModelRowView` + `warningText` stay internal.
+  - Move `Tests/SettingsUITests/ManageModelsViewModelTests.swift` →
+    `Tests/ModelManagementUITests/ManageModelsViewModelTests.swift` (+ `import ModelManagementUI`).
+  - `SettingsUI/SettingsView.swift`: `import ModelManagementUI` (no other change; identical sheet).
+  - *Green via `hooks-mcp` build + test + lint.* Settings behavior is unchanged — this CR is just the
+    move. If the repo's top-level `architecture.md` documents the module DAG, add `ModelManagementUI`.
+
+- [ ] **Phase 2 — OnboardingUI view-model logic + reuse seams (no screen rewrite).** Wire the data path
+  with the screen still rendering its old body so the package stays green.
+  - `Package.swift`: add `ModelManagementUI`, `Intelligence`, `LocalLLM` to `OnboardingUI`; add
+    `Intelligence`, `LocalLLM` to `OnboardingUITests`.
+  - `OnboardingScaffold.swift`: add `contentMaxWidth` param (default 520; no caller change yet).
+  - `PermissionRow.swift`: generalize `GrantPill` to `(title = "Grant", systemImage: String? = nil,
+    action)` so existing call sites keep compiling.
+  - Add `OnboardingUI/ModelRowState.swift`: `RowDownloadProgress` / `ModelRowState` enums.
+  - `OnboardingViewModel.swift` (Arch §4): `appCore` exposure, `showVariantSheet`,
+    `transcriptionDownloaded`; rename `startDownload()` → `startTranscriptionDownload()`; add
+    `startLanguageDownload()`, `languageTargetModelID`, `recommendedLanguageDisplayName`,
+    `languageReady`, `bothModelsReady`; `transcriptionRowState()` / `languageRowState()` mappers;
+    change `footerButton(.modelDownload)` to `bothModelsReady`; add `prepareModelStep()` and call it
+    from `proceed()` (replacing the `checkDiskSpace()` calls); update `resetForReplay()`; align the
+    transcription disk constant with the ~1.5 GB copy.
+  - Tests (`OnboardingUITests`, Arch §7): row-state mapping (table-driven), footer matrix, target
+    model, on-entry prepare, advance/skip; update existing tests for the `startDownload` rename.
+  - *Green via `hooks-mcp` build + test + lint.* (The old `modelDownloadStep` body still renders this
+    phase; the new footer rule may transiently sit on "Skip" until Phase 3 wires the language row —
+    acceptable at a phase boundary.)
+
+- [ ] **Phase 3 — Screen rewrite + sheet wiring.** Replace the step body with the two-row card and
+  present the extracted sheet.
+  - Add `OnboardingUI/ModelDownloadCard.swift`: `ModelCard` (560-wide, `.homeCard()`, inset divider),
+    `ModelDownloadRow` (icon tile + name + why + optional recommendation line, top-aligned),
+    `DownloadControl` (switch on `ModelRowState`: idle pill+caption / indeterminate (transcription) /
+    determinate %+bar (language) / READY tag / insufficient-disk warning / failed+Retry),
+    `RecommendationLine` (grey "Recommended · <model>" + "See all options ›", no icon).
+  - Rewrite `modelDownloadStep` (`OnboardingStepViews.swift`): `import ModelManagementUI`, new lead
+    copy, render `ModelCard`, keep the shared `footerButton`, attach
+    `.sheet(isPresented: $viewModel.showVariantSheet) { ManageModelsSheet(viewModel: ManageModelsViewModel(core: viewModel.appCore)) }`;
+    remove the old `downloadContent`.
+  - `OnboardingView.swift`: pass `contentMaxWidth: 560` for `.modelDownload` (else 520).
+  - Use `GrantPill(title: "Download", systemImage: "arrow.down.circle")` and `GrantedTag("READY")`.
+  - Verify: idle→downloading→READY for both rows; concurrent downloads; "See all" opens the sheet and
+    choices reflect back; both-ready→Continue; Skip advances; Reduced Motion (no springs/pulsing);
+    per-row insufficient-disk warning.
+  - *Green via `hooks-mcp` build + test + lint.* On-hardware visual confirmation is worthwhile
+    (non-gating; no `manual_test_results.json` impact — see Arch §9).

--- a/specs/projects/onboarding_download_models/phase_plans/phase_1.md
+++ b/specs/projects/onboarding_download_models/phase_plans/phase_1.md
@@ -1,0 +1,46 @@
+---
+status: complete
+---
+
+# Phase 1: Extract `ModelManagementUI` (pure refactor, no behavior change)
+
+## Overview
+
+Move the Manage Models sheet out of `SettingsUI` into a new shared `ModelManagementUI` module so
+both `SettingsUI` and `OnboardingUI` can present it. This is a mechanical move with no behavior
+change -- Settings presents the identical sheet afterward.
+
+## Steps
+
+1. **Create `Sources/ModelManagementUI/ManageModelsSheet.swift`**: Copy the file from
+   `Sources/SettingsUI/ManageModelsSheet.swift`. Make `ManageModelsSheet` `public` with a
+   `public init`. `ManageModelsViewModel` is already `public`. `ModelRowView` and
+   `ModelBlockedReason.warningText` stay internal to the new module.
+
+2. **Create `Tests/ModelManagementUITests/ManageModelsViewModelTests.swift`**: Copy from
+   `Tests/SettingsUITests/ManageModelsViewModelTests.swift`. Replace `@testable import SettingsUI`
+   with `import ModelManagementUI`. The `ModelBlockedReasonTests` suite also moves (it tests
+   `warningText` which is internal, so it needs `@testable import ModelManagementUI`).
+
+3. **Update `Package.swift`**: Add `ModelManagementUI` library product + target (deps: `AppCore`,
+   `DesignSystem`, `Intelligence`, `.product(name: "LocalLLM", package: "LocalLLM")`). Add
+   `ModelManagementUITests` test target (deps: `ModelManagementUI`, `AppCore`,
+   `BiscottiTestSupport`, `Intelligence`, `.product(name: "LocalLLM", package: "LocalLLM")`).
+   Add `"ModelManagementUI"` to `SettingsUI`'s dependencies.
+
+4. **Update `Sources/SettingsUI/SettingsView.swift`**: Add `import ModelManagementUI`.
+
+5. **Delete `Sources/SettingsUI/ManageModelsSheet.swift`**: The original file is now in
+   `ModelManagementUI`.
+
+6. **Delete `Tests/SettingsUITests/ManageModelsViewModelTests.swift`**: The tests are now in
+   `ModelManagementUITests`.
+
+7. **Update `architecture.md`**: Add `ModelManagementUI` to the L3a Screens layer in the DAG.
+
+## Tests
+
+- **Existing `ManageModelsViewModelTests`** (moved): all tests continue to pass unchanged,
+  verifying the extraction preserved behavior.
+- **Existing `SettingsUITests`** (not moved): continue to pass, verifying `SettingsView` still
+  compiles and uses the sheet through the new module.

--- a/specs/projects/onboarding_download_models/phase_plans/phase_2.md
+++ b/specs/projects/onboarding_download_models/phase_plans/phase_2.md
@@ -1,0 +1,66 @@
+---
+status: complete
+---
+
+# Phase 2: OnboardingUI view-model logic + reuse seams (no screen rewrite)
+
+## Overview
+
+Wire the data path for the two-row model download step while keeping the old `modelDownloadStep`
+body rendering. This phase adds the `ModelRowState` enums, extends `OnboardingViewModel` with
+language-model awareness and row-state mappers, generalizes `GrantPill`, adds the `contentMaxWidth`
+scaffold param, and updates `Package.swift` dependencies. The package stays green throughout. The
+screen rewrite comes in Phase 3.
+
+## Steps
+
+1. **`Package.swift`**: Add `ModelManagementUI`, `Intelligence`, `LocalLLM` to `OnboardingUI`
+   target deps. Add `Intelligence`, `LocalLLM` to `OnboardingUITests` target deps.
+
+2. **`OnboardingScaffold.swift`**: Add `var contentMaxWidth: CGFloat = 520` parameter, apply it in
+   `.frame(maxWidth: contentMaxWidth)` replacing the hard-coded 520.
+
+3. **`PermissionRow.swift`**: Generalize `GrantPill` to accept `title: String = "Grant"` and
+   `systemImage: String? = nil`. Existing call sites (`GrantPill { action }`) keep compiling via
+   the default args.
+
+4. **Add `ModelRowState.swift`**: Define `RowDownloadProgress` and `ModelRowState` enums (internal
+   to OnboardingUI). These are the VM output consumed by the card view in Phase 3.
+
+5. **`OnboardingViewModel.swift`**: Add `import Intelligence` and `import LocalLLM`.
+   - Add `public var appCore: AppCore { core }` (read-only, for sheet construction).
+   - Add `public var showVariantSheet: Bool = false`.
+   - Add `public private(set) var transcriptionDownloaded: Bool = false`.
+   - Rename `startDownload()` -> `startTranscriptionDownload()`.
+   - Add computed `var transcriptionReady: Bool`.
+   - Add `var transcriptionInsufficientDisk: Bool`.
+   - Set `requiredDiskSpaceMB` to 1500 (aligns with ~1.5 GB copy).
+   - Add `var languageTargetModelID: String?` computed from active/recommended.
+   - Add `var recommendedLanguageDisplayName: String?` computed.
+   - Add `var languageReady: Bool` computed.
+   - Add `func startLanguageDownload()`.
+   - Add `func transcriptionRowState() -> ModelRowState` mapper.
+   - Add `func languageRowState() -> ModelRowState` mapper.
+   - Add `var bothModelsReady: Bool`.
+   - Change `footerButton(for: .modelDownload)` to use `bothModelsReady`.
+   - Add `private func prepareModelStep() async`, replace `checkDiskSpace()` calls in `proceed()`.
+   - Update `resetForReplay()` to reset `transcriptionDownloaded` and `showVariantSheet`.
+
+6. **`OnboardingStepViews.swift`**: Update `startDownload()` call to `startTranscriptionDownload()`.
+
+7. **Tests**: Add new test file for row-state mapping, footer matrix, target model, on-entry
+   prepare, advance/skip. Update existing tests for the rename and footer rule change.
+
+## Tests
+
+- **Row-state mapping (table-driven)**: transcription idle/downloading/ready/insufficientDisk/failed;
+  language idle/downloading(fraction)/ready/insufficientDisk/failed; low-RAM E2B target.
+- **Footer matrix**: neither ready -> skip; transcription only -> skip; language only -> skip; both
+  ready -> continue.
+- **Target model**: languageTargetModelID = recommended when nothing downloaded; = active when a
+  model is downloaded/selected.
+- **On-entry prepare**: entering `.modelDownload` sets `transcriptionDownloaded` from transcription
+  fake and refreshes ModelManager.
+- **Skip/advance**: both advance to `.done` regardless of readiness.
+- **Existing tests**: update `startDownload()` -> `startTranscriptionDownload()` rename and footer
+  rule (modelDownload now requires `bothModelsReady`).

--- a/specs/projects/onboarding_download_models/phase_plans/phase_3.md
+++ b/specs/projects/onboarding_download_models/phase_plans/phase_3.md
@@ -1,0 +1,46 @@
+---
+status: complete
+---
+
+# Phase 3: Screen Rewrite + Sheet Wiring
+
+## Overview
+
+Replace the `modelDownloadStep` body in `OnboardingStepViews.swift` with the two-row model card
+(`ModelDownloadCard.swift`), present the extracted `ManageModelsSheet` via `.sheet`, and pass
+`contentMaxWidth: 560` for the `.modelDownload` step. Remove the old single-button `downloadContent`.
+
+## Steps
+
+1. **`OnboardingView.swift`** -- pass `contentMaxWidth: 560` for `.modelDownload`:
+   - `OnboardingScaffold(step: viewModel.currentStep, contentMaxWidth: viewModel.currentStep == .modelDownload ? 560 : 520)`
+
+2. **`ModelDownloadCard.swift`** (new file) -- build the card and row views:
+   - `ModelCard` -- `VStack(spacing: 0)` with two `ModelDownloadRow`s separated by `InsetDivider(leadingInset: 48)`, `.homeCard()`, `.frame(maxWidth: 560)`.
+   - `ModelDownloadRow` -- icon tile (34x34, cornerRadius 9, `Color.accentWashSoft` fill, SF Symbol `.sage`), name, why, optional extra content, trailing `DownloadControl`. Top-aligned HStack (`.top` alignment on the outer HStack).
+   - `DownloadControl` -- switches on `ModelRowState`:
+     - `.idle(caption)`: `GrantPill(title: "Download", systemImage: "arrow.down.circle")` + caption in `.biscottiMono(11)`, `.inkTertiary`.
+     - `.downloading(.indeterminate(status))`: indeterminate sage bar (240x3) + status text.
+     - `.downloading(.determinate(fraction))`: determinate sage capsule bar + "Downloading... NN%"; nil fraction -> indeterminate bar + "Downloading...".
+     - `.ready`: `GrantedTag("READY")`.
+     - `.insufficientDisk`: warning text "Insufficient free space on disk" with warning icon, no pill.
+     - `.failed(message)`: error text + Retry pill.
+   - `RecommendationLine` -- grey "Recommended . <name>" + "See all options" button with `chevron.right`.
+
+3. **`OnboardingStepViews.swift`** -- rewrite `modelDownloadStep`:
+   - Import `ModelManagementUI`.
+   - New lead copy: "One-time download. AI runs locally -- nothing leaves your Mac."
+   - Body -> `ModelCard(viewModel: viewModel)` instead of `downloadContent`.
+   - Attach `.sheet(isPresented: $viewModel.showVariantSheet) { ManageModelsSheet(viewModel: ManageModelsViewModel(core: viewModel.appCore)) }`.
+   - Remove the old `downloadContent` computed property.
+
+4. **Reduced Motion** -- ensure progress bar animations respect `@Environment(\.accessibilityReduceMotion)`. No springs or pulsing. Use `.animation(reduceMotion ? .none : .default, ...)` guards.
+
+## Tests
+
+No new VM/state tests needed (Phase 2 covered the view-model logic, row-state mappers, footer matrix,
+target model, on-entry preparation, and skip/advance). Phase 3 is purely view-layer: the card, rows,
+download control, recommendation line, sheet presentation, and contentMaxWidth wiring. These are
+SwiftUI view compositions consumed by the existing tested view model.
+
+Build + lint verification via `hooks-mcp` confirms the views compile and integrate correctly.

--- a/specs/projects/onboarding_download_models/project_overview.md
+++ b/specs/projects/onboarding_download_models/project_overview.md
@@ -1,0 +1,47 @@
+---
+status: complete
+---
+
+# Onboarding — Download Models (V2)
+
+This branch (`small_llm`) added the ability to select one of two LLM models — a smaller one for
+smaller Macs, a bigger one for bigger ones — including recommending a model for the user's machine.
+The `llm_model_selection` spec project built that: hardware probing + suitability, the persisted
+`selectedModelID`, `ModelManager`, the permanent **AI Language Model** Settings row, and the
+**Manage Models** sheet (variant picker with the Recommended badge, download/delete/choose, and
+the low-RAM disabling of 12B).
+
+**This project** refactors the **onboarding "Download Local AI Models" screen** (the `.modelDownload`
+step). Today that screen only downloads the **transcription** model; to get the **language model**
+the user has to go to Settings afterward. We want the onboarding screen to let the user download
+**both** model classes up front.
+
+## Goals
+
+- The onboarding models step downloads **two model classes**, each independently:
+  - **Transcription & Speaker ID** (Whisper V3 Turbo, ~1.5 GB) — already wired today.
+  - **Language Model** (Gemma 4 E2B or 12B, ~3–7 GB) — new on this screen.
+- The language class has a **recommended** variant (from the existing hardware logic). The easy path
+  is a single **Download** that pulls the recommended one; a **"See all options"** affordance opens
+  the **existing Manage Models sheet** to pick a variant.
+
+## Reuse-first constraints (from the human)
+
+- **Reuse existing code:** the existing **Manage Models sheet** for "See all options" — **minimal or
+  no new code**. Reuse the existing logic for checking whether a model is already downloaded, the
+  recommendation logic, download/progress machinery, etc. Refactor out of Settings into shared
+  helpers only if needed to share it.
+- A **design spec** (below, in the project context) from our design agent guides the visual update.
+  The design agent was **not** aware of the code and didn't make all UI decisions (e.g. the
+  Skip-only-until-all-downloaded footer rule already lives in code and has UI feedback/love). Treat
+  the design as **guidance, not overruling decisions already made in code**. Where the design
+  **conflicts** with code, raise clarifying questions during speccing rather than blindly following.
+
+## Out of scope
+
+- The Settings AI Language Model row and Manage Models sheet themselves (already shipped) — beyond
+  any refactor needed to reuse the sheet from onboarding.
+- Cancelling a download mid-flight (Skip still abandons the step; downloads continue in the
+  background and finish, matching existing behavior).
+- Changing the rest of the onboarding flow (window, scaffold, progress header, footer mechanics,
+  welcome / permissions / calendar / done steps).

--- a/specs/projects/onboarding_download_models/ui_design.md
+++ b/specs/projects/onboarding_download_models/ui_design.md
@@ -1,0 +1,106 @@
+---
+status: complete
+---
+
+# UI Design: Onboarding — Download Models (V2)
+
+Reconciles the design agent's V2 spec with the shipped onboarding components and the Decisions in
+`functional_spec.md` §9. Only the `.modelDownload` step body changes. Reuse shipped components
+verbatim where noted — do not invent new chrome.
+
+## Layout (top → bottom), inside the existing `OnboardingScaffold`
+
+1. **Title** — "Download Local AI Models", `.biscottiSerif(34)`, `.ink` (unchanged from today).
+2. **Lead** — "One-time download. AI runs locally — nothing leaves your Mac." `.system(16)`,
+   `.inkSecondary`, `maxWidth ~430`, `.padding(.top, 12)`. (Drops the inline "~1.5 GB"; sizes now
+   live per row.)
+3. **Model card** — the two-row card, `.padding(.top, 20–24)` (match the Grant-access card offset).
+4. **Footer** — `footerButton` (Skip / Continue), `.padding(.top, 24)`.
+
+## The card
+
+Reuse the **Grant-access card chrome**: `.homeCard()` + `.frame(maxWidth: 560)` (Decision
+**D2** — 560 per the design), two rows separated by `InsetDivider(leadingInset: 48)` — the
+same divider/inset the permission card uses. Rows are **top-aligned** (the language row has a third
+line).
+
+The scaffold's content column is widened to 560 for this step only: `OnboardingScaffold` gains a
+`contentMaxWidth` parameter (default 520) and `OnboardingView` passes 560 when the step is
+`.modelDownload`. All other steps stay at 520.
+
+```
+┌───────────────────────────────────────────────┐  ← .homeCard(), maxWidth 560
+│ [tile] Transcription & Speaker ID   <control>  │
+│        Turns speech into text and labels        │
+│        who's speaking.                          │
+│ ───────────────────────────────────────────── │  ← InsetDivider(leadingInset: 48)
+│ [tile] Language Model               <control>  │
+│        Meeting summaries, speaker matching,     │
+│        and automatic titles.                    │
+│        Recommended · Gemma 4 E2B  See all ›     │
+└───────────────────────────────────────────────┘
+```
+
+## The row
+
+Mirror the shipped `PermissionRow` skeleton (icon tile + name + "why" + trailing control), but
+**top-aligned** and with the language row's optional third line. Reuse the same icon tile (34×34,
+`cornerRadius 9`, `Color.accentWashSoft` fill, SF Symbol tinted `.sage`).
+
+- **Icon**: transcription → `waveform`; language → `sparkles`.
+- **Name**: `.system(14.5, weight: .semibold)`, `.ink`.
+- **Why**: `.system(12.5)`, `.inkSecondary`, wraps before the trailing control.
+- **Trailing control**: the per-state download control (below), top-aligned.
+
+Reuse decision: `PermissionRow` is currently parameterized for a single trailing control and an
+optional denial slot. The two model rows may either reuse `PermissionRow` (if the trailing/third-line
+needs fit its generics) or be a small sibling row view in `OnboardingUI` that copies its metrics. Pick
+whichever is least code at implementation time; keep the metrics identical to `PermissionRow`.
+
+## Trailing download control (per class)
+
+A top-aligned trailing column, `alignment: .trailing`. States:
+
+- **Idle**: a **Download** pill (reuse `GrantPill` / `JoinRecordButtonStyle`, generalized to take a
+  title + leading SF Symbol — label "Download", symbol `arrow.down.circle`) with a **size caption**
+  below it in `.biscottiMono(11)`, `.inkTertiary` — "~1.5 GB" (transcription) / the target model's
+  size, e.g. "~3.2 GB" (language). `spacing: 6`.
+- **Downloading**:
+  - **Transcription** (Decision **D1**): an **indeterminate** sage capsule bar (the existing
+    240×3 track + sliding fill idiom from today's `downloadContent`) + the engine's status text in
+    `.biscottiMono(11)`, `.inkSecondary`.
+  - **Language**: a **determinate** sage capsule bar bound to `downloads[id]` fraction + a
+    `.biscottiMono` caption "Downloading… NN%". If fraction is nil, fall back to the indeterminate
+    bar + "Downloading…". Reuse the header's sage capsule style (or a small shared bar view).
+- **Ready**: the shipped `GrantedTag`, labeled **"READY"** (Decision **D4**). No caption.
+- **Blocked — insufficient disk**: no pill; show a warning ("Insufficient free space on disk") in
+  the warning treatment used elsewhere (e.g. the `Banner`/warning chip idiom). Download disabled.
+- **Failed**: error text + a Retry control (reuse the small bordered Retry idiom).
+
+## Recommendation line (language row only)
+
+Shown **only in the idle state**. Two pieces on one row, `spacing ~10`, `.padding(.top, 6)`:
+- "Recommended · \(displayName of `recommendedModelID()`)" — `.system(12.5)`, `.inkSecondary`.
+- "See all options" — `.system(12.5, weight: .semibold)`, `.inkSecondary`, trailing
+  `chevron.right` (11pt). `.buttonStyle(.plain)`. Tap → `viewModel.showVariantSheet = true`.
+- **No icon/chip** next to "Recommended".
+
+## "See all options" sheet
+
+`.sheet(isPresented: $viewModel.showVariantSheet)` presenting the existing
+`ManageModelsSheet(viewModel: ManageModelsViewModel(core: <appCore>))` — identical to Settings.
+The view model needs access to the `AppCore` (expose it from `OnboardingViewModel`, mirroring how
+`SettingsViewModel` exposes `appCore`).
+
+## Footer
+
+Reuse the existing `footerButton` computed view. Its branch is driven by
+`viewModel.isCurrentStepComplete`, which for `.modelDownload` now means `bothReady`
+(`transcriptionReady && core.modelManager.isModelAvailable`). Idle/downloading → "Skip"; both ready →
+"Continue". Keep the fixed `minHeight: 40` so the swap doesn't shift layout. Respect Reduced Motion
+(no springs) — consistent with the shipped step transition.
+
+## Reduced Motion
+
+No pulsing/springs. State swaps are instant under `accessibilityReduceMotion`. The progress bars do
+not pulse; the language bar simply reflects fraction.


### PR DESCRIPTION
## Summary

Adds multi-model **LLM selection** (smaller Gemma E2B vs larger 12B, with a hardware recommendation) and reworks the onboarding **"Download Local AI Models"** screen to download **both** model classes (transcription + language) up front, with a reuse-first design that shares the existing Manage Models sheet.

## What's included

**LLM model selection (earlier phases on this branch):**
- LLM model catalog + on-disk inventory; persisted `selectedModelID`; hardware probing + suitability; `ModelManager` (multi-model downloads/selection); Settings **AI Language Model** row + **Manage Models** sheet (variant picker, Recommended badge, low-RAM disabling of 12B); hardened analysis prompts for weaker models.

**Onboarding — Download Models V2 (`onboarding_download_models`, 3 phases):**
- Extracted shared **`ModelManagementUI`** so onboarding reuses the Manage Models sheet.
- Two-row **model card** (Transcription & Speaker ID + Language Model) with per-row download controls, a recommendation line + **"See all options"** opening the shared sheet, and asymmetric progress (indeterminate transcription, determinate language).

**Fixes & polish from review/on-device testing:**
- Fixed the screen **hang on entry** (navigate first; probe readiness in the background with spinners).
- **Read-only** transcription readiness check — no more auto-download just by landing on the screen; **both models are now manual**. Probes are **pre-warmed** on the permissions screen.
- Language row now **reflects the model downloaded/chosen in the sheet** (target resolves in-flight → active → failed → selection → recommended).
- UI: wrapping descriptions, **animated** indeterminate bar, fixed-width download control with centered wrapping captions, footer flips **Skip→Continue once both downloads start**, and a **"Downloads will continue in the background"** footer caption.
- DEBUG **"Clear Selected LLM"** Settings button.

## Testing
- Package tests green (~2090). LLM manual tests run on hardware and recorded.
- **Heads-up:** the transcription `tx_*` manual-test steps are marked `not-run` (the read-only-readiness change touched `Packages/Transcription`), so `make manual-tests-check` is red until those 4 are re-run on hardware (non-gating CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)