### PR TITLE
Dark mode

### DIFF
--- a/Packages/BiscottiKit/Sources/AppShellUI/AppShellView.swift
+++ b/Packages/BiscottiKit/Sources/AppShellUI/AppShellView.swift
@@ -96,7 +96,7 @@ public struct AppShellView: View {
                                 }
                             }
                             .buttonStyle(
-                                ToolbarRecordButtonStyle(fill: .sage)
+                                ToolbarRecordButtonStyle(fill: .accentFill)
                             )
                             .help("Start recording")
                         }

--- a/Packages/BiscottiKit/Sources/DesignSystem/Avatar.swift
+++ b/Packages/BiscottiKit/Sources/DesignSystem/Avatar.swift
@@ -61,7 +61,7 @@ public struct Avatar: View {
         .overlay {
             if stacked {
                 Circle()
-                    .strokeBorder(.white, lineWidth: 2)
+                    .strokeBorder(.avatarRing, lineWidth: 2)
             }
         }
     }
@@ -184,7 +184,7 @@ public struct AvatarCluster: View {
                 .fill(Color.inkSecondary.opacity(0.28))
 
             Circle()
-                .strokeBorder(.white, lineWidth: 2)
+                .strokeBorder(.avatarRing, lineWidth: 2)
 
             Text("+\(overflowCount)")
                 .font(.monoBadge)
@@ -224,7 +224,7 @@ public struct RecordingAvatar: View {
         .overlay {
             if stacked {
                 Circle()
-                    .strokeBorder(.white, lineWidth: 2)
+                    .strokeBorder(.avatarRing, lineWidth: 2)
             }
         }
     }

--- a/Packages/BiscottiKit/Sources/DesignSystem/Color+Theme.swift
+++ b/Packages/BiscottiKit/Sources/DesignSystem/Color+Theme.swift
@@ -1,108 +1,169 @@
 import AppKit
 import SwiftUI
 
-// MARK: - Semantic color palette (F Sage)
+// MARK: - Semantic color palette (F Sage) — appearance-adaptive
+
+// Every token is defined once via `dynamicNSColor` / `dynamicColor`. Light values
+// are the exact sRGB literals from the original static palette. Dark values come
+// from the approved design (functional_spec.md §3). Views never branch on
+// `colorScheme` — appearance is resolved entirely here.
+
+// MARK: - NSColor tokens (single source of truth)
+
+// Tokens that have AppKit consumers (markdown editor, etc.) are defined as
+// `NSColor` first; the `Color` extension derives from them via `Color(nsColor:)`.
+// Tokens used only in SwiftUI are defined directly via `dynamicColor`.
+
+public extension NSColor {
+    /// Primary text — warm near-black (#1A1813) / warm off-white (#F7F2E8).
+    static let ink = dynamicNSColor(
+        light: NSColor(srgbRed: 0.102, green: 0.094, blue: 0.075, alpha: 1),
+        dark: NSColor(srgbRed: 0.969, green: 0.949, blue: 0.910, alpha: 1)
+    )
+
+    /// Secondary text: ink @ 54% / #F7F2E8 @ 58%.
+    static let inkSecondary = dynamicNSColor(
+        light: NSColor(srgbRed: 0.102, green: 0.094, blue: 0.075, alpha: 0.54),
+        dark: NSColor(srgbRed: 0.969, green: 0.949, blue: 0.910, alpha: 0.58)
+    )
+
+    /// Tertiary text / chevrons: ink @ 34% / #F7F2E8 @ 36%.
+    static let inkTertiary = dynamicNSColor(
+        light: NSColor(srgbRed: 0.102, green: 0.094, blue: 0.075, alpha: 0.34),
+        dark: NSColor(srgbRed: 0.969, green: 0.949, blue: 0.910, alpha: 0.36)
+    )
+
+    /// Brand accent — sage green (#4E7D5C / #86C295).
+    static let sage = dynamicNSColor(
+        light: NSColor(srgbRed: 0.306, green: 0.490, blue: 0.361, alpha: 1),
+        dark: NSColor(srgbRed: 0.525, green: 0.761, blue: 0.584, alpha: 1)
+    )
+
+    /// Selection background: sage @ 14% / #86C295 @ 16%.
+    static let accentWashStrong = dynamicNSColor(
+        light: NSColor(srgbRed: 0.306, green: 0.490, blue: 0.361, alpha: 0.14),
+        dark: NSColor(srgbRed: 0.525, green: 0.761, blue: 0.584, alpha: 0.16)
+    )
+
+    /// Focused find-match highlight: sage @ 35% / #86C295 @ 35%.
+    static let findHighlightFocused = dynamicNSColor(
+        light: NSColor(srgbRed: 0.306, green: 0.490, blue: 0.361, alpha: 0.35),
+        dark: NSColor(srgbRed: 0.525, green: 0.761, blue: 0.584, alpha: 0.35)
+    )
+
+    /// Card border (0.5pt): warm dark @ 10% / #F7F2E8 @ 12%.
+    static let cardStroke = dynamicNSColor(
+        light: NSColor(srgbRed: 0.102, green: 0.086, blue: 0.055, alpha: 0.10),
+        dark: NSColor(srgbRed: 0.969, green: 0.949, blue: 0.910, alpha: 0.12)
+    )
+}
+
+// MARK: - Color tokens (SwiftUI)
 
 public extension Color {
-    /// Warm ivory content background (#FBFAF5).
-    static let paper = Color(red: 0.984, green: 0.980, blue: 0.961)
+    /// Warm ivory content background (#FBFAF5 / #100E09).
+    static let paper = dynamicColor(
+        light: NSColor(srgbRed: 0.984, green: 0.980, blue: 0.961, alpha: 1),
+        dark: NSColor(srgbRed: 0.063, green: 0.055, blue: 0.035, alpha: 1)
+    )
 
-    /// Primary text -- warm near-black (#1A1813).
-    static let ink = Color(red: 0.102, green: 0.094, blue: 0.075)
+    /// Primary text — warm near-black / warm off-white.
+    static let ink = Color(nsColor: .ink)
 
-    /// Brand accent -- sage green (#4E7D5C).
-    static let sage = Color(red: 0.306, green: 0.490, blue: 0.361)
+    /// Brand accent — sage green.
+    static let sage = Color(nsColor: .sage)
 
-    /// Secondary text: ink @ 54%.
-    static let inkSecondary = ink.opacity(0.54)
+    /// Secondary text: ink @ 54% / warm off-white @ 58%.
+    static let inkSecondary = Color(nsColor: .inkSecondary)
 
-    /// Tertiary text / chevrons: ink @ 34%.
-    static let inkTertiary = ink.opacity(0.34)
+    /// Tertiary text / chevrons: ink @ 34% / warm off-white @ 36%.
+    static let inkTertiary = Color(nsColor: .inkTertiary)
 
-    /// Separator: ink @ 11%.
-    static let hairline = ink.opacity(0.11)
+    /// Separator: ink @ 11% / #F7F2E8 @ 12%.
+    static let hairline = dynamicColor(
+        light: NSColor(srgbRed: 0.102, green: 0.094, blue: 0.075, alpha: 0.11),
+        dark: NSColor(srgbRed: 0.969, green: 0.949, blue: 0.910, alpha: 0.12)
+    )
 
-    /// Neutral chip fill: ink @ 6%.
-    static let neutralChip = ink.opacity(0.06)
+    /// Neutral chip fill: ink @ 6% / #F7F2E8 @ 7%.
+    static let neutralChip = dynamicColor(
+        light: NSColor(srgbRed: 0.102, green: 0.094, blue: 0.075, alpha: 0.06),
+        dark: NSColor(srgbRed: 0.969, green: 0.949, blue: 0.910, alpha: 0.07)
+    )
 
-    /// Card border (0.5pt): warm dark @ 10%.
-    static let cardStroke = Color(red: 0.102, green: 0.086, blue: 0.055).opacity(0.10)
+    /// Card border (0.5pt).
+    static let cardStroke = Color(nsColor: .cardStroke)
 
-    /// Selection background: sage @ 14%.
-    static let accentWashStrong = sage.opacity(0.14)
+    /// Selection background: sage @ 14% / #86C295 @ 16%.
+    static let accentWashStrong = Color(nsColor: .accentWashStrong)
 
-    /// Focused find-match highlight: sage @ 35%.
-    static let findHighlightFocused = sage.opacity(0.35)
+    /// Focused find-match highlight: sage @ 35% / #86C295 @ 35%.
+    static let findHighlightFocused = Color(nsColor: .findHighlightFocused)
 
-    /// Hero tint / speaker chip: sage @ 8%.
-    static let accentWashSoft = sage.opacity(0.08)
+    /// Hero tint / speaker chip: sage @ 8% / #86C295 @ 12%.
+    static let accentWashSoft = dynamicColor(
+        light: NSColor(srgbRed: 0.306, green: 0.490, blue: 0.361, alpha: 0.08),
+        dark: NSColor(srgbRed: 0.525, green: 0.761, blue: 0.584, alpha: 0.12)
+    )
 
-    /// **The single canonical red for the entire app** (#B23320, RGB 178/51/32).
+    /// **The single canonical red for the entire app** (#B23320 / #E5604A).
     ///
-    /// A warm, dark-enough-for-text red chosen to complement sage. Use this
-    /// token everywhere you would reach for red -- do **not** introduce other
-    /// reds or use raw `Color.red` / `.systemRed`.
+    /// A warm red chosen to complement sage. In dark mode, brightens to maintain
+    /// contrast. Use this token for **marks**: dots, icons, stop-square, fills,
+    /// borders. For standalone red **text** labels on dark, use `signalRedText`
+    /// instead (lighter for AA legibility).
     ///
-    /// **Approved usages:**
-    /// - **Error / failure states:** error icons, error text, error-tinted
-    ///   backgrounds (`signalRed.opacity(0.15)`). Dark enough for readable
-    ///   error text on light backgrounds.
-    /// - **Recording indicators:** the pulsing recording dot, "Recording..."
-    ///   live-state labels and toolbar pills, and the Stop button fill.
-    /// - **Destructive actions & buttons:** destructive text links and icons
-    ///   via `.foregroundStyle(.signalRed)`. For a filled red destructive
-    ///   button, use an explicit custom `ButtonStyle` that fills with
-    ///   `signalRed` and sets a white label (same pattern as
-    ///   `ToolbarRecordButtonStyle`). **Do not use `.tint(.signalRed)`** --
-    ///   macOS ignores `.tint()` with custom colors on bordered/prominent
-    ///   buttons, rendering them grey. System-rendered `.alert` /
-    ///   `.confirmationDialog` destructive buttons are OS-styled; leave
-    ///   them as-is.
-    /// - **Button fills:** when used as a button background (recording or
-    ///   destructive), pair with **white** text/icons for contrast.
-    static let signalRed = Color(red: 0.698, green: 0.200, blue: 0.125)
-
-    /// **The single canonical warning color for the entire app** (#C6891E,
-    /// RGB 198/137/30).
-    ///
-    /// A warm ochre chosen to complement sage and read clearly on ivory
-    /// backgrounds. Use this token everywhere you would reach for
-    /// yellow/amber/orange for **warning semantics** -- do **not**
-    /// introduce other yellows/oranges or use raw `.yellow` / `.orange`
-    /// / `Color(.systemYellow)` / `Color(.systemOrange)` for warnings.
+    /// Do **not** introduce other reds or use raw `Color.red` / `.systemRed`.
     ///
     /// **Approved usages:**
-    /// - **Warning icons:** the primary use case. Warning triangles
-    ///   (`exclamationmark.triangle.fill`), caution indicators, and
-    ///   permission-denied state icons.
-    /// - **Warning text:** dark enough to be legible as text on light
-    ///   backgrounds if needed, but avoid relying on color alone to
-    ///   convey warnings in text -- pair with an icon or contextual
-    ///   label.
-    /// - **Warning-tinted backgrounds:** use
-    ///   `warningOchre.opacity(0.15)` for banner/chip fills.
-    /// - **Button fills (if ever needed):** follow the same rule as
-    ///   `signalRed` -- use a custom fill `ButtonStyle` with a
-    ///   white/legible label, not `.tint()`, which macOS ignores for
-    ///   custom colors on bordered/prominent buttons.
-    static let warningOchre = Color(red: 0.776, green: 0.537, blue: 0.118)
+    /// - **Error / failure states:** error icons, error-tinted backgrounds
+    ///   (`signalRed.opacity(0.15)`).
+    /// - **Recording indicators:** the pulsing recording dot, Stop button fill.
+    /// - **Destructive actions & buttons:** destructive icons and filled
+    ///   destructive buttons (pair with white label).
+    static let signalRed = dynamicColor(
+        light: NSColor(srgbRed: 0.698, green: 0.200, blue: 0.125, alpha: 1),
+        dark: NSColor(srgbRed: 0.898, green: 0.376, blue: 0.290, alpha: 1)
+    )
 
-    /// Window wall: flat warm-grey fallback (#E4E1D8).
-    static let wall = Color(red: 0.894, green: 0.882, blue: 0.847)
+    /// **The single canonical warning color** (#C6891E / #E8A13A).
+    ///
+    /// A warm ochre for warning **icons** (triangles) and the pulsing warning
+    /// **dot**. In dark mode, brightens to maintain contrast. For amber **text**
+    /// labels, use `warningChipText` (lighter in dark for legibility).
+    ///
+    /// Do **not** introduce other yellows/oranges for warnings.
+    static let warningOchre = dynamicColor(
+        light: NSColor(srgbRed: 0.776, green: 0.537, blue: 0.118, alpha: 1),
+        dark: NSColor(srgbRed: 0.910, green: 0.631, blue: 0.227, alpha: 1)
+    )
 
-    /// Sidebar tint: translucent ivory overlay (rgba 250,249,244 @ 82%).
-    static let sidebarTint = Color(red: 0.980, green: 0.976, blue: 0.957).opacity(0.82)
+    /// Window wall: flat warm-grey fallback (#E4E1D8 / #110F09).
+    static let wall = dynamicColor(
+        light: NSColor(srgbRed: 0.894, green: 0.882, blue: 0.847, alpha: 1),
+        dark: NSColor(srgbRed: 0.067, green: 0.059, blue: 0.035, alpha: 1)
+    )
+
+    /// Sidebar tint: translucent ivory / dark overlay.
+    static let sidebarTint = dynamicColor(
+        light: NSColor(srgbRed: 0.980, green: 0.976, blue: 0.957, alpha: 0.82),
+        dark: NSColor(srgbRed: 0.078, green: 0.071, blue: 0.051, alpha: 0.74)
+    )
 
     // MARK: - Recording redesign tokens
 
     /// Sidebar RECORDING NOW row fill; auto-stop card wash: signalRed @ 8%.
+    /// Auto-adapts via the dynamic `signalRed` base.
     static let recordingTintSoft = signalRed.opacity(0.08)
 
     /// Selected sidebar recording row fill: signalRed @ 12%.
     static let recordingTintStrong = signalRed.opacity(0.12)
 
-    /// Light Stop/REC button hairline: signalRed @ 32%.
-    static let recordingOutline = signalRed.opacity(0.32)
+    /// Light Stop/REC button hairline: signalRed @ 32% / #E5604A @ 36%.
+    static let recordingOutline = dynamicColor(
+        light: NSColor(srgbRed: 0.698, green: 0.200, blue: 0.125, alpha: 0.32),
+        dark: NSColor(srgbRed: 0.898, green: 0.376, blue: 0.290, alpha: 0.36)
+    )
 
     /// Selected recording row inset stroke: signalRed @ 20%.
     static let recordingOutlineStrong = signalRed.opacity(0.20)
@@ -110,11 +171,74 @@ public extension Color {
     /// Light Stop/REC button hover: signalRed @ 5%.
     static let recordingHoverFill = signalRed.opacity(0.05)
 
-    /// Left chip amber kicker + value text color.
-    static let warningChipText = warningOchre
+    /// Left chip amber kicker + value text (#C6891E / #F0C04A).
+    /// Separate from `warningOchre` in dark (brighter for text legibility).
+    static let warningChipText = dynamicColor(
+        light: NSColor(srgbRed: 0.776, green: 0.537, blue: 0.118, alpha: 1),
+        dark: NSColor(srgbRed: 0.941, green: 0.753, blue: 0.290, alpha: 1)
+    )
 
-    /// "Add note" + "Keep Recording" button fill: sage @ 12%.
-    static let softSageFill = sage.opacity(0.12)
+    /// "Add note" + "Keep Recording" button fill: sage @ 12% / #86C295 @ 14%.
+    static let softSageFill = dynamicColor(
+        light: NSColor(srgbRed: 0.306, green: 0.490, blue: 0.361, alpha: 0.12),
+        dark: NSColor(srgbRed: 0.525, green: 0.761, blue: 0.584, alpha: 0.14)
+    )
+
+    // MARK: - New semantic tokens (Phase 1)
+
+    /// Card fill (#FFFFFF / #1A170F). All card surfaces adapt via this token.
+    static let cardFill = dynamicColor(
+        light: NSColor(srgbRed: 1.0, green: 1.0, blue: 1.0, alpha: 1),
+        dark: NSColor(srgbRed: 0.102, green: 0.090, blue: 0.059, alpha: 1)
+    )
+
+    /// Button fills — deeper sage for white-label contrast (#4E7D5C / #56906A).
+    /// Light value equals `sage`; dark is a touch deeper so white labels pass AA.
+    static let accentFill = dynamicColor(
+        light: NSColor(srgbRed: 0.306, green: 0.490, blue: 0.361, alpha: 1),
+        dark: NSColor(srgbRed: 0.337, green: 0.565, blue: 0.416, alpha: 1)
+    )
+
+    /// Long-form body text (transcripts): ink @ 54% / #F7F2E8 @ 75%.
+    /// Brighter than `inkSecondary` in dark for comfortable sustained reading.
+    static let read = dynamicColor(
+        light: NSColor(srgbRed: 0.102, green: 0.094, blue: 0.075, alpha: 0.54),
+        dark: NSColor(srgbRed: 0.969, green: 0.949, blue: 0.910, alpha: 0.75)
+    )
+
+    /// Elevated control fill — white buttons/fields (#FFFFFF / #1A170F).
+    /// Light = white; dark = card surface (Stop&Save, REC pill, focused title).
+    static let elevatedFill = dynamicColor(
+        light: NSColor(srgbRed: 1.0, green: 1.0, blue: 1.0, alpha: 1),
+        dark: NSColor(srgbRed: 0.102, green: 0.090, blue: 0.059, alpha: 1)
+    )
+
+    /// Custom progress-bar fills (#4E7D5C / #5E9A6F).
+    /// Light = sage; dark = a touch less bright than text sage.
+    static let accentTrack = dynamicColor(
+        light: NSColor(srgbRed: 0.306, green: 0.490, blue: 0.361, alpha: 1),
+        dark: NSColor(srgbRed: 0.369, green: 0.604, blue: 0.435, alpha: 1)
+    )
+
+    /// Standalone red text labels (#B23320 / #F08A78).
+    /// Lighter than `signalRed` in dark for AA legibility on dark backgrounds.
+    /// Use for "RECORDING" labels, error messages, "Remove association" text.
+    static let signalRedText = dynamicColor(
+        light: NSColor(srgbRed: 0.698, green: 0.200, blue: 0.125, alpha: 1),
+        dark: NSColor(srgbRed: 0.941, green: 0.541, blue: 0.471, alpha: 1)
+    )
+
+    /// Home card shadow: black @ 5% / black @ 40%.
+    static let cardShadow = dynamicColor(
+        light: NSColor(srgbRed: 0, green: 0, blue: 0, alpha: 0.05),
+        dark: NSColor(srgbRed: 0, green: 0, blue: 0, alpha: 0.40)
+    )
+
+    /// Control shadow (light-alert buttons): black @ 6% / black @ 40%.
+    static let controlShadow = dynamicColor(
+        light: NSColor(srgbRed: 0, green: 0, blue: 0, alpha: 0.06),
+        dark: NSColor(srgbRed: 0, green: 0, blue: 0, alpha: 0.40)
+    )
 }
 
 // MARK: - ShapeStyle sugar
@@ -149,38 +273,40 @@ public extension ShapeStyle where Self == Color {
     static var warningOchre: Color {
         .warningOchre
     }
+
     // Note: `.hairline` and `.neutralChip` are less commonly used as ShapeStyles
     // so they are accessed through Color.hairline / Color.neutralChip directly.
-}
 
-// MARK: - NSColor mirrors (same RGB literals, for AppKit consumers)
+    /// New tokens (Phase 1)
+    static var accentFill: Color {
+        .accentFill
+    }
 
-/// AppKit-native mirrors of the F Sage palette, built from the same
-/// RGB/alpha literals as the SwiftUI `Color` extensions above. Preferred
-/// over `NSColor(Color.x)` to avoid color-space surprises.
-///
-/// These names intentionally shadow no built-in `NSColor` properties
-/// (AppKit has no `.ink`, `.sage`, etc.). The naming mirrors the
-/// `Color` extensions above for single-sourced consistency.
-public extension NSColor {
-    /// Primary text -- warm near-black (#1A1813).
-    static let ink = NSColor(srgbRed: 0.102, green: 0.094, blue: 0.075, alpha: 1)
+    static var read: Color {
+        .read
+    }
 
-    /// Secondary text: ink @ 54%.
-    static let inkSecondary = NSColor(srgbRed: 0.102, green: 0.094, blue: 0.075, alpha: 0.54)
+    static var elevatedFill: Color {
+        .elevatedFill
+    }
 
-    /// Tertiary text / chevrons: ink @ 34%.
-    static let inkTertiary = NSColor(srgbRed: 0.102, green: 0.094, blue: 0.075, alpha: 0.34)
+    static var accentTrack: Color {
+        .accentTrack
+    }
 
-    /// Brand accent -- sage green (#4E7D5C).
-    static let sage = NSColor(srgbRed: 0.306, green: 0.490, blue: 0.361, alpha: 1)
+    static var signalRedText: Color {
+        .signalRedText
+    }
 
-    /// Selection background: sage @ 14%.
-    static let accentWashStrong = NSColor(srgbRed: 0.306, green: 0.490, blue: 0.361, alpha: 0.14)
+    static var cardShadow: Color {
+        .cardShadow
+    }
 
-    /// Focused find-match highlight: sage @ 35%.
-    static let findHighlightFocused = NSColor(srgbRed: 0.306, green: 0.490, blue: 0.361, alpha: 0.35)
+    static var controlShadow: Color {
+        .controlShadow
+    }
 
-    /// Card border: warm dark @ 10%.
-    static let cardStroke = NSColor(srgbRed: 0.102, green: 0.086, blue: 0.055, alpha: 0.10)
+    static var cardFill: Color {
+        .cardFill
+    }
 }

--- a/Packages/BiscottiKit/Sources/DesignSystem/Color+Theme.swift
+++ b/Packages/BiscottiKit/Sources/DesignSystem/Color+Theme.swift
@@ -239,6 +239,14 @@ public extension Color {
         light: NSColor(srgbRed: 0, green: 0, blue: 0, alpha: 0.06),
         dark: NSColor(srgbRed: 0, green: 0, blue: 0, alpha: 0.40)
     )
+
+    /// Avatar stacked-ring border (#FFFFFF / #1A170F).
+    /// Matches the surface behind overlapping avatars so the ring cuts a
+    /// visual gap between circles. Dark value = cardFill-dark.
+    static let avatarRing = dynamicColor(
+        light: NSColor(srgbRed: 1.0, green: 1.0, blue: 1.0, alpha: 1),
+        dark: NSColor(srgbRed: 0.102, green: 0.090, blue: 0.059, alpha: 1)
+    )
 }
 
 // MARK: - ShapeStyle sugar
@@ -308,5 +316,9 @@ public extension ShapeStyle where Self == Color {
 
     static var cardFill: Color {
         .cardFill
+    }
+
+    static var avatarRing: Color {
+        .avatarRing
     }
 }

--- a/Packages/BiscottiKit/Sources/DesignSystem/DynamicColor.swift
+++ b/Packages/BiscottiKit/Sources/DesignSystem/DynamicColor.swift
@@ -1,0 +1,21 @@
+import AppKit
+import SwiftUI
+
+// MARK: - Appearance-resolving color helpers
+
+/// Returns an `NSColor` that resolves to `light` under `.aqua` and `dark` under
+/// `.darkAqua`. This is the **single point** in the codebase where appearance is
+/// branched -- view code never checks `colorScheme`.
+///
+/// Both inputs must be sRGB. The provider closure captures only `Sendable` values
+/// (`NSColor` + `[NSAppearance.Name]`), satisfying Swift 6 strict concurrency.
+func dynamicNSColor(light: NSColor, dark: NSColor) -> NSColor {
+    NSColor(name: nil) { appearance in
+        appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua ? dark : light
+    }
+}
+
+/// SwiftUI sugar: a dynamic `Color` from light/dark sRGB `NSColor` literals.
+func dynamicColor(light: NSColor, dark: NSColor) -> Color {
+    Color(nsColor: dynamicNSColor(light: light, dark: dark))
+}

--- a/Packages/BiscottiKit/Sources/DesignSystem/EditableMeetingTitle.swift
+++ b/Packages/BiscottiKit/Sources/DesignSystem/EditableMeetingTitle.swift
@@ -114,7 +114,7 @@ public struct EditableMeetingTitle: View {
             RoundedRectangle(cornerRadius: 6)
                 .fill(
                     isFocused
-                        ? Color.white : Color.clear
+                        ? Color.elevatedFill : Color.clear
                 )
         )
         .overlay(

--- a/Packages/BiscottiKit/Sources/DesignSystem/EventPickerSheet.swift
+++ b/Packages/BiscottiKit/Sources/DesignSystem/EventPickerSheet.swift
@@ -122,7 +122,7 @@ public struct EventPickerSheet: View {
                     Button("Remove association") {
                         onRemove()
                     }
-                    .foregroundStyle(.signalRed)
+                    .foregroundStyle(.signalRedText)
                 }
                 Spacer()
                 Button("Cancel") { onCancel() }

--- a/Packages/BiscottiKit/Sources/DesignSystem/HomeCardModifier.swift
+++ b/Packages/BiscottiKit/Sources/DesignSystem/HomeCardModifier.swift
@@ -11,7 +11,7 @@ public struct HomeCardModifier: ViewModifier {
                 RoundedRectangle(cornerRadius: Tokens.cardRadius)
                     .strokeBorder(Tokens.cardStroke, lineWidth: 0.5)
             )
-            .shadow(color: .black.opacity(0.05), radius: 1.5, y: 1)
+            .shadow(color: .cardShadow, radius: 1.5, y: 1)
     }
 }
 

--- a/Packages/BiscottiKit/Sources/DesignSystem/JoinRecordButtonStyle.swift
+++ b/Packages/BiscottiKit/Sources/DesignSystem/JoinRecordButtonStyle.swift
@@ -16,7 +16,7 @@ public struct JoinRecordButtonStyle: ButtonStyle {
             .frame(height: 32)
             .background(
                 RoundedRectangle(cornerRadius: Tokens.buttonRadius)
-                    .fill(Color.sage)
+                    .fill(Color.accentFill)
                     .overlay(alignment: .top) {
                         // Subtle top highlight
                         RoundedRectangle(cornerRadius: Tokens.buttonRadius)
@@ -40,7 +40,7 @@ public struct JoinRecordButtonStyle: ButtonStyle {
 /// them grey instead of the requested color. This custom style draws the fill
 /// explicitly so the color is guaranteed regardless of toolbar hosting context.
 ///
-/// Usage: `.buttonStyle(ToolbarRecordButtonStyle(fill: .sage))` for idle,
+/// Usage: `.buttonStyle(ToolbarRecordButtonStyle(fill: .accentFill))` for idle,
 /// `.buttonStyle(ToolbarRecordButtonStyle(fill: .signalRed))` for active.
 public struct ToolbarRecordButtonStyle: ButtonStyle {
     let fill: Color

--- a/Packages/BiscottiKit/Sources/DesignSystem/LightAlertButtonStyle.swift
+++ b/Packages/BiscottiKit/Sources/DesignSystem/LightAlertButtonStyle.swift
@@ -3,7 +3,7 @@ import SwiftUI
 /// Light alert button style shared by Stop & Save and the recording-state
 /// header button.
 ///
-/// White `cardFill`, `recordingOutline` 0.5pt border, whisper shadow,
+/// Elevated fill `elevatedFill`, `recordingOutline` 0.5pt border, whisper shadow,
 /// `signalRed` content, `recordingHoverFill` on hover. The caller's label
 /// controls layout (padding, height); this style only provides the chrome.
 public struct LightAlertButtonStyle: ButtonStyle {
@@ -17,7 +17,7 @@ public struct LightAlertButtonStyle: ButtonStyle {
             .foregroundStyle(Color.signalRed)
             .background(
                 RoundedRectangle(cornerRadius: 9)
-                    .fill(isHovering ? Color.recordingHoverFill : Tokens.cardFill)
+                    .fill(isHovering ? Color.recordingHoverFill : Color.elevatedFill)
             )
             .overlay(
                 RoundedRectangle(cornerRadius: 9)
@@ -25,7 +25,7 @@ public struct LightAlertButtonStyle: ButtonStyle {
             )
             // Tighter whisper shadow than HomeCardModifier (0.05/1.5/1)
             // -- intentional for the smaller button footprint.
-            .shadow(color: .black.opacity(0.06), radius: 1, x: 0, y: 0.5)
+            .shadow(color: .controlShadow, radius: 1, x: 0, y: 0.5)
             .opacity(
                 !isEnabled ? 0.4 : configuration.isPressed ? 0.7 : 1.0
             )

--- a/Packages/BiscottiKit/Sources/DesignSystem/Tokens.swift
+++ b/Packages/BiscottiKit/Sources/DesignSystem/Tokens.swift
@@ -92,6 +92,9 @@ public enum Tokens {
     /// Control shadow for light-alert buttons (adaptive opacity).
     public static let controlShadow = Color.controlShadow
 
+    /// Avatar stacked-ring border (matches surface behind overlapping avatars).
+    public static let avatarRing = Color.avatarRing
+
     /// Sage accent -- formerly "liveGreen". Meet chip icon, "Next in" dot, conference video icon.
     public static let liveGreen = Color.sage
 

--- a/Packages/BiscottiKit/Sources/DesignSystem/Tokens.swift
+++ b/Packages/BiscottiKit/Sources/DesignSystem/Tokens.swift
@@ -25,8 +25,8 @@ public enum Tokens {
     /// Warm ivory content background.
     public static let contentBackground = Color.paper
 
-    /// Card fill (white).
-    public static let cardFill = Color.white
+    /// Card fill (adaptive: white / warm dark).
+    public static let cardFill = Color.cardFill
 
     /// Hairline separator: ink @ 11%.
     public static let hairline = Color.hairline
@@ -70,6 +70,27 @@ public enum Tokens {
 
     /// "Add note" + "Keep Recording" button fill.
     public static let softSageFill = Color.softSageFill
+
+    /// Button fills -- deeper sage for white-label contrast in dark.
+    public static let accentFill = Color.accentFill
+
+    /// Elevated control fill (white buttons/fields in light, card surface in dark).
+    public static let elevatedFill = Color.elevatedFill
+
+    /// Long-form body text (transcripts) -- brighter in dark for reading.
+    public static let read = Color.read
+
+    /// Custom progress-bar fills.
+    public static let accentTrack = Color.accentTrack
+
+    /// Standalone red text labels -- lighter in dark for AA legibility.
+    public static let signalRedText = Color.signalRedText
+
+    /// Home card shadow (adaptive opacity).
+    public static let cardShadow = Color.cardShadow
+
+    /// Control shadow for light-alert buttons (adaptive opacity).
+    public static let controlShadow = Color.controlShadow
 
     /// Sage accent -- formerly "liveGreen". Meet chip icon, "Next in" dot, conference video icon.
     public static let liveGreen = Color.sage

--- a/Packages/BiscottiKit/Sources/MeetingDetailUI/TranscriptListView.swift
+++ b/Packages/BiscottiKit/Sources/MeetingDetailUI/TranscriptListView.swift
@@ -193,7 +193,7 @@ private struct TranscriptSegmentRow: View {
     private var utteranceText: some View {
         Text(segment.text.drop(while: \.isWhitespace))
             .font(.system(size: 14))
-            .foregroundStyle(.inkSecondary)
+            .foregroundStyle(.read)
             .fixedSize(horizontal: false, vertical: true)
     }
 }

--- a/Packages/BiscottiKit/Sources/ModelManagementUI/ManageModelsSheet.swift
+++ b/Packages/BiscottiKit/Sources/ModelManagementUI/ManageModelsSheet.swift
@@ -278,7 +278,7 @@ struct ModelRowView: View {
                 descriptionText
                 Text("Download failed: \(message)")
                     .font(Tokens.metadataFont)
-                    .foregroundStyle(.signalRed)
+                    .foregroundStyle(.signalRedText)
 
             default:
                 descriptionText

--- a/Packages/BiscottiKit/Sources/OnboardingUI/GrantedTag.swift
+++ b/Packages/BiscottiKit/Sources/OnboardingUI/GrantedTag.swift
@@ -15,7 +15,7 @@ struct GrantedTag: View {
     var body: some View {
         HStack(spacing: 6) {
             Circle()
-                .fill(Color.sage)
+                .fill(Color.accentFill)
                 .frame(width: 15, height: 15)
                 .overlay(
                     Image(systemName: "checkmark")

--- a/Packages/BiscottiKit/Sources/OnboardingUI/ModelDownloadCard.swift
+++ b/Packages/BiscottiKit/Sources/OnboardingUI/ModelDownloadCard.swift
@@ -149,7 +149,7 @@ private struct IndeterminateBar: View {
                 .fill(Color.hairline)
                 .frame(width: trackWidth, height: 3)
             Capsule()
-                .fill(Color.sage)
+                .fill(Color.accentTrack)
                 .frame(width: segmentWidth, height: 3)
                 .offset(x: animate ? maxOffset : 0)
         }
@@ -205,7 +205,7 @@ struct DownloadControl: View {
             case let .failed(message):
                 Text(message)
                     .font(.biscottiMono(11))
-                    .foregroundStyle(.signalRed)
+                    .foregroundStyle(.signalRedText)
                     .multilineTextAlignment(.center)
                     .fixedSize(horizontal: false, vertical: true)
                 GrantPill(
@@ -263,7 +263,7 @@ struct DownloadControl: View {
                 .fill(Color.hairline)
                 .frame(width: controlWidth, height: 3)
             Capsule()
-                .fill(Color.sage)
+                .fill(Color.accentTrack)
                 .frame(
                     width: max(3, controlWidth * min(fraction, 1.0)),
                     height: 3

--- a/Packages/BiscottiKit/Sources/OnboardingUI/OnboardingPrimaryButtonStyle.swift
+++ b/Packages/BiscottiKit/Sources/OnboardingUI/OnboardingPrimaryButtonStyle.swift
@@ -15,7 +15,7 @@ struct OnboardingPrimaryButtonStyle: ButtonStyle {
             .frame(height: 40)
             .background(
                 RoundedRectangle(cornerRadius: 9)
-                    .fill(Color.sage)
+                    .fill(Color.accentFill)
                     .overlay(alignment: .top) {
                         RoundedRectangle(cornerRadius: 9)
                             .fill(

--- a/Packages/BiscottiKit/Sources/OnboardingUI/ProgressHeader.swift
+++ b/Packages/BiscottiKit/Sources/OnboardingUI/ProgressHeader.swift
@@ -33,7 +33,7 @@ struct ProgressHeader: View {
                     .frame(width: trackWidth, height: trackHeight)
 
                 Capsule()
-                    .fill(Color.sage)
+                    .fill(Color.accentTrack)
                     .frame(
                         width: trackWidth * fillFraction,
                         height: trackHeight

--- a/Packages/BiscottiKit/Sources/RecordingUI/AutoStopCountdownCard.swift
+++ b/Packages/BiscottiKit/Sources/RecordingUI/AutoStopCountdownCard.swift
@@ -43,7 +43,7 @@ struct AutoStopCountdownCard: View {
                 Spacer()
                 Text("\(secondsLabel)s")
                     .font(.biscottiMono(14, weight: .medium))
-                    .foregroundStyle(Color.signalRed)
+                    .foregroundStyle(Color.signalRedText)
                     .monospacedDigit()
             }
 

--- a/Packages/BiscottiKit/Sources/RecordingUI/RecordingView.swift
+++ b/Packages/BiscottiKit/Sources/RecordingUI/RecordingView.swift
@@ -214,7 +214,7 @@ public struct RecordingView: View {
             Text("RECORDING")
                 .font(.biscottiMono(12.5, weight: .medium))
                 .tracking(1.5)
-                .foregroundStyle(Color.signalRed)
+                .foregroundStyle(Color.signalRedText)
         }
     }
 

--- a/Packages/BiscottiKit/Tests/DesignSystemTests/DynamicColorTests.swift
+++ b/Packages/BiscottiKit/Tests/DesignSystemTests/DynamicColorTests.swift
@@ -1,0 +1,519 @@
+import AppKit
+import Foundation
+import SwiftUI
+import Testing
+@testable import DesignSystem
+
+// MARK: - Test helpers
+
+/// Resolved sRGB color components for comparison.
+private struct SRGB {
+    let red: CGFloat
+    let green: CGFloat
+    let blue: CGFloat
+    let alpha: CGFloat
+}
+
+/// Resolves a dynamic `NSColor` under a specific appearance and returns sRGB components.
+private func resolve(
+    _ color: NSColor, appearance appearanceName: NSAppearance.Name
+) -> SRGB {
+    var result = SRGB(red: 0, green: 0, blue: 0, alpha: 0)
+    // swiftlint:disable:next force_unwrapping
+    NSAppearance(named: appearanceName)!.performAsCurrentDrawingAppearance {
+        // swiftlint:disable:next force_unwrapping
+        let resolved = color.usingColorSpace(.sRGB)!
+        result = SRGB(
+            red: resolved.redComponent,
+            green: resolved.greenComponent,
+            blue: resolved.blueComponent,
+            alpha: resolved.alphaComponent
+        )
+    }
+    return result
+}
+
+/// Resolves a dynamic SwiftUI `Color` (via its NSColor backing) under a specific appearance.
+/// **Assumption:** all SwiftUI `Color` tokens in this codebase are backed by `Color(nsColor:)` or
+/// `dynamicColor(light:dark:)` (which uses `Color(nsColor:)` internally), so round-tripping
+/// through `NSColor(Color)` recovers the underlying dynamic `NSColor` for appearance resolution.
+/// If a token were ever built from a raw `Color(red:green:blue:)` initializer, this helper would
+/// lose the dynamic provider and always return the light value.
+private func resolve(
+    _ color: Color, appearance appearanceName: NSAppearance.Name
+) -> SRGB {
+    let nsColor = NSColor(color)
+    return resolve(nsColor, appearance: appearanceName)
+}
+
+/// Sub-8-bit tolerance (1/512 ~ 0.00195).
+private let tolerance: CGFloat = 1.0 / 512.0
+
+private func assertSRGB(
+    _ actual: SRGB,
+    expected: SRGB,
+    label: String,
+    sourceLocation: SourceLocation = #_sourceLocation
+) {
+    #expect(
+        abs(actual.red - expected.red) <= tolerance,
+        "\(label) red: expected \(expected.red), got \(actual.red)",
+        sourceLocation: sourceLocation
+    )
+    #expect(
+        abs(actual.green - expected.green) <= tolerance,
+        "\(label) green: expected \(expected.green), got \(actual.green)",
+        sourceLocation: sourceLocation
+    )
+    #expect(
+        abs(actual.blue - expected.blue) <= tolerance,
+        "\(label) blue: expected \(expected.blue), got \(actual.blue)",
+        sourceLocation: sourceLocation
+    )
+    #expect(
+        abs(actual.alpha - expected.alpha) <= tolerance,
+        "\(label) alpha: expected \(expected.alpha), got \(actual.alpha)",
+        sourceLocation: sourceLocation
+    )
+}
+
+// MARK: - Test 1: Light values match legacy literals
+
+@Suite("Light values match legacy literals")
+struct LightValuesTests {
+    // Surfaces & ink
+
+    @Test("paper light == #FBFAF5")
+    func paperLight() {
+        let color = resolve(Color.paper, appearance: .aqua)
+        assertSRGB(color, expected: SRGB(red: 0.984, green: 0.980, blue: 0.961, alpha: 1), label: "paper")
+    }
+
+    @Test("ink light == #1A1813")
+    func inkLight() {
+        let color = resolve(NSColor.ink, appearance: .aqua)
+        assertSRGB(color, expected: SRGB(red: 0.102, green: 0.094, blue: 0.075, alpha: 1), label: "ink")
+    }
+
+    @Test("inkSecondary light == ink@54%")
+    func inkSecondaryLight() {
+        let color = resolve(NSColor.inkSecondary, appearance: .aqua)
+        assertSRGB(color, expected: SRGB(red: 0.102, green: 0.094, blue: 0.075, alpha: 0.54), label: "inkSecondary")
+    }
+
+    @Test("inkTertiary light == ink@34%")
+    func inkTertiaryLight() {
+        let color = resolve(NSColor.inkTertiary, appearance: .aqua)
+        assertSRGB(color, expected: SRGB(red: 0.102, green: 0.094, blue: 0.075, alpha: 0.34), label: "inkTertiary")
+    }
+
+    @Test("hairline light == ink@11%")
+    func hairlineLight() {
+        let color = resolve(Color.hairline, appearance: .aqua)
+        assertSRGB(color, expected: SRGB(red: 0.102, green: 0.094, blue: 0.075, alpha: 0.11), label: "hairline")
+    }
+
+    @Test("neutralChip light == ink@6%")
+    func neutralChipLight() {
+        let color = resolve(Color.neutralChip, appearance: .aqua)
+        assertSRGB(color, expected: SRGB(red: 0.102, green: 0.094, blue: 0.075, alpha: 0.06), label: "neutralChip")
+    }
+
+    @Test("cardStroke light == warm dark@10%")
+    func cardStrokeLight() {
+        let color = resolve(NSColor.cardStroke, appearance: .aqua)
+        assertSRGB(color, expected: SRGB(red: 0.102, green: 0.086, blue: 0.055, alpha: 0.10), label: "cardStroke")
+    }
+
+    @Test("wall light == #E4E1D8")
+    func wallLight() {
+        let color = resolve(Color.wall, appearance: .aqua)
+        assertSRGB(color, expected: SRGB(red: 0.894, green: 0.882, blue: 0.847, alpha: 1), label: "wall")
+    }
+
+    @Test("sidebarTint light == rgba(250,249,244,0.82)")
+    func sidebarTintLight() {
+        let color = resolve(Color.sidebarTint, appearance: .aqua)
+        assertSRGB(color, expected: SRGB(red: 0.980, green: 0.976, blue: 0.957, alpha: 0.82), label: "sidebarTint")
+    }
+
+    // Sage family
+
+    @Test("sage light == #4E7D5C")
+    func sageLight() {
+        let color = resolve(NSColor.sage, appearance: .aqua)
+        assertSRGB(color, expected: SRGB(red: 0.306, green: 0.490, blue: 0.361, alpha: 1), label: "sage")
+    }
+
+    @Test("accentWashSoft light == sage@8%")
+    func accentWashSoftLight() {
+        let color = resolve(Color.accentWashSoft, appearance: .aqua)
+        assertSRGB(color, expected: SRGB(red: 0.306, green: 0.490, blue: 0.361, alpha: 0.08), label: "accentWashSoft")
+    }
+
+    @Test("accentWashStrong light == sage@14%")
+    func accentWashStrongLight() {
+        let color = resolve(NSColor.accentWashStrong, appearance: .aqua)
+        assertSRGB(color, expected: SRGB(red: 0.306, green: 0.490, blue: 0.361, alpha: 0.14), label: "accentWashStrong")
+    }
+
+    @Test("softSageFill light == sage@12%")
+    func softSageFillLight() {
+        let color = resolve(Color.softSageFill, appearance: .aqua)
+        assertSRGB(color, expected: SRGB(red: 0.306, green: 0.490, blue: 0.361, alpha: 0.12), label: "softSageFill")
+    }
+
+    @Test("findHighlightFocused light == sage@35%")
+    func findHighlightFocusedLight() {
+        let color = resolve(NSColor.findHighlightFocused, appearance: .aqua)
+        assertSRGB(color, expected: SRGB(red: 0.306, green: 0.490, blue: 0.361, alpha: 0.35), label: "findHighlightFocused")
+    }
+
+    // Alert red
+
+    @Test("signalRed light == #B23320")
+    func signalRedLight() {
+        let color = resolve(Color.signalRed, appearance: .aqua)
+        assertSRGB(color, expected: SRGB(red: 0.698, green: 0.200, blue: 0.125, alpha: 1), label: "signalRed")
+    }
+
+    @Test("recordingOutline light == signalRed@32%")
+    func recordingOutlineLight() {
+        let color = resolve(Color.recordingOutline, appearance: .aqua)
+        assertSRGB(color, expected: SRGB(red: 0.698, green: 0.200, blue: 0.125, alpha: 0.32), label: "recordingOutline")
+    }
+
+    // Amber
+
+    @Test("warningOchre light == #C6891E")
+    func warningOchreLight() {
+        let color = resolve(Color.warningOchre, appearance: .aqua)
+        assertSRGB(color, expected: SRGB(red: 0.776, green: 0.537, blue: 0.118, alpha: 1), label: "warningOchre")
+    }
+
+    @Test("warningChipText light == #C6891E (same as ochre)")
+    func warningChipTextLight() {
+        let color = resolve(Color.warningChipText, appearance: .aqua)
+        assertSRGB(color, expected: SRGB(red: 0.776, green: 0.537, blue: 0.118, alpha: 1), label: "warningChipText")
+    }
+
+    // New tokens — light values must equal the literal they replace
+
+    @Test("cardFill light == #FFFFFF")
+    func cardFillLight() {
+        let color = resolve(Color.cardFill, appearance: .aqua)
+        assertSRGB(color, expected: SRGB(red: 1.0, green: 1.0, blue: 1.0, alpha: 1), label: "cardFill")
+    }
+
+    @Test("accentFill light == sage (#4E7D5C)")
+    func accentFillLight() {
+        let color = resolve(Color.accentFill, appearance: .aqua)
+        assertSRGB(color, expected: SRGB(red: 0.306, green: 0.490, blue: 0.361, alpha: 1), label: "accentFill")
+    }
+
+    @Test("read light == ink@54%")
+    func readLight() {
+        let color = resolve(Color.read, appearance: .aqua)
+        assertSRGB(color, expected: SRGB(red: 0.102, green: 0.094, blue: 0.075, alpha: 0.54), label: "read")
+    }
+
+    @Test("elevatedFill light == #FFFFFF")
+    func elevatedFillLight() {
+        let color = resolve(Color.elevatedFill, appearance: .aqua)
+        assertSRGB(color, expected: SRGB(red: 1.0, green: 1.0, blue: 1.0, alpha: 1), label: "elevatedFill")
+    }
+
+    @Test("accentTrack light == sage (#4E7D5C)")
+    func accentTrackLight() {
+        let color = resolve(Color.accentTrack, appearance: .aqua)
+        assertSRGB(color, expected: SRGB(red: 0.306, green: 0.490, blue: 0.361, alpha: 1), label: "accentTrack")
+    }
+
+    @Test("signalRedText light == #B23320")
+    func signalRedTextLight() {
+        let color = resolve(Color.signalRedText, appearance: .aqua)
+        assertSRGB(color, expected: SRGB(red: 0.698, green: 0.200, blue: 0.125, alpha: 1), label: "signalRedText")
+    }
+
+    @Test("cardShadow light == black@5%")
+    func cardShadowLight() {
+        let color = resolve(Color.cardShadow, appearance: .aqua)
+        assertSRGB(color, expected: SRGB(red: 0, green: 0, blue: 0, alpha: 0.05), label: "cardShadow")
+    }
+
+    @Test("controlShadow light == black@6%")
+    func controlShadowLight() {
+        let color = resolve(Color.controlShadow, appearance: .aqua)
+        assertSRGB(color, expected: SRGB(red: 0, green: 0, blue: 0, alpha: 0.06), label: "controlShadow")
+    }
+}
+
+// MARK: - Test 2: Dark values match design spec
+
+@Suite("Dark values match design spec")
+struct DarkValuesTests {
+    // Surfaces & ink
+
+    @Test("paper dark == #100E09")
+    func paperDark() {
+        let color = resolve(Color.paper, appearance: .darkAqua)
+        assertSRGB(color, expected: SRGB(red: 0.063, green: 0.055, blue: 0.035, alpha: 1), label: "paper dark")
+    }
+
+    @Test("ink dark == #F7F2E8")
+    func inkDark() {
+        let color = resolve(NSColor.ink, appearance: .darkAqua)
+        assertSRGB(color, expected: SRGB(red: 0.969, green: 0.949, blue: 0.910, alpha: 1), label: "ink dark")
+    }
+
+    @Test("inkSecondary dark == #F7F2E8@58%")
+    func inkSecondaryDark() {
+        let color = resolve(NSColor.inkSecondary, appearance: .darkAqua)
+        assertSRGB(color, expected: SRGB(red: 0.969, green: 0.949, blue: 0.910, alpha: 0.58), label: "inkSecondary dark")
+    }
+
+    @Test("inkTertiary dark == #F7F2E8@36%")
+    func inkTertiaryDark() {
+        let color = resolve(NSColor.inkTertiary, appearance: .darkAqua)
+        assertSRGB(color, expected: SRGB(red: 0.969, green: 0.949, blue: 0.910, alpha: 0.36), label: "inkTertiary dark")
+    }
+
+    @Test("hairline dark == #F7F2E8@12%")
+    func hairlineDark() {
+        let color = resolve(Color.hairline, appearance: .darkAqua)
+        assertSRGB(color, expected: SRGB(red: 0.969, green: 0.949, blue: 0.910, alpha: 0.12), label: "hairline dark")
+    }
+
+    @Test("neutralChip dark == #F7F2E8@7%")
+    func neutralChipDark() {
+        let color = resolve(Color.neutralChip, appearance: .darkAqua)
+        assertSRGB(color, expected: SRGB(red: 0.969, green: 0.949, blue: 0.910, alpha: 0.07), label: "neutralChip dark")
+    }
+
+    @Test("cardStroke dark == #F7F2E8@12%")
+    func cardStrokeDark() {
+        let color = resolve(NSColor.cardStroke, appearance: .darkAqua)
+        assertSRGB(color, expected: SRGB(red: 0.969, green: 0.949, blue: 0.910, alpha: 0.12), label: "cardStroke dark")
+    }
+
+    @Test("wall dark == #110F09")
+    func wallDark() {
+        let color = resolve(Color.wall, appearance: .darkAqua)
+        assertSRGB(color, expected: SRGB(red: 0.067, green: 0.059, blue: 0.035, alpha: 1), label: "wall dark")
+    }
+
+    @Test("sidebarTint dark == #14120D@74%")
+    func sidebarTintDark() {
+        let color = resolve(Color.sidebarTint, appearance: .darkAqua)
+        assertSRGB(color, expected: SRGB(red: 0.078, green: 0.071, blue: 0.051, alpha: 0.74), label: "sidebarTint dark")
+    }
+
+    // Sage family
+
+    @Test("sage dark == #86C295")
+    func sageDark() {
+        let color = resolve(NSColor.sage, appearance: .darkAqua)
+        assertSRGB(color, expected: SRGB(red: 0.525, green: 0.761, blue: 0.584, alpha: 1), label: "sage dark")
+    }
+
+    @Test("accentWashSoft dark == #86C295@12%")
+    func accentWashSoftDark() {
+        let color = resolve(Color.accentWashSoft, appearance: .darkAqua)
+        assertSRGB(color, expected: SRGB(red: 0.525, green: 0.761, blue: 0.584, alpha: 0.12), label: "accentWashSoft dark")
+    }
+
+    @Test("accentWashStrong dark == #86C295@16%")
+    func accentWashStrongDark() {
+        let color = resolve(NSColor.accentWashStrong, appearance: .darkAqua)
+        assertSRGB(color, expected: SRGB(red: 0.525, green: 0.761, blue: 0.584, alpha: 0.16), label: "accentWashStrong dark")
+    }
+
+    @Test("softSageFill dark == #86C295@14%")
+    func softSageFillDark() {
+        let color = resolve(Color.softSageFill, appearance: .darkAqua)
+        assertSRGB(color, expected: SRGB(red: 0.525, green: 0.761, blue: 0.584, alpha: 0.14), label: "softSageFill dark")
+    }
+
+    @Test("findHighlightFocused dark == #86C295@35%")
+    func findHighlightFocusedDark() {
+        let color = resolve(NSColor.findHighlightFocused, appearance: .darkAqua)
+        assertSRGB(color, expected: SRGB(red: 0.525, green: 0.761, blue: 0.584, alpha: 0.35), label: "findHighlightFocused dark")
+    }
+
+    // Alert red
+
+    @Test("signalRed dark == #E5604A")
+    func signalRedDark() {
+        let color = resolve(Color.signalRed, appearance: .darkAqua)
+        assertSRGB(color, expected: SRGB(red: 0.898, green: 0.376, blue: 0.290, alpha: 1), label: "signalRed dark")
+    }
+
+    @Test("recordingOutline dark == #E5604A@36%")
+    func recordingOutlineDark() {
+        let color = resolve(Color.recordingOutline, appearance: .darkAqua)
+        assertSRGB(color, expected: SRGB(red: 0.898, green: 0.376, blue: 0.290, alpha: 0.36), label: "recordingOutline dark")
+    }
+
+    // Amber
+
+    @Test("warningOchre dark == #E8A13A")
+    func warningOchreDark() {
+        let color = resolve(Color.warningOchre, appearance: .darkAqua)
+        assertSRGB(color, expected: SRGB(red: 0.910, green: 0.631, blue: 0.227, alpha: 1), label: "warningOchre dark")
+    }
+
+    @Test("warningChipText dark == #F0C04A")
+    func warningChipTextDark() {
+        let color = resolve(Color.warningChipText, appearance: .darkAqua)
+        assertSRGB(color, expected: SRGB(red: 0.941, green: 0.753, blue: 0.290, alpha: 1), label: "warningChipText dark")
+    }
+
+    // New tokens
+
+    @Test("cardFill dark == #1A170F")
+    func cardFillDark() {
+        let color = resolve(Color.cardFill, appearance: .darkAqua)
+        assertSRGB(color, expected: SRGB(red: 0.102, green: 0.090, blue: 0.059, alpha: 1), label: "cardFill dark")
+    }
+
+    @Test("accentFill dark == #56906A")
+    func accentFillDark() {
+        let color = resolve(Color.accentFill, appearance: .darkAqua)
+        assertSRGB(color, expected: SRGB(red: 0.337, green: 0.565, blue: 0.416, alpha: 1), label: "accentFill dark")
+    }
+
+    @Test("read dark == #F7F2E8@75%")
+    func readDark() {
+        let color = resolve(Color.read, appearance: .darkAqua)
+        assertSRGB(color, expected: SRGB(red: 0.969, green: 0.949, blue: 0.910, alpha: 0.75), label: "read dark")
+    }
+
+    @Test("elevatedFill dark == #1A170F")
+    func elevatedFillDark() {
+        let color = resolve(Color.elevatedFill, appearance: .darkAqua)
+        assertSRGB(color, expected: SRGB(red: 0.102, green: 0.090, blue: 0.059, alpha: 1), label: "elevatedFill dark")
+    }
+
+    @Test("accentTrack dark == #5E9A6F")
+    func accentTrackDark() {
+        let color = resolve(Color.accentTrack, appearance: .darkAqua)
+        assertSRGB(color, expected: SRGB(red: 0.369, green: 0.604, blue: 0.435, alpha: 1), label: "accentTrack dark")
+    }
+
+    @Test("signalRedText dark == #F08A78")
+    func signalRedTextDark() {
+        let color = resolve(Color.signalRedText, appearance: .darkAqua)
+        assertSRGB(color, expected: SRGB(red: 0.941, green: 0.541, blue: 0.471, alpha: 1), label: "signalRedText dark")
+    }
+
+    @Test("cardShadow dark == black@40%")
+    func cardShadowDark() {
+        let color = resolve(Color.cardShadow, appearance: .darkAqua)
+        assertSRGB(color, expected: SRGB(red: 0, green: 0, blue: 0, alpha: 0.40), label: "cardShadow dark")
+    }
+
+    @Test("controlShadow dark == black@40%")
+    func controlShadowDark() {
+        let color = resolve(Color.controlShadow, appearance: .darkAqua)
+        assertSRGB(color, expected: SRGB(red: 0, green: 0, blue: 0, alpha: 0.40), label: "controlShadow dark")
+    }
+
+    // Opacity-derived tokens: auto-adapt via their dynamic base color.
+    // These validate that `.opacity()` on a dynamic Color resolves the
+    // correct dark-mode base before applying the alpha multiplier.
+
+    @Test("recordingTintSoft dark == #E5604A@8%")
+    func recordingTintSoftDark() {
+        let color = resolve(Color.recordingTintSoft, appearance: .darkAqua)
+        assertSRGB(color, expected: SRGB(red: 0.898, green: 0.376, blue: 0.290, alpha: 0.08), label: "recordingTintSoft dark")
+    }
+
+    @Test("recordingTintStrong dark == #E5604A@12%")
+    func recordingTintStrongDark() {
+        let color = resolve(Color.recordingTintStrong, appearance: .darkAqua)
+        assertSRGB(color, expected: SRGB(red: 0.898, green: 0.376, blue: 0.290, alpha: 0.12), label: "recordingTintStrong dark")
+    }
+
+    @Test("recordingOutlineStrong dark == #E5604A@20%")
+    func recordingOutlineStrongDark() {
+        let color = resolve(Color.recordingOutlineStrong, appearance: .darkAqua)
+        assertSRGB(color, expected: SRGB(red: 0.898, green: 0.376, blue: 0.290, alpha: 0.20), label: "recordingOutlineStrong dark")
+    }
+
+    @Test("recordingHoverFill dark == #E5604A@5%")
+    func recordingHoverFillDark() {
+        let color = resolve(Color.recordingHoverFill, appearance: .darkAqua)
+        assertSRGB(color, expected: SRGB(red: 0.898, green: 0.376, blue: 0.290, alpha: 0.05), label: "recordingHoverFill dark")
+    }
+
+    @Test("warningBackground dark == #E8A13A@15%")
+    func warningBackgroundDark() {
+        let color = resolve(Tokens.warningBackground, appearance: .darkAqua)
+        assertSRGB(color, expected: SRGB(red: 0.910, green: 0.631, blue: 0.227, alpha: 0.15), label: "warningBackground dark")
+    }
+
+    @Test("errorBackground dark == #E5604A@15%")
+    func errorBackgroundDark() {
+        let color = resolve(Tokens.errorBackground, appearance: .darkAqua)
+        assertSRGB(color, expected: SRGB(red: 0.898, green: 0.376, blue: 0.290, alpha: 0.15), label: "errorBackground dark")
+    }
+}
+
+// MARK: - Test 3: Tokens aliases resolve correctly
+
+@Suite("Tokens aliases resolve correctly")
+struct TokensAliasTests {
+    @Test("Tokens.cardFill light == white")
+    func tokensCardFillLight() {
+        let color = resolve(Tokens.cardFill, appearance: .aqua)
+        assertSRGB(color, expected: SRGB(red: 1.0, green: 1.0, blue: 1.0, alpha: 1), label: "Tokens.cardFill light")
+    }
+}
+
+// MARK: - Test 4: No colorScheme conditionals in view code
+
+@Suite("No colorScheme conditionals in view code")
+struct NoColorSchemeConditionalsTests {
+    @Test("No @Environment colorScheme or colorScheme == in view sources")
+    func noColorSchemeInViews() throws {
+        // Find the Sources directory relative to this test file.
+        // The repo structure is: Packages/BiscottiKit/Sources/... and .../Tests/...
+        let testsDir = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+        let biscottiKitDir = testsDir
+            .deletingLastPathComponent() // Tests/
+            .deletingLastPathComponent() // BiscottiKit/
+        let sourcesDir = biscottiKitDir.appendingPathComponent("Sources")
+
+        let fileManager = FileManager.default
+        guard let enumerator = fileManager.enumerator(
+            at: sourcesDir,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        ) else {
+            Issue.record("Could not enumerate Sources directory at \(sourcesDir.path)")
+            return
+        }
+
+        var violations: [String] = []
+        let dynamicColorFile = "DynamicColor.swift"
+
+        while let url = enumerator.nextObject() as? URL {
+            guard url.pathExtension == "swift" else { continue }
+            let filename = url.lastPathComponent
+            // The only allowed appearance logic lives in DynamicColor.swift.
+            if filename == dynamicColorFile { continue }
+
+            let contents = try String(contentsOf: url, encoding: .utf8)
+            if contents.contains("colorScheme ==")
+                || contents.contains("@Environment(\\.colorScheme)")
+            {
+                violations.append(filename)
+            }
+        }
+
+        #expect(
+            violations.isEmpty,
+            "Files with colorScheme conditionals (should be zero): \(violations)"
+        )
+    }
+}

--- a/Packages/BiscottiKit/Tests/DesignSystemTests/DynamicColorTests.swift
+++ b/Packages/BiscottiKit/Tests/DesignSystemTests/DynamicColorTests.swift
@@ -246,6 +246,12 @@ struct LightValuesTests {
         let color = resolve(Color.controlShadow, appearance: .aqua)
         assertSRGB(color, expected: SRGB(red: 0, green: 0, blue: 0, alpha: 0.06), label: "controlShadow")
     }
+
+    @Test("avatarRing light == #FFFFFF")
+    func avatarRingLight() {
+        let color = resolve(Color.avatarRing, appearance: .aqua)
+        assertSRGB(color, expected: SRGB(red: 1.0, green: 1.0, blue: 1.0, alpha: 1), label: "avatarRing")
+    }
 }
 
 // MARK: - Test 2: Dark values match design spec
@@ -416,6 +422,12 @@ struct DarkValuesTests {
     func controlShadowDark() {
         let color = resolve(Color.controlShadow, appearance: .darkAqua)
         assertSRGB(color, expected: SRGB(red: 0, green: 0, blue: 0, alpha: 0.40), label: "controlShadow dark")
+    }
+
+    @Test("avatarRing dark == #1A170F")
+    func avatarRingDark() {
+        let color = resolve(Color.avatarRing, appearance: .darkAqua)
+        assertSRGB(color, expected: SRGB(red: 0.102, green: 0.090, blue: 0.059, alpha: 1), label: "avatarRing dark")
     }
 
     // Opacity-derived tokens: auto-adapt via their dynamic base color.

--- a/specs/projects/dark_mode/architecture.md
+++ b/specs/projects/dark_mode/architecture.md
@@ -1,0 +1,246 @@
+---
+status: complete
+---
+
+# Dark Mode — Architecture
+
+Mechanism and file-level design for the dark-mode token migration. Grounded in the
+functional spec's token map (`functional_spec.md`). Mechanism chosen with the
+user: **Swift dynamic colors** (not an asset catalog).
+
+UI-design step is intentionally skipped — no screens, layout, navigation, or
+behavior change. Component-design docs are not needed — the whole change
+centralizes in `DesignSystem` plus a short, enumerated list of call-site repoints.
+
+---
+
+## 1. Mechanism: one dynamic helper, two value branches
+
+There is no pure-SwiftUI dynamic-color primitive on macOS 15, but AppKit's
+`NSColor(name:dynamicProvider:)` resolves per `NSAppearance` at draw time, and
+`Color(nsColor:)` bridges that into SwiftUI so it re-resolves against the view's
+appearance. This gives us:
+
+- a **single** definition per token (one light `NSColor`, one dark `NSColor`),
+- automatic resolution with **zero `colorScheme` branches in views**,
+- one source feeding **both** SwiftUI (`Color`) and AppKit (`NSColor`) — removing
+  today's hand-synced duplication.
+
+The only appearance switch in the entire codebase lives here:
+
+```swift
+// DesignSystem/DynamicColor.swift  (internal)
+import AppKit
+import SwiftUI
+
+/// The single point where appearance is resolved. Returns an NSColor that
+/// picks `dark` under .darkAqua and `light` otherwise. Both inputs are sRGB
+/// and Sendable, so this is concurrency-safe under Swift 6.
+func dynamicNSColor(light: NSColor, dark: NSColor) -> NSColor {
+    NSColor(name: nil) { appearance in
+        appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua ? dark : light
+    }
+}
+
+/// SwiftUI sugar: a dynamic `Color` from light/dark sRGB literals.
+func dynamicColor(light: NSColor, dark: NSColor) -> Color {
+    Color(nsColor: dynamicNSColor(light: light, dark: dark))
+}
+```
+
+> Future-proofing (out of scope now): `bestMatch(from:)` can be widened to
+> `[.aqua, .darkAqua, .accessibilityHighContrastAqua, .accessibilityHighContrastDarkAqua]`
+> to add Increased-Contrast variants without touching any call site. We do not do
+> this now (it would require defining HC values and must not affect light).
+
+### Why this is byte-identical for light
+
+Every token's **light** branch is `NSColor(srgbRed: r, green: g, blue: b, alpha: a)`
+with the **exact same literals** the code uses today. The codebase already trusts
+this construction: `Color+Theme.swift` today maintains `NSColor(srgbRed: …)`
+mirrors built from "the same RGB/alpha literals … to avoid color-space surprises."
+We are simply making the `Color` token *derive from* that same sRGB `NSColor`
+(via `Color(nsColor:)`) instead of from a parallel `Color(red:…)` literal — and
+adding a dark branch. Light resolution returns the identical sRGB color.
+
+This equivalence is **asserted by an automated test** (§4), so it isn't taken on
+faith.
+
+---
+
+## 2. File changes
+
+### 2.1 `DesignSystem/DynamicColor.swift` (new, internal)
+The helper above. Internal to the `DesignSystem` module.
+
+### 2.2 `DesignSystem/Color+Theme.swift` (rewrite, behavior-preserving for light)
+Convert every semantic token from a static literal into a `dynamicColor(light:dark:)`.
+
+Pattern — define the `NSColor` tokens from light/dark sRGB, then derive the
+`Color` tokens and `ShapeStyle` sugar from them (single source):
+
+```swift
+public extension NSColor {
+    static let ink = dynamicNSColor(
+        light: NSColor(srgbRed: 0.102, green: 0.094, blue: 0.075, alpha: 1),      // #1A1813
+        dark:  NSColor(srgbRed: 0.969, green: 0.949, blue: 0.910, alpha: 1)       // #F7F2E8
+    )
+    static let inkSecondary = dynamicNSColor(
+        light: NSColor(srgbRed: 0.102, green: 0.094, blue: 0.075, alpha: 0.54),
+        dark:  NSColor(srgbRed: 0.969, green: 0.949, blue: 0.910, alpha: 0.58)
+    )
+    // … inkTertiary, sage, cardStroke, accentWashStrong, findHighlightFocused …
+}
+
+public extension Color {
+    static let ink = Color(nsColor: .ink)
+    static let inkSecondary = Color(nsColor: .inkSecondary)
+    // … etc.
+}
+```
+
+Notes on this rewrite:
+- **Derived tokens become explicit two-value entries.** `inkSecondary`,
+  `inkTertiary`, `hairline`, `neutralChip`, `accentWashSoft/Strong`, `softSageFill`
+  are no longer `base.opacity(x)` — each gets explicit light/dark `NSColor`s so the
+  dark alpha (and brightened dark base) can differ from light per the token map.
+- **NSColor mirrors that don't exist today** (e.g. an NSColor for `paper`,
+  `warningOchre`, washes) are only added where an AppKit consumer needs them. The
+  current AppKit consumers are `ink`, `inkSecondary` (markdown editor) — those
+  must stay NSColor-backed. For SwiftUI-only tokens we can define the dynamic
+  `Color` directly via `dynamicColor(light:dark:)` without a public `NSColor`.
+- **New tokens added here:** `accentFill`, `read`, `elevatedFill`, `accentTrack`,
+  `signalRedText`, `cardShadow`, `controlShadow` (values per functional spec §3).
+- **`ShapeStyle` sugar** (`static var ink: Color { .ink }`, etc.) is preserved and
+  extended for the new tokens used as `ShapeStyle` (`.foregroundStyle(.read)`,
+  `.fill(.accentFill)`, `.fill(.signalRedText)`).
+- The big doc-comments on `signalRed` / `warningOchre` ("the single canonical red /
+  warning") are updated to note the dark-only text variant (`signalRedText`) and
+  that values are now appearance-adaptive — preserving the "don't introduce other
+  reds/yellows" guidance.
+
+### 2.3 `DesignSystem/Tokens.swift` (mostly mechanical)
+`Tokens.*` are thin aliases of `Color.*`. Update:
+- `cardFill = Color.white` → `cardFill = Color.cardFill` (new adaptive token:
+  light `#FFFFFF`, dark `#1A170F`). Every card surface adapts for free.
+- `warningChipText = Color.warningChipText` — redefine the underlying token to its
+  own dark value (`#F0C04A`), no longer `= warningOchre`.
+- `warningBackground` / `warningChipFill` / `errorBackground` stay expressed as
+  `…ochre/red.opacity(0.15)`; they auto-adapt once `warningOchre` / `signalRed`
+  are dynamic (the opacity composites over the adaptive base — but verify the
+  dark alpha lands per spec; if a precise dark alpha is required, promote to an
+  explicit dynamic token).
+- Add `Tokens.elevatedFill`, `Tokens.accentFill`, `Tokens.read`,
+  `Tokens.accentTrack`, `Tokens.signalRedText`, `Tokens.cardShadow`,
+  `Tokens.controlShadow` aliases (match the existing aliasing style so call sites
+  can use either `Color.x` or `Tokens.x` as they do today).
+- `avatarPalette`, all typography/spacing/radii tokens: **untouched.**
+
+> Decision: opacity-derived washes (`warningBackground`, `errorBackground`,
+> `recordingTintSoft`, `recordingHoverFill`) may stay as `base.opacity(x)` ONLY
+> where the resulting dark value matches the spec within tolerance; otherwise make
+> them explicit dynamic tokens. The §4 dark-resolution test catches mismatches.
+
+### 2.4 Call-site repoints (≈16 sites)
+Exactly the list in functional spec §4. These are 1–2 token-name swaps each, in:
+`JoinRecordButtonStyle`, `OnboardingPrimaryButtonStyle`, `AppShellView` (toolbar
+fill), `GrantedTag`, `LightAlertButtonStyle` (fill + shadow), `EditableMeetingTitle`,
+`TranscriptListView`, `RecordingView`, `AutoStopCountdownCard`, `EventPickerSheet`,
+`ManageModelsSheet`, `ModelDownloadCard`, `ProgressHeader`, `HomeCardModifier`.
+
+### 2.5 `MarkdownEditorConfiguration+Biscotti.swift`
+No edit needed beyond the token redefinition: it reads `NSColor.ink` /
+`NSColor.inkSecondary`, which become dynamic — the `NSTextView` adapts to the
+window's `effectiveAppearance` automatically. Verify the editor re-renders on a
+live appearance switch (it should, via standard AppKit appearance propagation).
+
+### 2.6 App / window level
+No change required. The app sets no `preferredColorScheme`; `AppShellView` paints
+`Color.wall` (now adaptive) as the window backdrop and `Color.sidebarTint` (now
+adaptive) on the sidebar. The title bar / toolbar / dividers / sheets are native
+and adapt. Confirm no stray `.preferredColorScheme(.light)` exists (verified: none).
+
+---
+
+## 3. Concurrency / Swift 6 notes
+
+- The repo builds with strict concurrency + warnings-as-errors. Static `let`
+  tokens of type `Color` (Sendable) and `NSColor` are already used today and pass
+  CI, so the new static `let`s are fine.
+- `dynamicNSColor`'s provider closure captures two `NSColor`s and a small
+  `[NSAppearance.Name]` array (Strings) — all Sendable — so it satisfies a
+  `@Sendable` provider requirement if the SDK imposes one. If the compiler flags
+  the closure, the fix is local to the helper (e.g. mark inputs explicitly), not
+  the call sites.
+- Validate by building through `hooks-mcp` (agent cannot run `swift build` in the
+  Bash sandbox).
+
+---
+
+## 4. Testing — the linchpin guarantees, automated in `swift test`
+
+A new `DesignSystemTests` suite resolves each token under both appearances and
+asserts components. This makes both hard guarantees machine-checked and runs
+without xcodebuild.
+
+Resolve a dynamic `NSColor` for a given appearance deterministically:
+
+```swift
+func components(_ color: NSColor, _ appearanceName: NSAppearance.Name)
+    -> (r: CGFloat, g: CGFloat, b: CGFloat, a: CGFloat) {
+    var out = (CGFloat(0), CGFloat(0), CGFloat(0), CGFloat(0))
+    NSAppearance(named: appearanceName)!.performAsCurrentDrawingAppearance {
+        let c = color.usingColorSpace(.sRGB)!
+        out = (c.redComponent, c.greenComponent, c.blueComponent, c.alphaComponent)
+    }
+    return out
+}
+```
+
+**Test 1 — light is byte-identical (the critical regression guard).** For every
+token, assert its `.aqua` resolution equals the **legacy literal** it replaced
+(keep a table of the old `Color(red:…)`/opacity values in the test). Tolerance
+≈ 1/512 (sub-8-bit). This is the automated proof that light didn't move.
+
+**Test 2 — dark matches the design.** For every token, assert its `.darkAqua`
+resolution equals the design hex (within the same tolerance).
+
+**Test 3 — no view conditionals.** A test (or CI grep) asserts zero
+`colorScheme ==` / `@Environment(\.colorScheme)` occurrences under
+`Packages/BiscottiKit/Sources/**` view code (the only allowed appearance logic is
+in `DynamicColor.swift`).
+
+> `performAsCurrentDrawingAppearance` (macOS 11+) is deterministic and
+> single-threaded here; resolving at the `NSColor` layer avoids any ambiguity in
+> how SwiftUI bridges the dynamic color, and it directly validates the AppKit
+> consumers too.
+
+Existing `DesignSystemTests` and other package tests must stay green
+(`make test` / `mcp__hooks-mcp__test`).
+
+---
+
+## 5. Manual / on-hardware verification (non-gating, human)
+
+Toggle System Settings → Appearance while the app is open and confirm a **live**
+switch (no relaunch) across: Home, Meeting Detail (transcript + notes), Active
+Recording (Stop&Save, REC pill, Elapsed + amber ≤5:00 chips, RECORDING badge),
+Upcoming, Onboarding, Settings, model sheets, error + warning banners, menu-bar
+popover, and the markdown notes editor. No white-on-light or light-on-light
+defects; avatars unchanged; native controls correct.
+
+This is captured as the dark-mode acceptance pass; it does not change the
+manual-test gate for Transcription/AudioCapture/LocalLLM (no package touched
+there).
+
+---
+
+## 6. Risks & mitigations
+
+| Risk | Mitigation |
+|---|---|
+| `Color(nsColor: srgb)` ≠ today's `Color(red:)` for light | Test 1 asserts exact light components; if any token drifts, construct that `Color` via `Color(.sRGB, red:…)` to match. High confidence both are plain sRGB. |
+| Opacity-derived washes land at wrong dark alpha | Test 2 catches it; promote the token to an explicit dynamic light/dark entry. |
+| AppKit text view doesn't live-update on appearance switch | Standard appearance propagation should handle it; manual §5 confirms; if not, observe `effectiveAppearance` in the editor config (localized fix). |
+| Swift 6 `@Sendable` provider error | Captured values are Sendable; fix is local to the helper. |
+| A repoint accidentally changes a light pixel | Each new token's light value == the literal it replaces (Test 1 covers the token; repoints only swap which equal-in-light token is used). |

--- a/specs/projects/dark_mode/functional_spec.md
+++ b/specs/projects/dark_mode/functional_spec.md
@@ -137,6 +137,7 @@ kicker vs value (see §6) — one bright amber text value reads well for both.
 | **`elevatedFill`** *(NEW)* | `#FFFFFF` (= white) | `#1A170F` (= card) | the white-fill **buttons/fields**: Stop&Save / REC pill chrome (`LightAlertButtonStyle`), focused title field. Identical value to `card` today but semantically a control fill. |
 | **`cardShadow`** *(NEW)* | `black @5%` | `black @40%` | `HomeCardModifier` shadow. Adaptive opacity only; radius/offset unchanged. |
 | **`controlShadow`** *(NEW)* | `black @6%` | `black @40%` | `LightAlertButtonStyle` shadow. Separate token to keep light's 6% exact. |
+| **`avatarRing`** *(NEW)* | `#FFFFFF` | `#1A170F` (= card) | Avatar stacked-border ring. Matches the surface behind overlapping avatars. |
 
 > Shadows "recede" on dark (design §3). Tokenizing is low-stakes — black@5% on a
 > near-black surface is nearly invisible regardless — but we tokenize for fidelity
@@ -227,9 +228,11 @@ token's light value equals what's there today).
   — white text/icon on sage/red fill is correct in both modes. Keep.
 - **White sheen gradients** over filled buttons (`JoinRecordButtonStyle:24-25`,
   `OnboardingPrimaryButtonStyle:22-23`) — a top highlight on the fill; keep.
-- **Avatars** (`Avatar.swift` palette gradient, white rings `:48,64,187,217,227`,
-  white initials `:53,57,221`) — unchanged per design §6; the separator/`+N` rings
-  already use the `card` token and track the surface automatically.
+- **Avatars** (`Avatar.swift` palette gradient, white initials `:53,57,221`,
+  inset hairline rings `:48,217`) — white-on-colored-fill elements stay white.
+  The **stacked border rings** (`:64,187,227`) now use the adaptive `avatarRing`
+  token (`#FFFFFF` / `#1A170F`) so the thick 2pt ring matches the surface in
+  both modes instead of being a stark white outline on dark backgrounds.
 - **`.ultraThinMaterial`** (`MeetingDetailView.swift:1064`) — adapts automatically;
   behind a `macOS 26` `.glassEffect` guard. Leave.
 - **`Color(hex:)`** calendar colors and **`Tokens.avatarPalette`** — data/identity

--- a/specs/projects/dark_mode/functional_spec.md
+++ b/specs/projects/dark_mode/functional_spec.md
@@ -1,0 +1,318 @@
+---
+status: complete
+---
+
+# Dark Mode — Functional Spec
+
+This spec turns the approved Dark Mode design (see `project_overview.md`) into a
+concrete, code-grounded contract. It is the authoritative **token map** and the
+list of **reconciliations** where the shipped code diverges from the comps.
+
+The design doc is the source of truth for **dark color values**. The **code** is
+the source of truth for **everything else** — light values, structure, which
+elements exist, and whether a surface is flat or gradient.
+
+---
+
+## 1. Scope & non-goals
+
+**In scope**
+- Make the existing semantic palette appearance-adaptive so the app renders
+  correctly in dark mode, following the system appearance.
+- Add a small number of new semantic tokens where dark needs to split a role the
+  light system collapsed (`accentFill`, `read`, `elevatedFill`, and two optional
+  splits below).
+- Repoint the handful of call sites those splits require, plus a few hardcoded
+  literals (`Color.white` button/field fills, two `.black` shadows).
+
+**Out of scope / non-goals**
+- **No feature, layout, spacing, type, radius, navigation, or behavior changes.**
+- **No new backgrounds, highlights, borders, or shadows** where the code does not
+  already have one. (Where the design comps describe an element the code doesn't
+  render — e.g. a gradient backdrop — we do **not** add it.)
+- **No changes to light-mode rendering.** Light must be byte-for-byte identical.
+- No in-app light/dark toggle.
+- Avatar identity colors (`Tokens.avatarPalette`) and EventKit calendar colors
+  (`Color(hex:)`) are **not** touched — they read on both appearances.
+- Increased-Contrast accessibility variants are **future work** (the mechanism
+  leaves room for them; see architecture).
+
+---
+
+## 2. Hard guarantees (acceptance contract)
+
+1. **Light is unchanged, byte-for-byte.** Every token's light value equals the
+   exact literal it replaces (same sRGB components, same alpha). Introducing
+   adaptivity is a pure refactor for light.
+2. **No appearance conditionals in view code.** There are zero
+   `if colorScheme == .dark` branches in any view, `ButtonStyle`, or modifier.
+   Appearance is resolved entirely inside the palette layer.
+3. **Single source of truth.** Each color is defined once (one entry carrying a
+   light value and a dark value). SwiftUI (`Color`) and AppKit (`NSColor`)
+   consumers read the same source — the current hand-synced `Color`/`NSColor`
+   duplication is eliminated.
+4. **Follows the system.** No forced `preferredColorScheme`; the app already sets
+   none, so adapting the tokens is sufficient.
+5. **Native controls are left alone** — segmented `Picker`, `Slider`, `Menu`,
+   `DisclosureGroup`, `role: .destructive`, sheets, materials, traffic lights,
+   dividers — they adapt automatically.
+
+---
+
+## 3. Token families — light (keep) → dark (port)
+
+Notation: light values are the **current code literals** (do not edit). Dark
+values are hex from the design. "Derived" means the token is currently expressed
+as `base.opacity(x)`; under the new mechanism it becomes an explicit two-value
+entry so the dark alpha can differ from light (the design bumps several).
+
+`#F7F2E8` = the dark "ink" (warm off-white) used as the base for all dark
+text/separator/chip/wash-on-neutral values.
+
+### 3.1 Surfaces & ink (redefine in place — no call-site changes)
+
+| Code token | Light (keep exact) | Dark (port) | Notes |
+|---|---|---|---|
+| `paper` / `Tokens.contentBackground` | `#FBFAF5` | `#100E09` | pane/content bg |
+| `wall` | `#E4E1D8` (flat) | `#110F09` (flat) | window backdrop. **Code is flat**, design comp is a radial — keep flat, port the midpoint dark value. |
+| `sidebarTint` | `rgba(250,249,244,.82)` | `rgba(20,18,13,.74)` = `#14120D@74%` | flat tint (code has no vibrancy layer under it — keep flat) |
+| `cardFill` / `Tokens.cardFill` | `#FFFFFF` | `#1A170F` | this is the design's `card`. Becomes adaptive; all card surfaces get dark for free. |
+| `cardStroke` (`Color`+`NSColor`) | `rgba(26,22,14,.10)` | `rgba(247,242,232,.12)` | card border |
+| `ink` (`Color`+`NSColor`) | `#1A1813` | `#F7F2E8` | primary text |
+| `inkSecondary` (`Color`+`NSColor`) | `#1A1813 @54%` | `#F7F2E8 @58%` | derived → explicit (alpha bumps 54→58) |
+| `inkTertiary` (`Color`+`NSColor`) | `#1A1813 @34%` | `#F7F2E8 @36%` | derived → explicit |
+| `hairline` | `#1A1813 @11%` | `#F7F2E8 @12%` | separator; derived → explicit |
+| `neutralChip` | `#1A1813 @6%` | `#F7F2E8 @7%` | derived → explicit |
+
+### 3.2 Sage / accent
+
+| Code token | Light (keep) | Dark | Notes |
+|---|---|---|---|
+| `sage` (`Color`+`NSColor`) / `Tokens.liveGreen` | `#4E7D5C` | `#86C295` | the **text/icon/link/timestamp** accent (design `accent`). Brightened in dark. |
+| **`accentFill`** *(NEW)* | `#4E7D5C` (= sage) | `#56906A` | **button fills** under a white label. Light = sage (no change); dark = deeper sage for white-label contrast. |
+| **`accentTrack`** *(NEW, optional — see §6)* | `#4E7D5C` (= sage, flat) | `#5E9A6F` | custom **progress-bar** fills. Code is flat sage (comp is a gradient) — keep flat. |
+| `accentWashSoft` / `Tokens.speakerChipBackground` | `sage @8%` | `#86C295 @12%` | derived → explicit (dark base brightens + alpha bumps) |
+| `accentWashStrong` (`Color`+`NSColor`) | `sage @14%` | `#86C295 @16%` | selection wash; derived → explicit |
+| `softSageFill` | `sage @12%` | `#86C295 @14%` | "Add note" / soft button wash |
+| `findHighlightFocused` (`Color`+`NSColor`) | `sage @35%` | `#86C295 @35%` | find-match; keep alpha |
+
+### 3.3 Alert red
+
+The codebase ships **one** canonical red `signalRed` `#B23320`, used for marks
+**and** text. The design splits dark into a mark red and a (lighter) text red, but
+its **light** split values (`alert #C9402B`) do **not** match the shipped single
+red. Per "code wins + zero light change," **both** stay `#B23320` in light; only
+dark diverges (exactly the `accentFill` pattern).
+
+| Code token | Light (keep) | Dark | Notes |
+|---|---|---|---|
+| `signalRed` (`Color`+`NSColor`?) | `#B23320` | `#E5604A` | **marks**: dots, icons, stop-square, fills, borders. (design `alert`) |
+| **`signalRedText`** *(NEW, optional — see §6)* | `#B23320` (= signalRed) | `#F08A78` | **standalone red text** labels (design `alertText`). Lighter for AA on dark. |
+| `errorBackground` (`Tokens`) | `signalRed @15%` | `#E5604A @15%` | error banner wash. Auto-correct once signalRed is adaptive (design `alertWash` ≈ .13; keep code's .15). |
+| `recordingTintSoft` | `signalRed @8%` | `#E5604A @8%` | sidebar / auto-stop wash; auto via adaptive signalRed |
+| `recordingTintStrong` | `signalRed @12%` | `#E5604A @12%` | *(currently unused; keep adaptive)* |
+| `recordingOutline` | `signalRed @32%` | `#E5604A @36%` | Stop/REC button & card ring (design `alertBorder` .36). Derived → explicit to hit .36. |
+| `recordingOutlineStrong` | `signalRed @20%` | `#E5604A @20%` | *(unused; keep adaptive)* |
+| `recordingHoverFill` | `signalRed @5%` | `#E5604A @5%` | button hover; auto via adaptive signalRed |
+
+### 3.4 Amber / warning
+
+The codebase ships **one** canonical `warningOchre` `#C6891E` (icons + dot) and
+one `warningChipText` (= warningOchre) for both kicker and value text. The design
+splits amber into kicker/value/wash/dot with **darker** light text values
+(`#996A12`, `#7D540A`) than the shipped `#C6891E`. Per "code wins," **light stays
+`#C6891E`** everywhere; dark ports the design's bright amber. We do **not** split
+kicker vs value (see §6) — one bright amber text value reads well for both.
+
+| Code token | Light (keep) | Dark | Notes |
+|---|---|---|---|
+| `warningOchre` (`Color`+`NSColor` mirror? Color only) | `#C6891E` | `#E8A13A` | warning **icons** (triangles) + the pulsing **dot** (design `amberDot`, reads in both) |
+| `warningChipText` / `Tokens.warningChipText` | `#C6891E` (= ochre) | `#F0C04A` | amber **text**: time-chip kicker + value, "Requires …" labels. Redefine to its own dark value (no longer `= warningOchre`). |
+| `warningBackground` / `warningChipFill` | `ochre @15%` | `#E8A13A @15%` | chip/banner **wash** (design `amberWash` .15). Auto via adaptive warningOchre; keep code's .15 (not the comp's .18). |
+
+### 3.5 New surface/elevation tokens
+
+| Code token | Light (keep) | Dark | Used by |
+|---|---|---|---|
+| **`elevatedFill`** *(NEW)* | `#FFFFFF` (= white) | `#1A170F` (= card) | the white-fill **buttons/fields**: Stop&Save / REC pill chrome (`LightAlertButtonStyle`), focused title field. Identical value to `card` today but semantically a control fill. |
+| **`cardShadow`** *(NEW)* | `black @5%` | `black @40%` | `HomeCardModifier` shadow. Adaptive opacity only; radius/offset unchanged. |
+| **`controlShadow`** *(NEW)* | `black @6%` | `black @40%` | `LightAlertButtonStyle` shadow. Separate token to keep light's 6% exact. |
+
+> Shadows "recede" on dark (design §3). Tokenizing is low-stakes — black@5% on a
+> near-black surface is nearly invisible regardless — but we tokenize for fidelity
+> and to keep light byte-exact (5% vs 6% can't be collapsed).
+
+### 3.6 Design tokens deliberately NOT created (code moved beyond the comps)
+
+These appear in the design's token table but have **no flat-color home in the
+code** (the code renders flat where the comp uses a gradient, or the element does
+not exist). Per "code wins," we do not introduce them:
+
+- `windowWall` **radial gradient** — code uses flat `wall`. Port flat only.
+- `cardTop` / raised **card gradient** (`#FFFDFB → … `) — code cards are flat
+  `cardFill`. No gradient cards exist.
+- `recordIdle` **gradient** + `recordRing` — the idle Record button is a **flat**
+  `accentFill` (no sage gradient, no sage ring in code; the in-pane ripple ring is
+  **red**, handled by `signalRed`).
+- `alertGrad` **gradient** — the REC pill / Stop&Save are white-fill + red text
+  (`LightAlertButtonStyle`), not a red-gradient pill.
+- `accentTrack` **gradient** — code progress fills are flat; we add a *flat*
+  `accentTrack` (§3.2) not the gradient. The audio `Slider` keeps the bright
+  `sage` tint per design ("its tint is accent(text-bright)").
+- `fill` / `hover` neutral soft-fill tokens — the audit found **no** neutral
+  `black.opacity(.04–.06)` hover/fill literals in view code (the only neutral
+  blacks are the two card shadows; the only hover is the red `recordingHoverFill`).
+  Nothing to repoint, so these tokens aren't needed. (Trivial to add later.)
+- `windowHairline` — window/section dividers are native `Divider()`s that adapt
+  automatically.
+
+If any of these elements is later added to the code, the matching token can be
+added then. We are not pre-building tokens for comps the code doesn't use.
+
+---
+
+## 4. Call-site repoints (the only view-code edits)
+
+Everything else is a token **redefinition** (§3) with no call-site change. These
+sites change which token they reference. None changes light pixels (each new
+token's light value equals what's there today).
+
+**`accentFill` (solid sage button fills → deeper dark sage):**
+- `DesignSystem/JoinRecordButtonStyle.swift:19` — `.fill(Color.sage)` → `accentFill`
+- `OnboardingUI/OnboardingPrimaryButtonStyle.swift:18` — `.fill(Color.sage)` → `accentFill`
+- `AppShellUI/AppShellView.swift:99` — `ToolbarRecordButtonStyle(fill: .sage)` → `fill: .accentFill`
+- `OnboardingUI/GrantedTag.swift:18` — `Circle().fill(Color.sage)` → `accentFill`
+- *Leave* `SettingsUI/AlertsHelpSheet.swift:43` `.tint(.sage)` on a `.borderedProminent`
+  button — native control; macOS suppresses custom tint there anyway.
+- *Leave* `DesignSystem/RecordButton.swift:22` 10pt sage indicator dot — no white
+  label; reads better at the brighter `sage` value.
+
+**`elevatedFill` (white control fills):**
+- `DesignSystem/LightAlertButtonStyle.swift:20` — `Tokens.cardFill` → `elevatedFill`
+- `DesignSystem/EditableMeetingTitle.swift:117` — `Color.white` → `elevatedFill`
+  (focused title field; dark = card surface lift, matching light's white lift)
+
+**`read` (long-form body):**
+- `MeetingDetailUI/TranscriptListView.swift:196` — transcript utterance text
+  `.inkSecondary` → `.read`. (Speaker name stays its palette color; timestamp
+  stays `.inkTertiary`. Notes body is already `.ink` — **stays `.ink`**, contrary
+  to the comp's "notes body = label2," because the code already uses full ink.)
+
+**`signalRedText` (standalone red text — optional, §6):**
+- `RecordingUI/RecordingView.swift:217` — "RECORDING" label
+- `RecordingUI/AutoStopCountdownCard.swift:46` — countdown seconds text
+- `DesignSystem/EventPickerSheet.swift:125` — "Remove association"
+- `ModelManagementUI/ManageModelsSheet.swift:281` — download-failed message
+- `OnboardingUI/ModelDownloadCard.swift:208` — download-failed message
+- *Leave* `LightAlertButtonStyle.swift:17` (single `foregroundStyle` tints the
+  Stop-square **and** the label together — keep `signalRed`; `#E5604A` reads fine
+  on the elevated card). *Leave* `Banner.swift:37` (mark icon).
+
+**`accentTrack` (custom progress bars — optional, §6):**
+- `OnboardingUI/ProgressHeader.swift:36`
+- `OnboardingUI/ModelDownloadCard.swift:152` and `:266`
+- *Leave* `DesignSystem/AudioTransport.swift:88` `Slider.tint(.sage)` (design keeps
+  the slider tint at the bright accent).
+
+**Shadows (tokenize):**
+- `DesignSystem/HomeCardModifier.swift:14` — `.black.opacity(0.05)` → `Color.cardShadow`
+- `DesignSystem/LightAlertButtonStyle.swift:28` — `.black.opacity(0.06)` → `Color.controlShadow`
+
+---
+
+## 5. Hardcoded sites that intentionally stay
+
+- **White labels on colored fills** (`JoinRecordButtonStyle:14,56`,
+  `OnboardingPrimaryButtonStyle:13`, `GrantedTag:23`, `ToolbarRecordButtonStyle:56`)
+  — white text/icon on sage/red fill is correct in both modes. Keep.
+- **White sheen gradients** over filled buttons (`JoinRecordButtonStyle:24-25`,
+  `OnboardingPrimaryButtonStyle:22-23`) — a top highlight on the fill; keep.
+- **Avatars** (`Avatar.swift` palette gradient, white rings `:48,64,187,217,227`,
+  white initials `:53,57,221`) — unchanged per design §6; the separator/`+N` rings
+  already use the `card` token and track the surface automatically.
+- **`.ultraThinMaterial`** (`MeetingDetailView.swift:1064`) — adapts automatically;
+  behind a `macOS 26` `.glassEffect` guard. Leave.
+- **`Color(hex:)`** calendar colors and **`Tokens.avatarPalette`** — data/identity
+  colors; not migrated.
+- **Native controls** — segmented `Picker`, `Slider` rail, `Menu`/popovers,
+  `DisclosureGroup`, `.destructive`, `Divider`, sheets. Leave.
+
+---
+
+## 6. Open judgment calls (decided here; flagged for review)
+
+Three of the design's splits are subtle and slightly grow the codebase's
+deliberately minimal "one red / one amber / one sage" palette. I've **decided to
+include the high-value ones** and **simplify the lowest-value ones**, but these
+are easy to flip during spec review:
+
+1. **`signalRedText` (red text split) — INCLUDED.** Standalone red text at the
+   mark red `#E5604A` is only ~4.5:1 on dark (borderline AA); the design's lighter
+   `#F08A78` (~7:1) is a real legibility win for error/recording text. Cost: 1
+   token + 5 repoints. *Alternative:* drop it and let red text use `signalRed`
+   `#E5604A`.
+2. **`accentTrack` (progress-bar split) — INCLUDED.** The design wants progress
+   fills a touch less bright than text sage (`#5E9A6F` vs `#86C295`). Cost: 1
+   token + 3 repoints. *Alternative:* drop it and let progress bars use `sage`
+   `#86C295`.
+3. **Amber kicker vs value split — SIMPLIFIED OUT.** The design splits amber text
+   into kicker `#D9A53A` and value `#F0C04A`; the code uses one `warningChipText`
+   for both. We keep one token at the brighter `#F0C04A` (more legible; the only
+   effect is the small "LEFT/OVER" kicker being a hair brighter than the comp).
+   *Alternative:* split into two tokens to match the comp exactly.
+
+If the reviewer prefers maximum minimalism, (1) and (2) collapse into `signalRed`
+and `sage` with no other change.
+
+---
+
+## 7. Per-surface behavior (reconciled with code)
+
+All "palette swap" — listed only where there's a nuance beyond §3/§4.
+
+- **Home:** pure token swap (greeting serif, mono kickers/timestamps, stat chips,
+  `accentWashSoft` hero row, avatars). Nothing special.
+- **Meeting Detail:** transcript body → `read` (§4); speaker names keep palette
+  colors; timestamps `inkTertiary`; segmented control, Slider, `.destructive`
+  Delete, "…" Menu/popovers all native. Source pill / soft buttons use
+  `neutralChip`/`accentWashSoft` + `inkSecondary` (already token-driven).
+- **Active Recording:** RECORDING dot `signalRed` (mark) + label `signalRedText`;
+  Stop&Save / REC pill = `elevatedFill` fill + `recordingOutline` border + red
+  content; Elapsed chip = `neutralChip`; Left≤5:00 chip = `warningChipFill` +
+  `warningChipText` + `warningOchre` dot; note composer = `softSageFill` +
+  `sage` timestamps. (All via §3/§4 — no structural change.)
+- **Upcoming Event / Onboarding:** token swap; progress bars → `accentTrack`
+  (§4); permission cards `accentWashSoft` + `sage` checks; CTA buttons
+  `accentFill`; destructive items `signalRed`/`signalRedText`.
+
+---
+
+## 8. Accessibility & motion
+
+- **Contrast (dark):** targets from design — `ink` ~16:1, `read` ~10:1,
+  `inkSecondary` ~7:1; `sage`/`signalRedText`/`warningChipText` clear AA on
+  `content`; `accentFill` carries white labels at AA-large (keep label weight
+  ≥ 500, already the case in the button styles).
+- **Motion is unchanged** (recording halo, header dot pulse, amber dot, caret
+  blink) and still honors Reduce Motion exactly as today — no motion edits.
+- Increased-Contrast appearance variants are out of scope; the dynamic-color
+  helper is structured so they can be added later without touching call sites.
+
+---
+
+## 9. Verification / acceptance criteria
+
+1. **Light unchanged:** existing unit/snapshot tests pass; a spot diff of key
+   screens in light shows no pixel change. (The token literals are provably equal;
+   verify the mechanism preserves sRGB exactly — see architecture.)
+2. **Dark renders correctly:** Home, Meeting Detail (transcript + notes), Active
+   Recording (Stop&Save, REC pill, time chips incl. amber ≤5:00, RECORDING badge),
+   Upcoming, Onboarding, Settings, model-management sheets, banners (error +
+   warning), and the menu-bar surfaces all show no white-on-light / light-on-light
+   defects in dark.
+3. **No conditionals:** grep confirms zero `colorScheme ==` / `@Environment(\.colorScheme)`
+   in view code; the only appearance switch lives in the palette helper.
+4. **Single source:** `Color` and `NSColor` tokens derive from one definition; the
+   markdown editor (AppKit) adapts.
+5. Manual on-hardware check toggling System Settings → Appearance Light/Dark with
+   the app open (live switch updates without relaunch).

--- a/specs/projects/dark_mode/implementation_plan.md
+++ b/specs/projects/dark_mode/implementation_plan.md
@@ -42,7 +42,7 @@ decisions**. Details live in `functional_spec.md` (token map, repoint list) and
     white-on-light / light-on-light defects, nothing unreadable. (Aesthetic
     sign-off is Phase 3.)
 
-- [ ] **Phase 3 — Human visual review of agent decisions.**
+- [x] **Phase 3 — Human visual review of agent decisions.**
   This project is the agent interpreting design *comps* against the real code, so
   every color choice gets an explicit human eyeball before it's considered done.
   - **Agent prepares a review packet:** run the app and capture **side-by-side

--- a/specs/projects/dark_mode/implementation_plan.md
+++ b/specs/projects/dark_mode/implementation_plan.md
@@ -28,7 +28,7 @@ decisions**. Details live in `functional_spec.md` (token map, repoint list) and
   - Green `make lint` + `make test` (via `hooks-mcp`). No call-site repoints yet —
     after this phase the app already renders dark for all redefined tokens.
 
-- [ ] **Phase 2 — Split repoints, hardcoded sites, verification.**
+- [x] **Phase 2 — Split repoints, hardcoded sites, verification.**
   - Repoint the ≈16 call sites in functional-spec §4: `accentFill` button fills,
     `elevatedFill` (button style + focused title field), `read` transcript body,
     `signalRedText` red-text labels, `accentTrack` progress bars, and the two

--- a/specs/projects/dark_mode/implementation_plan.md
+++ b/specs/projects/dark_mode/implementation_plan.md
@@ -1,0 +1,71 @@
+---
+status: complete
+---
+
+# Implementation Plan: Dark Mode
+
+Three phases. Phase 1 is the foundation and makes most of the app adapt; Phase 2
+is the split-token repoints + hardcoded-site fixes + automated/functional
+verification; Phase 3 is a dedicated **human visual review of the agent's
+decisions**. Details live in `functional_spec.md` (token map, repoint list) and
+`architecture.md` (mechanism, tests). Keep light byte-identical throughout.
+
+## Phases
+
+- [x] **Phase 1 — Adaptive palette foundation (+ guarantee tests).**
+  - Add `DesignSystem/DynamicColor.swift` (the single appearance-resolving helper).
+  - Rewrite `Color+Theme.swift`: every existing token → `dynamicColor(light:dark:)`
+    with light = exact current literal, dark = functional-spec §3 value. Unify the
+    `Color`/`NSColor` definitions into one source. Preserve `ShapeStyle` sugar.
+  - Add the new tokens: `accentFill`, `read`, `elevatedFill`, `accentTrack`,
+    `signalRedText`, `cardShadow`, `controlShadow` (light = the literal each
+    replaces).
+  - Update `Tokens.swift`: `cardFill` adaptive; `warningChipText` to its own dark
+    value; add aliases for the new tokens; leave avatar/type/spacing/radii.
+  - Add `DesignSystemTests`: Test 1 (every token's `.aqua` == legacy literal —
+    the byte-identical-light guard), Test 2 (`.darkAqua` == design hex), Test 3
+    (no `colorScheme` conditionals in view code).
+  - Green `make lint` + `make test` (via `hooks-mcp`). No call-site repoints yet —
+    after this phase the app already renders dark for all redefined tokens.
+
+- [ ] **Phase 2 — Split repoints, hardcoded sites, verification.**
+  - Repoint the ≈16 call sites in functional-spec §4: `accentFill` button fills,
+    `elevatedFill` (button style + focused title field), `read` transcript body,
+    `signalRedText` red-text labels, `accentTrack` progress bars, and the two
+    `.black` shadows → `cardShadow`/`controlShadow`.
+  - Confirm hardcoded "stays" sites are untouched (white labels/sheen, avatars,
+    material, calendar hex, native controls) — functional-spec §5.
+  - Green `make lint` + `make test`; `make build-app` (non-gating) builds.
+  - **Functional dark-mode smoke pass** (architecture §5): live Light↔Dark toggle
+    across Home, Meeting Detail, Active Recording, Upcoming, Onboarding, Settings,
+    model sheets, banners, menu-bar, markdown editor. Confirms *correctness* — no
+    white-on-light / light-on-light defects, nothing unreadable. (Aesthetic
+    sign-off is Phase 3.)
+
+- [ ] **Phase 3 — Human visual review of agent decisions.**
+  This project is the agent interpreting design *comps* against the real code, so
+  every color choice gets an explicit human eyeball before it's considered done.
+  - **Agent prepares a review packet:** run the app and capture **side-by-side
+    light/dark screenshots** of each surface (Home, Meeting Detail incl. transcript
+    + notes, Active Recording incl. Stop&Save / REC pill / Elapsed + amber ≤5:00
+    chips / RECORDING badge, Upcoming, Onboarding, Settings, model sheets, error +
+    warning banners, menu-bar popover, markdown editor). Annotate each shot with the
+    **decisions that landed there**, drawn from:
+    - the §6 judgment calls (`signalRedText`, `accentTrack`, amber non-split),
+    - the §3.6 *skipped* comp elements (flat where the comp used a gradient:
+      window backdrop, cards, record pill/button, progress tracks),
+    - any token whose dark value is applied in an unusual context.
+  - **Human reviews decision-by-decision**, not just "does it render": does each
+    dark value read well *in situ*; does any flat-instead-of-gradient or
+    skipped-token surface look wrong; are the splits/non-splits the right call.
+  - Capture every delta as a concrete tweak (token value or a missed
+    repoint/split) and fold the small adjustments back in. Light must stay
+    byte-identical (Phase 1 Test 1 re-runs green after any tweak).
+  - Sign-off here is the project's acceptance gate.
+
+## Notes
+- No `Packages/Transcription`, `AudioCapture`, or `LocalLLM` files are touched —
+  the manual-test gate for those is unaffected.
+- The two optional splits (`signalRedText`, `accentTrack`) can be dropped if the
+  reviewer prefers a more minimal palette (functional-spec §6); that only removes
+  two tokens and a few repoints.

--- a/specs/projects/dark_mode/phase_plans/phase_1.md
+++ b/specs/projects/dark_mode/phase_plans/phase_1.md
@@ -1,0 +1,65 @@
+---
+status: draft
+---
+
+# Phase 1: Adaptive Palette Foundation + Guarantee Tests
+
+## Overview
+
+Convert the static color palette into appearance-adaptive tokens so the app
+renders correctly in both light and dark mode, using a single
+`dynamicNSColor(light:dark:)` helper. Light-mode output is byte-identical to the
+current code. Add new semantic tokens needed for Phase 2 repoints. No call-site
+changes in this phase -- after it lands, every redefined token already renders its
+dark value when the system appearance is dark.
+
+## Steps
+
+1. **Create `DesignSystem/DynamicColor.swift`** -- internal helper with two
+   functions: `dynamicNSColor(light:dark:) -> NSColor` and
+   `dynamicColor(light:dark:) -> Color`. The only appearance switch in the
+   codebase.
+
+2. **Rewrite `DesignSystem/Color+Theme.swift`** -- convert every token from a
+   static literal to a `dynamicColor(light:dark:)` call:
+   - Surfaces & ink: `paper`, `wall`, `sidebarTint`, `ink`, `inkSecondary`,
+     `inkTertiary`, `hairline`, `neutralChip`, `cardStroke`.
+   - Sage family: `sage`, `accentWashSoft`, `accentWashStrong`, `softSageFill`,
+     `findHighlightFocused`.
+   - Alert red: `signalRed`, `recordingOutline`. Keep derived tokens
+     (`recordingTintSoft/Strong`, `recordingOutlineStrong`, `recordingHoverFill`)
+     as `base.opacity(x)` where spec allows, else promote.
+   - Amber: `warningOchre`, `warningChipText` (gets its own dark value).
+   - New tokens: `accentFill`, `read`, `elevatedFill`, `accentTrack`,
+     `signalRedText`, `cardShadow`, `controlShadow`, `cardFill`.
+   - Unify `Color`/`NSColor` into single-source: `NSColor` tokens via
+     `dynamicNSColor`, `Color` tokens as `Color(nsColor:)`.
+   - Preserve `ShapeStyle` sugar, extend for new tokens.
+   - Update doc comments on `signalRed`/`warningOchre` to note the dark text
+     variants and adaptive behavior.
+
+3. **Update `DesignSystem/Tokens.swift`**:
+   - `cardFill = Color.white` -> `cardFill = Color.cardFill` (adaptive).
+   - `warningChipText` stays as `Color.warningChipText` (now has own dark value).
+   - Add aliases: `elevatedFill`, `accentFill`, `read`, `accentTrack`,
+     `signalRedText`, `cardShadow`, `controlShadow`.
+   - Avatar palette, typography, spacing, radii: untouched.
+
+4. **Add `Tests/DesignSystemTests/DynamicColorTests.swift`**:
+   - Test 1 (light byte-identical): resolve every token at `.aqua` and assert
+     components match the legacy literal values within 1/512 tolerance.
+   - Test 2 (dark matches design): resolve every token at `.darkAqua` and assert
+     components match the functional-spec hex values.
+   - Test 3 (no view conditionals): grep `Packages/BiscottiKit/Sources/` for
+     `colorScheme` references and assert zero hits outside `DynamicColor.swift`.
+
+5. **Green `hooks-mcp` checks**: `lint`, `format`, `test`, `build`.
+
+## Tests
+
+- `testLightValuesMatchLegacyLiterals` -- every token's `.aqua` resolution ==
+  legacy sRGB literal (the byte-identical-light guard).
+- `testDarkValuesMatchDesignSpec` -- every token's `.darkAqua` resolution ==
+  design hex from functional spec section 3.
+- `testNoColorSchemeConditionalsInViewCode` -- grep-based assertion that no view
+  file uses `@Environment(\.colorScheme)` or `colorScheme ==`.

--- a/specs/projects/dark_mode/phase_plans/phase_2.md
+++ b/specs/projects/dark_mode/phase_plans/phase_2.md
@@ -1,0 +1,50 @@
+---
+status: draft
+---
+
+# Phase 2: Split Repoints, Hardcoded Sites, Verification
+
+## Overview
+
+Repoint the ~16 call sites identified in functional-spec section 4 to use the new
+semantic tokens added in Phase 1. Confirm the hardcoded "stays" sites (section 5)
+are untouched. Run all automated checks (lint, format, test, build-app).
+
+The live dark-mode smoke pass (architecture section 5) is a human-on-hardware step
+flagged for manual execution.
+
+## Steps
+
+1. **`JoinRecordButtonStyle.swift:19`** -- `.fill(Color.sage)` -> `.fill(Color.accentFill)`
+2. **`OnboardingPrimaryButtonStyle.swift:18`** -- `.fill(Color.sage)` -> `.fill(Color.accentFill)`
+3. **`AppShellView.swift:99`** -- `ToolbarRecordButtonStyle(fill: .sage)` -> `fill: .accentFill`
+4. **`GrantedTag.swift:18`** -- `Circle().fill(Color.sage)` -> `.fill(Color.accentFill)`
+5. **`LightAlertButtonStyle.swift:20`** -- `Tokens.cardFill` -> `Color.elevatedFill`
+6. **`LightAlertButtonStyle.swift:28`** -- `.black.opacity(0.06)` -> `Color.controlShadow`
+7. **`EditableMeetingTitle.swift:117`** -- `Color.white` -> `Color.elevatedFill`
+8. **`TranscriptListView.swift:196`** -- `.foregroundStyle(.inkSecondary)` -> `.foregroundStyle(.read)`
+9. **`RecordingView.swift:217`** -- `.foregroundStyle(Color.signalRed)` (RECORDING label) -> `.foregroundStyle(Color.signalRedText)`
+10. **`AutoStopCountdownCard.swift:46`** -- `.foregroundStyle(Color.signalRed)` (seconds text) -> `.foregroundStyle(Color.signalRedText)`
+11. **`EventPickerSheet.swift:125`** -- `.foregroundStyle(.signalRed)` -> `.foregroundStyle(.signalRedText)`
+12. **`ManageModelsSheet.swift:281`** -- `.foregroundStyle(.signalRed)` -> `.foregroundStyle(.signalRedText)`
+13. **`ModelDownloadCard.swift:208`** -- `.foregroundStyle(.signalRed)` -> `.foregroundStyle(.signalRedText)`
+14. **`ProgressHeader.swift:36`** -- `.fill(Color.sage)` -> `.fill(Color.accentTrack)`
+15. **`ModelDownloadCard.swift:152`** -- `.fill(Color.sage)` (indeterminate bar) -> `.fill(Color.accentTrack)`
+16. **`ModelDownloadCard.swift:266`** -- `.fill(Color.sage)` (determinate bar) -> `.fill(Color.accentTrack)`
+17. **`HomeCardModifier.swift:14`** -- `.black.opacity(0.05)` -> `Color.cardShadow`
+
+18. **Verify "stays" sites** are untouched: white labels, white sheen gradients,
+    avatar whites, `.ultraThinMaterial`, `Color(hex:)`, native controls,
+    `AlertsHelpSheet.swift` `.tint(.sage)`, `RecordButton.swift` sage dot,
+    `AudioTransport.swift` `.tint(.sage)`, `Banner.swift` signalRed icon.
+
+19. **Green automated checks** via hooks-mcp: format, lint, test, build-app.
+
+## Tests
+
+- Existing Phase 1 tests (light byte-identical, dark matches design, no colorScheme
+  conditionals) continue to pass -- they validate the tokens, and these repoints
+  only change which token a call site references (same light value).
+- No new tests needed: the repoints swap one equal-in-light token for another;
+  the token values are already fully tested. The `noColorSchemeInViews` test
+  confirms we did not introduce any appearance conditionals.

--- a/specs/projects/dark_mode/phase_plans/phase_3_review_packet.md
+++ b/specs/projects/dark_mode/phase_plans/phase_3_review_packet.md
@@ -1,0 +1,481 @@
+# Phase 3 Review Packet: Dark Mode Visual Review
+
+This packet lists every dark-mode decision, surface by surface, so the human
+reviewer can evaluate each one in situ. For each surface the packet names the
+tokens that appear there, flags the judgment calls and deliberate simplifications,
+and gives a concrete "what to check" prompt.
+
+Automated screenshots were **not captured** (see the note at the end). A manual
+capture/review script is provided instead.
+
+---
+
+## Token quick-reference (dark hex values)
+
+For easy cross-referencing while reviewing. Light values are unchanged from the
+pre-dark-mode codebase.
+
+| Token | Dark value | Role |
+|---|---|---|
+| `paper` | `#100E09` | content/pane background |
+| `wall` | `#110F09` | window backdrop (flat) |
+| `sidebarTint` | `#14120D @ 74%` | sidebar overlay tint |
+| `cardFill` | `#1A170F` | card surfaces |
+| `cardStroke` | `#F7F2E8 @ 12%` | card border hairline |
+| `ink` | `#F7F2E8` | primary text |
+| `inkSecondary` | `#F7F2E8 @ 58%` | secondary/meta text |
+| `inkTertiary` | `#F7F2E8 @ 36%` | tertiary text, chevrons |
+| `hairline` | `#F7F2E8 @ 12%` | separators |
+| `neutralChip` | `#F7F2E8 @ 7%` | neutral chip fill |
+| `sage` | `#86C295` | accent text/icon/link |
+| `accentFill` | `#56906A` | button fills (white label) |
+| `accentTrack` | `#5E9A6F` | progress bar fills |
+| `accentWashSoft` | `#86C295 @ 12%` | hero tint, speaker chips |
+| `accentWashStrong` | `#86C295 @ 16%` | selection wash |
+| `softSageFill` | `#86C295 @ 14%` | "Add note" button fill |
+| `read` | `#F7F2E8 @ 75%` | long-form body text |
+| `elevatedFill` | `#1A170F` | white-button/field fills |
+| `signalRed` | `#E5604A` | red marks/dots/icons/fills |
+| `signalRedText` | `#F08A78` | standalone red text labels |
+| `recordingOutline` | `#E5604A @ 36%` | Stop/REC button border |
+| `recordingTintSoft` | `#E5604A @ 8%` | auto-stop card wash |
+| `warningOchre` | `#E8A13A` | warning icons, pulsing dot |
+| `warningChipText` | `#F0C04A` | amber text (kicker + value) |
+| `warningChipFill` | `#E8A13A @ 15%` | amber chip background |
+| `cardShadow` | `black @ 40%` | home card shadow |
+| `controlShadow` | `black @ 40%` | light-alert button shadow |
+| `findHighlightFocused` | `#86C295 @ 35%` | current find match |
+
+---
+
+## Surface-by-surface review
+
+### 1. Home
+
+**Tokens landing here:**
+- `paper` (`#100E09`) -- full-pane background via `Tokens.contentBackground`
+- `ink` (`#F7F2E8`) -- greeting serif title
+- `inkSecondary` (`#F7F2E8 @ 58%`) -- date line (mono)
+- `cardFill` (`#1A170F`) -- card backgrounds via `HomeCardModifier`
+- `cardStroke` (`#F7F2E8 @ 12%`) -- card border hairlines
+- `cardShadow` (`black @ 40%`) -- card whisper shadow
+- `neutralChip` (`#F7F2E8 @ 7%`) -- stat chips
+- `accentWashSoft` (`#86C295 @ 12%`) -- hero "starting soon" row tint
+- `sage` (`#86C295`) -- timestamps, "Join & Record" text accents, meet chip icons
+- `accentFill` (`#56906A`) -- "Join & Record" / "Record" button fills
+- `hairline` (`#F7F2E8 @ 12%`) -- inset dividers between rows
+- `inkTertiary` (`#F7F2E8 @ 36%`) -- chevrons, meta separators
+- Avatars: **unchanged** (colorful palette, white initials, white rings)
+
+**Judgment calls to scrutinize:**
+- **Flat wall (skipped comp gradient):** The window backdrop is flat `wall`
+  `#110F09`. The design comp used a radial gradient; we kept the code's flat fill
+  and ported only the midpoint dark value. *Check:* does the flat dark backdrop
+  feel too uniform, or does the card elevation provide enough visual structure?
+- **Flat cards (skipped comp gradient):** Cards are flat `cardFill` `#1A170F`. The
+  comp had a subtle `card -> cardTop` gradient. *Check:* do flat dark cards read
+  as properly elevated against the `#100E09` paper?
+- **Card shadow at 40%:** Light shadow is `black @ 5%`. Dark bumps to `black @ 40%`
+  per design. On a near-black surface, even 40% black shadow is subtle. *Check:*
+  is the shadow visible enough, or is the card hairline doing all the lifting?
+
+**What to check:**
+- Greeting title legibility (serif `ink` on `paper`).
+- Stat chips: `neutralChip` fill visible against `paper`?
+- Hero row: `accentWashSoft` tint differentiates the row from plain cards?
+- Avatar colors read well against `cardFill`; white initials/rings still pop?
+- Card elevation: `cardFill` vs `paper` -- enough contrast to see the card lift?
+- "Join & Record" button: white label on `accentFill` `#56906A` -- sufficient
+  contrast? (Should be AA-large at weight >= 500.)
+
+---
+
+### 2. Meeting Detail (transcript + notes)
+
+**Tokens landing here:**
+- `paper` -- pane background
+- `ink` -- meeting title, notes body, speaker names (palette colors override for
+  identified speakers)
+- `inkSecondary` -- submeta text, source pill text, "Open in Calendar" meta
+- `inkTertiary` -- timestamps (mono), dot separators
+- `read` (`#F7F2E8 @ 75%`) -- **transcript utterance body text**
+- `sage` -- clickable links ("Open in Calendar"), speaker timestamps in playback
+- `cardFill` / `cardStroke` -- any card surfaces
+- `accentWashSoft` -- speaker chip backgrounds
+- `accentWashStrong` (`#86C295 @ 16%`) -- selection wash, find-match background
+- `findHighlightFocused` (`#86C295 @ 35%`) -- current find-match highlight
+- `neutralChip` -- source pill fill
+- `hairline` -- dividers
+- `.ultraThinMaterial` (pinned transport bar) -- native, adapts automatically
+- `elevatedFill` (`#1A170F`) -- focused title field background
+- Segmented `Picker`, `Slider`, `.destructive` Delete, "..." `Menu` -- all **native**
+
+**Judgment calls to scrutinize:**
+- **`read` token (the main one):** Transcript body was `inkSecondary` (54% alpha);
+  dark bumps to 75% alpha (`#F7F2E8 @ 75%`). This is the primary reason the
+  `read` token exists -- sustained reading comfort. *Check:* does the `read`
+  token at 75% provide comfortable reading contrast against `paper` `#100E09`
+  without being too bright (fatiguing)? Is the visual hierarchy clear between
+  `read` (75%), `inkSecondary` (58%), and `inkTertiary` (36%)?
+- **Flat progress tracks (skipped comp gradient):** The audio `Slider` tint stays
+  at bright `sage` `#86C295` per design ("its tint is accent(text-bright)"). The
+  Slider rail is native. *Check:* does the bright sage tint read well on the
+  native dark Slider rail?
+
+**What to check:**
+- Transcript text (`read`) legibility against dark `paper` for sustained reading.
+- Speaker names in their palette colors -- do they still pop on the dark card?
+- Timestamps (`inkTertiary` @ 36%) -- readable but receded?
+- Notes tab: `ink` body text in the MarkdownEditor (AppKit, uses `NSColor.ink`
+  and `NSColor.inkSecondary` -- should auto-adapt via dynamic NSColor).
+- Find/replace highlights: `accentWashStrong` and `findHighlightFocused` visible?
+- Source pill: `neutralChip` fill + `inkSecondary` text on dark.
+- Segmented control, Slider, Delete button, "..." menu: native dark adaptation correct?
+- Focused title field: `elevatedFill` background + `sage` border visible?
+
+---
+
+### 3. Active Recording
+
+#### 3a. RECORDING badge + Stop & Save button
+
+**Tokens landing here:**
+- `signalRed` (`#E5604A`) -- pulsing dot fill, ripple ring stroke, stop-square icon
+- `signalRedText` (`#F08A78`) -- "RECORDING" label text
+- `elevatedFill` (`#1A170F`) -- Stop & Save button fill (was white)
+- `recordingOutline` (`#E5604A @ 36%`) -- Stop & Save button border
+- `controlShadow` (`black @ 40%`) -- button shadow
+
+**Judgment calls to scrutinize:**
+- **`signalRedText` split (judgment call #1):** The "RECORDING" label uses the
+  lighter `#F08A78` instead of the mark red `#E5604A`. The mark red is ~4.5:1
+  contrast on dark (borderline AA); `signalRedText` is ~7:1. *Check:* does
+  `#F08A78` look harmonious next to the `#E5604A` dot, or does the lighter text
+  feel disconnected from the recording state?
+- **Flat record pill (skipped comp gradient):** The comp showed a red gradient
+  (`alertGrad`) for the recording pill. The code uses flat `elevatedFill` + red
+  text/icon via `LightAlertButtonStyle`. *Check:* does the flat elevated-fill
+  Stop & Save button read correctly as the primary recording action?
+- **`elevatedFill` = `cardFill`:** Both resolve to `#1A170F` in dark. The
+  Stop & Save button fill is the same color as a card. *Check:* does the
+  `recordingOutline` border provide enough distinction?
+
+**What to check:**
+- "RECORDING" badge: dot + text alignment; `signalRedText` legibility on `paper`.
+- Stop & Save: white stop-square icon visible on `elevatedFill`? Wait -- the icon
+  uses `signalRed` (`foregroundStyle(Color.signalRed)` from `LightAlertButtonStyle`).
+  Is the red icon + red label readable on the dark card-colored button?
+- Ripple animation rings: `signalRed` stroke visible against `paper`?
+- Button shadow: `controlShadow` at 40% -- visible or irrelevant on dark?
+
+#### 3b. REC pill (toolbar header)
+
+**Tokens landing here:**
+- `elevatedFill` -- pill fill
+- `recordingOutline` -- pill border
+- `signalRed` -- pulsing dot inside the pill
+- Mono timer text uses `signalRed` (via `LightAlertButtonStyle` foreground)
+
+**What to check:**
+- REC pill in the toolbar area: does it stand out against the window chrome?
+- Timer text legibility (mono `signalRed` on `elevatedFill`).
+
+#### 3c. Time chips (Elapsed + amber warning)
+
+**Tokens landing here:**
+- Elapsed chip: `neutralChip` (`#F7F2E8 @ 7%`) fill, `inkTertiary` kicker, `ink` value
+- Warning chip (LEFT <= 5:00 / OVER): `warningChipFill` (`#E8A13A @ 15%`) fill,
+  `warningChipText` (`#F0C04A`) for kicker AND value, `warningOchre` (`#E8A13A`) dot
+
+**Judgment calls to scrutinize:**
+- **Amber non-split (judgment call #3):** The design split amber text into kicker
+  (`#D9A53A`) and value (`#F0C04A`). We use one token `warningChipText` at the
+  brighter `#F0C04A` for both. *Check:* is the "LEFT" / "OVER" kicker too bright
+  at `#F0C04A` (the comp wanted `#D9A53A` there), or does the unified bright
+  amber read well?
+- **Amber chip fill at 15%:** The comp used 18% for the wash; code uses 15%
+  (matching the existing `warningBackground` opacity). *Check:* is the amber chip
+  fill visible enough at 15% against `paper`, or should it be bumped?
+
+**What to check:**
+- Elapsed chip: `neutralChip` fill visible against `paper`? Mono value text clear?
+- Warning chip: amber text `#F0C04A` legible against `warningChipFill` `#E8A13A @ 15%`
+  on `paper`? The chip should be visually distinct from the neutral Elapsed chip.
+- Pulsing amber dot (`warningOchre` `#E8A13A`) visible and animated?
+
+#### 3d. Note composer + notes list
+
+**Tokens landing here:**
+- `softSageFill` (`#86C295 @ 14%`) -- "Add note" button fill
+- `sage` -- note timestamps
+- `ink` -- note body text
+- `inkSecondary` -- note meta
+- `hairline` -- divider above composer
+
+**What to check:**
+- "Add note" button: `softSageFill` visible against `paper`?
+- Note timestamps in `sage` -- differentiated from body `ink`?
+
+#### 3e. Auto-stop countdown card
+
+**Tokens landing here:**
+- `cardFill` + `recordingTintSoft` (`#E5604A @ 8%`) -- card fill with red wash overlay
+- `cardStroke` + `recordingOutline` -- double-border
+- `ink` -- "Auto-stopping soon" heading
+- `signalRedText` (`#F08A78`) -- countdown seconds text
+- `signalRed` -- countdown progress bar fill
+- `neutralChip` -- progress bar track, "Keep Recording" button fill
+- `hairline` -- "Keep Recording" button border
+
+**What to check:**
+- Card red wash: is `recordingTintSoft` (8% of `#E5604A`) visible on `cardFill`?
+- Countdown seconds in `signalRedText` -- legible on the washed card?
+- Progress bar: `signalRed` fill on `neutralChip` track -- visible?
+
+---
+
+### 4. Upcoming Event detail
+
+**Tokens landing here:**
+- `paper` -- pane background
+- `cardFill` / `cardStroke` -- event cards
+- `ink` / `inkSecondary` / `inkTertiary` -- text hierarchy
+- `sage` -- links, toggles (on state), disclosure triangles (native)
+- `accentWashSoft` -- auto-record card tint
+- Destructive menu items: native (`.destructive` role)
+
+**What to check:**
+- Event detail card elevation on `paper`.
+- Auto-record card: `accentWashSoft` tint visible on `cardFill`?
+- Native controls (toggles, disclosure triangles, destructive items) -- correct
+  dark adaptation?
+
+---
+
+### 5. Onboarding
+
+**Tokens landing here:**
+- `paper` -- full background
+- `ink` -- serif titles ("Welcome to Biscotti", "Grant access")
+- `inkSecondary` -- subtitle text, description text
+- `accentFill` (`#56906A`) -- "Continue" / "Get Started" / "Download" CTA buttons
+- `accentTrack` (`#5E9A6F`) -- progress bar fill (3 sites: `ProgressHeader`,
+  `ModelDownloadCard` indeterminate bar, `ModelDownloadCard` determinate bar)
+- `hairline` -- progress bar track, dividers
+- `accentWashSoft` -- permission icon tile fill
+- `sage` -- permission icon foreground, "GRANTED" tag text, sage links
+- `accentFill` -- "GRANTED" tag circle fill, "Grant" pill buttons
+- `signalRedText` (`#F08A78`) -- download-failed error message
+- `warningOchre` -- insufficient-disk warning icon + text
+
+**Judgment calls to scrutinize:**
+- **`accentTrack` split (judgment call #2):** Progress bar fills use `#5E9A6F`
+  instead of bright `sage` `#86C295`. The design wanted fills a touch less bright
+  than text. *Check:* does `#5E9A6F` read as a filled progress bar against the
+  `hairline` (`#F7F2E8 @ 12%`) track on dark `paper`? Or is it too dim?
+- **Flat progress tracks (skipped comp gradient):** The comp showed gradient
+  progress fills. Code uses flat `accentTrack`. *Check:* do flat sage progress
+  bars look intentional, not broken?
+
+**What to check:**
+- Progress header bar: `accentTrack` fill vs `hairline` track -- enough contrast?
+- CTA button: white label on `accentFill` `#56906A` -- legible? White sheen
+  gradient overlay still works on the darker fill?
+- Permission cards: `accentWashSoft` icon tiles visible on `cardFill`?
+- "GRANTED" tag: `accentFill` circle + white checkmark visible?
+- Error text (`signalRedText`) legible in the download-failed state?
+- Indeterminate bar animation: `accentTrack` segment on `hairline` track?
+
+---
+
+### 6. Settings
+
+**Tokens landing here:**
+- `paper` (`Tokens.contentBackground`) -- full background
+- Native `Form` / `.grouped` -- sections, toggles, pickers, buttons all native
+- `sage` -- debug section links ("Replay Onboarding", "Clear Selected LLM")
+- `inkSecondary` (`Tokens.secondaryText`) -- description captions
+- `warningOchre` -- permission warning icons (exclamation triangle)
+- `warningChipText` + `warningChipFill` -- "Requires Calendar Access" badge
+- Calendar row: `Color(hex:)` calendar dots -- **unchanged** (data colors)
+- `.bordered` buttons ("Request Access", "Open Settings", "Manage") -- native
+
+**What to check:**
+- Native form sections render correctly on `paper` background in dark?
+- Toggle controls, segmented pickers, bordered buttons -- all native dark?
+- Warning icons (`warningOchre`) visible?
+- "Requires Calendar Access" amber badge: `warningChipText` on `warningChipFill`
+  legible?
+- Calendar color dots: data colors still visible on dark form row backgrounds?
+
+---
+
+### 7. Model management sheets (ManageModelsSheet)
+
+**Tokens landing here:**
+- Native sheet chrome -- adapts automatically
+- `ink` -- model names, headings
+- `inkSecondary` (`Tokens.secondaryText`) -- descriptions, downloading status
+- `signalRedText` (`#F08A78`) -- "Download failed: ..." error text
+- `warningOchre` -- insufficient-disk warnings
+- Native buttons, pickers, progress views
+
+**What to check:**
+- Sheet background: native dark sheet chrome?
+- Error text (`signalRedText`) legibility within the sheet context.
+- All native controls (buttons, progress indicators) adapt correctly?
+
+---
+
+### 8. Error + warning banners
+
+**Tokens landing here:**
+- Warning banner: `warningOchre` icon + `warningBackground` (`#E8A13A @ 15%`) fill
+  + `inkSecondary` message text
+- Error banner: `signalRed` icon + `errorBackground` (`#E5604A @ 15%`) fill
+  + `inkSecondary` message text
+- `.borderless` action button -- native
+
+**What to check:**
+- Warning banner: `warningOchre` icon visible on `warningBackground` fill? The
+  fill is `warningOchre` at 15% -- does it read as a tinted background strip?
+- Error banner: `signalRed` icon visible on `errorBackground` fill?
+- Banner message text (`inkSecondary`) legible on the tinted fill?
+- Banner fills visible against `paper`?
+
+---
+
+### 9. Menu-bar popover
+
+**Tokens landing here:**
+- This is a **`.menu`-style `MenuBarExtra`** -- entirely native menu items
+  (`Button`, `Divider`, `Text`). No custom views, no custom colors.
+
+**What to check:**
+- The menu uses standard macOS menu rendering. Confirm it appears as a native
+  dark menu with no custom color artifacts.
+- "Start Recording" / "Stop Recording", "Open Biscotti", "Quit Biscotti" --
+  all standard menu items, should adapt automatically.
+
+---
+
+### 10. Markdown editor (AppKit NSTextView)
+
+**Tokens landing here:**
+- `NSColor.ink` (dynamic) -- body text color via `MarkdownEditorTheme.bodyText`
+- `NSColor.inkSecondary` (dynamic) -- muted/heading-marker/strikethrough text,
+  placeholder text
+- `NSColor.inkTertiary` (dynamic) -- disabled text
+- `NSColor.sage` (dynamic) -- links
+- `NSColor.accentWashStrong` (dynamic) -- find-match highlight
+- `NSColor.findHighlightFocused` (dynamic) -- current find-match highlight
+
+**Judgment calls to scrutinize:**
+- **NSColor dynamic resolution:** The `MarkdownEditorConfiguration+Biscotti`
+  passes NSColor-backed tokens into the theme. These should resolve via the
+  window's `effectiveAppearance`. *Check:* does the editor re-render correctly
+  on a **live** Light -> Dark toggle (no relaunch)?
+
+**What to check:**
+- Body text (`ink`) legibility in the editor.
+- Placeholder text (`inkSecondary`) visible but receded?
+- Links (`sage`) visible and clickable-looking?
+- Find highlights: both wash and focused highlight visible?
+- **Live appearance switch:** toggle System Settings while the editor is visible
+  -- text colors update without closing the editor?
+
+---
+
+## Consolidated judgment-call checklist
+
+These are the decisions the reviewer should explicitly approve or request changes to:
+
+| # | Decision | Where to look | Alternatives if rejected |
+|---|---|---|---|
+| 1 | **`signalRedText` split** (`#F08A78` for text vs `#E5604A` for marks) | RECORDING label, auto-stop seconds, "Remove association", download-failed messages | Drop the token; let all red text use `signalRed` `#E5604A` (~4.5:1 on dark) |
+| 2 | **`accentTrack` split** (`#5E9A6F` for progress fills vs `#86C295` for text) | Onboarding progress bar, model download bars | Drop the token; let progress bars use `sage` `#86C295` |
+| 3 | **Amber non-split** (one `warningChipText` `#F0C04A` for both kicker + value) | Warning time chips (LEFT/OVER) | Split into two tokens: kicker `#D9A53A`, value `#F0C04A` |
+| 4 | **Flat window wall** (no radial gradient) | Entire app backdrop | Add a radial gradient (new code, not just a token) |
+| 5 | **Flat cards** (no top-to-bottom gradient) | All card surfaces (home, recording, onboarding) | Add `cardTop` gradient (new code) |
+| 6 | **Flat record pill/button** (no `alertGrad` gradient) | Stop & Save, REC pill | Add a red gradient fill (new code) |
+| 7 | **Flat progress tracks** (no gradient fills) | Onboarding progress, model download bars | Add gradient fills (new code) |
+| 8 | **`elevatedFill` = `cardFill`** (same `#1A170F` value) | Stop & Save button, REC pill, focused title field | Use a lighter elevated value like `#211D14` |
+
+Items 4-7 are the "skipped comp elements" from functional-spec section 3.6 -- places the code
+is flat where the design comp used a gradient. These would require **new code** (not
+just token changes) to implement. The functional spec deliberately chose to keep the
+code's flat approach and port only the dark color value.
+
+---
+
+## Manual capture and review script
+
+Automated screenshots were not feasible for this menu-bar app. The app has
+transient surfaces (recording requires active mic capture, onboarding requires
+state reset, popovers close on focus loss), and toggling system appearance
+programmatically during capture would not cover the stateful surfaces. The
+reviewer should walk the surfaces manually.
+
+### Setup
+
+1. Build and run: `make build-app` then launch from
+   `App/DerivedData/.../Build/Products/Debug/Biscotti.app`, or run from Xcode.
+2. Open **System Settings > Appearance**. Keep it visible for quick toggling.
+3. Have a past meeting in the database (or use preview/debug data if available).
+
+### Walk-through (do each in Light, then repeat in Dark)
+
+Toggle appearance between each full pass. Confirm live-switch updates without
+relaunch.
+
+**Pass 1 -- Light (baseline confirmation):**
+
+1. **Home:** Scroll through greeting, stat chips, upcoming section, past section.
+   Confirm it looks identical to pre-dark-mode.
+2. **Meeting Detail -- Transcript tab:** Open a meeting with a transcript. Check
+   speaker names, timestamps, utterance body text, audio transport bar.
+3. **Meeting Detail -- Notes tab:** Check the MarkdownEditor with content. Type
+   something. Check placeholder text when empty.
+4. **Meeting Detail -- Summary tab:** If a summary exists, check heading + body.
+5. **Settings:** Open settings. Check all sections: General, Permissions,
+   Notifications, AI Enhancements, Calendars. Note toggles, pickers, buttons,
+   warning badges.
+6. **Onboarding:** Debug > Replay Onboarding. Walk through Welcome, Permissions
+   (with Grant buttons), Model Download (idle, downloading if possible), Done.
+   Note the progress bar, CTA buttons, permission cards.
+7. **Recording (if safe):** Start a recording (or use preview). Check RECORDING
+   badge, Stop & Save button, time chips (Elapsed + Left/Over if applicable),
+   note composer, title field.
+
+**Pass 2 -- Dark (the review):**
+
+Repeat steps 1-7 in dark appearance. For each surface, consult the
+surface-specific "what to check" items above. Pay special attention to:
+
+- Text legibility (especially `read` in transcripts, `signalRedText` in recording).
+- Card elevation (`cardFill` vs `paper`).
+- Button fills (`accentFill` with white labels, `elevatedFill` with red content).
+- Amber chips (unified `warningChipText`, chip fill visibility).
+- Progress bars (`accentTrack` on `hairline` track).
+- Shadows (likely invisible on dark -- is that OK?).
+- Native controls (toggles, pickers, sliders, menus).
+
+**Pass 3 -- Live toggle:**
+
+With each surface open, toggle Light <-> Dark in System Settings without closing
+or navigating away. Confirm:
+
+- Colors update instantly (no stale light colors lingering).
+- MarkdownEditor (AppKit NSTextView) updates its text colors live.
+- No flash of wrong colors during transition.
+
+### Recording the review
+
+For each surface, note:
+- **Pass** -- the dark rendering is acceptable.
+- **Tweak** -- acceptable with a specific token value adjustment (note the token
+  and suggested direction, e.g. "bump `accentTrack` brighter" or "drop
+  `signalRedText`, use `signalRed` for all red text").
+- **Reject** -- a structural change is needed (e.g. "add card gradient").
+
+Every tweak must keep light byte-identical (Phase 1 Test 1 re-runs green).

--- a/specs/projects/dark_mode/project_overview.md
+++ b/specs/projects/dark_mode/project_overview.md
@@ -1,0 +1,313 @@
+---
+status: complete
+---
+
+# Dark Mode
+
+Biscotti generally failed at supporting dark mode. Many backgrounds are hardcoded
+light colors, so in dark appearance the app ends up with white text on light
+backgrounds (and other unreadable combinations).
+
+A design agent produced a "migrate to dark mode" plan (the **Dark Mode Spec**,
+embedded below). The human has visually reviewed its color choices and approved
+them. The catch: the design agent isn't a coding agent and never saw the
+codebase. Its spec is based on *comps* of our designs, and the actual app has
+moved beyond those comps in places. So this project's job is to figure out what
+from the design spec makes sense to port in, grounded in the real code.
+
+## Guiding rules
+
+- **The codebase behavior always trumps the design docs.** Where the shipped code
+  diverges from the comps, the code wins — we keep those decisions.
+- **This is a color-mapping exercise for dark mode, not a feature change.** No
+  adding backgrounds/highlights where there wasn't one. It's about selecting the
+  appropriate migration for what's already there.
+- **Zero changes to light-mode rendering.** The code may change, but light mode
+  must produce the same pixels, byte-for-byte.
+- **Make it reusable.** Create the needed palette/token plumbing so that going
+  forward it's just a matter of attaching the right color to a design and dark
+  mode is automatic — no per-view conditionals.
+- Dark mode **follows the system appearance** — no in-app toggle.
+
+## Codebase grounding (verified before this overview)
+
+- Colors are already centralized: `DesignSystem/Color+Theme.swift` (semantic
+  `Color` + `NSColor` extensions, defined as hardcoded sRGB literals) and
+  `DesignSystem/Tokens.swift` (a `Tokens` enum aliasing those colors plus
+  typography/spacing/radii). The app is **well-tokenized** — there are **zero**
+  inline `Color(red:…)` literals in feature code.
+- These tokens are static literals, so they do **not** adapt to appearance — that
+  is the root cause of the dark-mode failure.
+- The app does **not** force a color scheme anywhere (`preferredColorScheme`),
+  so once the tokens adapt, dark mode largely "just works."
+- A small set of hardcoded sites need individual attention: `.white`/`.black`
+  used in button styles, avatar rings, shadows, and gradients; one
+  `.ultraThinMaterial`; one `NSColor` use in the markdown editor; the flat
+  `Color.wall` window backdrop and `Color.sidebarTint` sidebar.
+- `Color(hex:)` (calendar colors) and `Tokens.avatarPalette` (colorful avatars)
+  are **data/identity colors** and are intentionally **not** migrated — they read
+  on both appearances.
+
+## The Dark Mode Spec (design agent's plan — source for dark *values*)
+
+> Note: this is the design intent. Where it describes structure that differs from
+> the shipped code (e.g. it calls the window backdrop a radial gradient; the code
+> uses a flat fill), the **code wins** and we port only the color *values*.
+
+```
+# Biscotti — Dark Mode Spec
+
+How to add dark mode to Biscotti. Identity is unchanged: **F · Sage + Pressroom**
+(warm ivory paper → warm near-black ink, sage primary, Newsreader serif,
+IBM Plex Mono numbers/kickers, colorful avatars). Direction chosen: **B · Deep Ink**.
+
+Platform: SwiftUI, macOS Tahoe. Dark mode **follows the system appearance** — no
+in-app toggle. Units are points.
+
+Visual references in this project:
+- `Biscotti Dark Mode.html` — Home, Deep Ink beside the light Rev F.
+- `Biscotti Dark Mode — Screens.html` — Meeting Detail pane, Active Recording, and the semantic-color swatches.
+
+---
+
+## 0. The one principle: this is a palette, not a parallel UI
+
+Dark mode is implemented **entirely as token values that change with appearance.**
+There are **no `if colorScheme == .dark` branches in view code**, no duplicated
+layouts, no per-component dark variants.
+
+Mechanism:
+
+- Every color is a **semantic token** with a *role* (`accent`, `card`, `read`,
+  `alert`…), defined in **one place** as a two-value entry — an **asset-catalog
+  color set** with an **"Any Appearance"** value and a **"Dark"** value. macOS
+  resolves it automatically. Views reference `Pal.card` and never know the mode.
+  - (If you model the palette as a Swift struct instead of the catalog, allow
+    **exactly one** `@Environment(\.colorScheme)` switch at the palette layer.
+    Do not let `colorScheme` leak into individual views.)
+- **Layout, spacing, type, radii, avatars, and structure are identical** across
+  modes. Only color/elevation token *values* differ.
+
+### Guarantee: light mode does not change
+Every **new** token below has its **light value set equal to the literal it
+replaces**, so introducing it is a pure refactor — light renders byte-for-byte
+the same. Only the **Dark** column diverges. Do **not** change any light value as
+part of this work (including light-mode reading contrast).
+
+---
+
+## 1. Three new semantic tokens (the only non-mechanical change)
+
+The light system used one token where dark needs two. Add these; in light they
+collapse to an existing value (no visible change), in dark they diverge.
+
+| New token | Light value (unchanged behavior) | Dark value | Why dark needs it |
+|---|---|---|---|
+| **`accentFill`** | `#4E7D5C` (= `accent`) | **`#56906A`** | A *brightened* sage carries text/icons for contrast on dark, but a button **fill** that bright would fail white-label contrast. Fills use the deeper sage; text uses the bright one. |
+| **`read`** | `label2` = `#1A1813` @ 54% (= today's transcript body) | **`#F7F2E8` @ 75%** | 54% white is fatiguing for long-form reading on near-black. Body prose lifts; meta/labels stay at the secondary level. |
+| **`elevatedFill`** | `#FFFFFF` (= today's white buttons) | **`#1A170F`** (= `card`) | The "white-fill" light buttons (Stop & Save, header REC pill) can't stay white on dark; their fill becomes the elevated card surface. |
+
+**Refactor required (one-time, light-neutral):** repoint these usages from the
+hardcoded literal to the token —
+- button **fills** currently using `accent` → `accentFill`.
+- **transcript & notes body** text currently using `label2` → `read`.
+- **Stop & Save** and the **recording header pill** fills currently using
+  `white`/`#fff` → `elevatedFill`.
+- any **hover/soft-fill** literals (`Color.black.opacity(0.045–0.06)`,
+  `rgba(26,24,19,.05)`) → the `hover` / `fill` tokens in §2.
+
+Everything else is already token-driven.
+
+---
+
+## 2. Full token table — light → dark
+
+> Light column = the shipped **F · Sage + Pressroom** values (source of truth;
+> do not edit). Dark column = Deep Ink.
+
+### Surfaces & ink
+| Token | Light | Dark |
+|---|---|---|
+| `windowWall` (backdrop) | `radial #E9E7E0 → #E4E1D8 55% → #DCD9CF` | `radial #16140E → #110F09 55% → #0B0A06` |
+| `content` (pane bg) | `#FBFAF5` | **`#100E09`** |
+| `sidebar` (over vibrancy) | `rgba(250,249,244,.82)` | **`rgba(20,18,13,.74)`** (over dark vibrancy) |
+| `card` | `#FFFFFF` | **`#1A170F`** |
+| `cardTop` (raised gradient top, e.g. record console) | `#FFFDFB` | **`#211D14`** |
+| `elevatedFill` (white-button fill) | `#FFFFFF` | **`#1A170F`** |
+| `cardBorder` | `rgba(26,22,14,.10)` | **`rgba(247,242,232,.12)`** |
+| `cardShadow` | `0 1px 3px rgba(40,34,20,.05)` | **`0 1px 2px rgba(0,0,0,.40)`** |
+| `windowHairline` | `rgba(0,0,0,.18)` | **`rgba(255,255,255,.11)`** |
+| `ink` (primary) | `#1A1813` | **`#F7F2E8`** |
+| `ink2` (secondary/meta) | `rgba(26,24,19,.54)` | **`rgba(247,242,232,.58)`** |
+| `ink3` (tertiary/chevron) | `rgba(26,24,19,.34)` | **`rgba(247,242,232,.36)`** |
+| `read` (long-form body) | `rgba(26,24,19,.54)` | **`rgba(247,242,232,.75)`** |
+| `separator` | `rgba(26,24,19,.11)` | **`rgba(247,242,232,.12)`** |
+| `chip` (neutral chip) | `rgba(26,24,19,.06)` | **`rgba(247,242,232,.07)`** |
+| `fill` (soft control fill) | `rgba(26,24,19,.05)` | **`rgba(247,242,232,.06)`** |
+| `hover` | `rgba(0,0,0,.045)` | **`rgba(247,242,232,.06)`** |
+
+### Sage (primary)
+| Token | Light | Dark |
+|---|---|---|
+| `accent` (text/icon/link/timestamp) | `#4E7D5C` | **`#86C295`** |
+| `accentFill` (button fill, white label) | `#4E7D5C` | **`#56906A`** |
+| `accentWash` (selection / soon-row / soft btn) | `rgba(78,125,92,.08–.16)` | **`rgba(134,194,149,.12–.16)`** |
+| `accentTrack` (scrubber/progress fill) | `#5D9069 → #43704F` | **`#5E9A6F`** |
+| `recordIdle` (idle Record pill gradient) | `#5D9069 → #43704F` | **`#5F9D70 → #3F6F4D`** |
+| `recordRing` | `rgba(78,125,92,.16)` | **`rgba(134,194,149,.16)`** |
+
+### Alert red (recording · errors · destructive)
+| Token | Light | Dark |
+|---|---|---|
+| `alert` (dot/mark/icon) | `#C9402B` | **`#E5604A`** |
+| `alertText` (red text on bg) | `#B23320` | **`#F08A78`** |
+| `alertGrad` (recording-pill gradient) | `#DB5740 → #BE331E` | **`#E5604A → #C73D27`** |
+| `alertWash` (error/banner/sidebar-row bg) | `rgba(201,64,43,.09)` | **`rgba(229,96,74,.13)`** |
+| `alertBorder` (outline/ring) | `rgba(201,64,43,.28–.32)` | **`rgba(229,96,74,.36)`** |
+
+### Amber warning (last 5 min — never red)
+| Token | Light | Dark |
+|---|---|---|
+| `amberWash` (chip bg) | `rgba(232,161,58,.18)` | **`rgba(232,161,58,.15)`** |
+| `amberKicker` (label) | `#996A12` | **`#D9A53A`** |
+| `amberValue` (value text) | `#7D540A` | **`#F0C04A`** |
+| `amberDot` (pulsing dot) | `#E8A13A` | **`#E8A13A`** (reads in both) |
+
+> The amber **fully flips polarity**: light is dark-brown text on a light amber
+> wash; dark is bright-amber text on a low-alpha wash. It's the one token where
+> the dark value isn't simply a lightened light value — see the swatch.
+
+---
+
+## 3. Elevation inverts
+
+In light, cards are pure white **lighter** than the ivory page, with a hairline +
+whisper shadow. In dark you **cannot** lift with white, so:
+
+- **Background is the darkest layer** (`content` `#100E09`).
+- **Cards sit *above* it as a lighter warm surface** (`card` `#1A170F`) + the
+  `cardBorder` hairline. The lift *is* the card; **shadows recede** (they do
+  little on dark — keep them but don't lean on them).
+- Doubly-raised surfaces (record console, soft cards that use a `#fff→#fffdfb`
+  gradient in light) use `card → cardTop`.
+- Stacked-avatar separator rings and the `+N` badge ring use `card` (already
+  token-driven) so they read against whatever surface they're on.
+
+No shadow values carry over literally — use the `cardShadow` token.
+
+---
+
+## 4. Per-surface notes
+
+Only the points that need care. Everything else is the token swap.
+
+### Home
+Pure palette swap. Greeting serif, mono kickers/timestamps, stat chips, soon-row
+`accentWash`, colorful avatars — all unchanged structurally.
+
+### Meeting Detail pane
+- **Transcript / Notes body → `read`** (the brighter token). Speaker name stays
+  `ink`, timestamp stays `ink3`/mono. This is the main reason `read` exists.
+- **Audio scrubber:** native `Slider` — let it follow appearance; its tint is
+  `accent`(text-bright) and the filled portion reads as `accentTrack`. The rail
+  is the system track on dark.
+- **Segmented control** (`Picker(.segmented)`) and **`role: .destructive`**
+  Delete: **native — do not restyle.** They adapt to dark automatically.
+- **Source pill / soft "Open in Calendar" button:** `chip` / `fill` + `ink2`.
+- **"…" menu / popovers:** dark glass — `rgba(30,27,20,.97)` + `cardBorder`
+  hairline; hover row uses `accentFill` with white text (unchanged rule).
+
+### Active Recording ("E · Quiet")
+- **RECORDING badge:** dot/halo `alert`; label `alertText`, mono.
+- **Stop & Save (light button):** fill `elevatedFill` (now the card surface, not
+  white), `0.5pt` `alertBorder` outline, `alert` stop-square, `alertText` label.
+- **Header REC pill (live):** fill `elevatedFill`, `alertBorder` outline,
+  pulsing `alert` dot, `alertText` mono timer. (Idle Record pill = `recordIdle`
+  sage gradient, static.)
+- **Sidebar "RECORDING NOW" row:** `alertWash` fill + `alertBorder` inset.
+- **Time chips:** Elapsed = neutral `fill`. **Left ≤ 5:00** → `amberWash` bg,
+  `amberKicker` label, `amberValue` value, pulsing `amberDot`. Never red.
+- **Note composer / Add note / note timestamps:** sage — `accentWash` button,
+  `accent` timestamps; note body uses `read`.
+
+### Upcoming Event detail
+Palette swap. Auto-record card = `accentWash` over `card`; toggle on = `accent`,
+off = neutral. Disclosure triangle is native. Destructive menu item = `alertText`
+/ `alert`, hover `alert` fill.
+
+### Onboarding
+Palette swap. Progress lines/bars/dots: track = `separator`/neutral on dark,
+fill = `accentTrack`/`accent`. Permission checklist/cards = `accentWash` + `accent`
+checks. Mastheads/footer lockups keep the sage `lock.shield.fill`.
+
+---
+
+## 5. Native vs. custom — the rule
+
+- **Native controls follow the system. Don't touch them in dark:** segmented
+  `Picker`, `Slider`, `Menu`, `DisclosureGroup`, `role: .destructive`, sidebar
+  `List` vibrancy, traffic lights, sheets.
+- **Custom-styled pieces reference tokens** (everything in §2). They get dark for
+  free once tokenized.
+- **Materials:** keep `.regularMaterial`/vibrancy on the sidebar and popovers;
+  it darkens automatically. The `sidebar` token is the ivory/ink overlay tint
+  *on top of* that material.
+
+---
+
+## 6. Avatars — unchanged
+
+Colorful initial-keyed gradients stay **exactly** as in light (they read well on
+dark). White initials stay white. The only adaptive part — the separator ring
+between stacked avatars and the `+N` badge ring — already uses the `card` token,
+so it tracks the surface automatically. Do not tint avatars for dark.
+
+---
+
+## 7. Motion & accessibility
+
+- Motion is unchanged and still reserved for the live state only: RECORDING
+  halo (~2s), header dot pulse (~1.6s), amber warning dot (~1.7s), composer
+  caret blink. Honor **Reduce Motion** (steady states).
+- **Contrast:** the dark values target WCAG AA — `ink` ~16:1, `read` ~10:1,
+  `ink2` ~7:1, `accent`/`alertText`/`amberValue` all clear AA on `content`.
+  `accentFill`/`alertGrad` carry white labels at AA-large (≥3:1) — keep label
+  weight ≥ 500 on them.
+- Verify both appearances against the two reference HTML comps before shipping.
+
+---
+
+## 8. Quick diff (copy/paste)
+
+```
+// NEW TOKENS (light value = today's literal; only dark diverges)
+accentFill   : #4E7D5C            →  #56906A     // button fills
+read         : ink@54%            →  #F7F2E8@75% // transcript/notes body
+elevatedFill : #FFFFFF            →  #1A170F     // white-button fill
+
+// SURFACES
+content      : #FBFAF5            →  #100E09
+card         : #FFFFFF            →  #1A170F
+cardBorder   : rgba(26,22,14,.10) →  rgba(247,242,232,.12)
+ink 1/2/3    : #1A1813 /.54/.34   →  #F7F2E8 /.58/.36
+separator    : rgba(26,24,19,.11) →  rgba(247,242,232,.12)
+chip / fill  : ink@.06 / .05      →  rgba(247,242,232,.07 / .06)
+
+// SAGE  (split: text vs fill)
+accent(text) : #4E7D5C            →  #86C295
+accentTrack  : #5D9069→#43704F    →  #5E9A6F
+recordIdle   : #5D9069→#43704F    →  #5F9D70→#3F6F4D
+
+// ALERT RED
+alert        : #C9402B            →  #E5604A
+alertText    : #B23320            →  #F08A78
+alertGrad    : #DB5740→#BE331E    →  #E5604A→#C73D27
+
+// AMBER (flips polarity)
+amberValue   : #7D540A            →  #F0C04A
+amberKicker  : #996A12            →  #D9A53A
+amberWash    : amber@.18          →  amber@.15
+
+// RULE: native controls follow appearance; custom pieces use tokens; no view conditionals.
+```
+```


### PR DESCRIPTION
Adds full dark-mode support to Biscotti via an adaptive color system, built as the `dark_mode` spec project (3 phases). Light appearance is **byte-identical** to before — guarded by tests.

## Mechanism
A single appearance-resolving helper (`DynamicColor.swift`) backs every design token with `NSColor.dynamicProvider`. There are **no `colorScheme` conditionals in view code** (enforced by a test) — all light/dark resolution lives in the `DesignSystem` palette.

## Phase 1 — Adaptive palette foundation (`d63fd27`)
- `DynamicColor.swift`: `dynamicColor(light:dark:)` / `dynamicNSColor(light:dark:)`.
- Rewrote `Color+Theme.swift` so every token resolves light = exact current literal, dark = design-spec value; unified the `Color`/`NSColor` definitions into one source.
- New semantic tokens: `accentFill`, `read`, `elevatedFill`, `accentTrack`, `signalRedText`, `cardShadow`, `controlShadow`.
- `DesignSystemTests`: (1) every token's `.aqua` == legacy literal (byte-identical-light guard), (2) `.darkAqua` == design hex, (3) no `colorScheme` conditionals in views, plus opacity-derived dark adaptation and alias coverage.

## Phase 2 — Split repoints (`d7e9664`)
- Repointed ~17 call sites to the new tokens: sage button fills → `accentFill`, white control/field fills → `elevatedFill`, transcript body → `read`, standalone red labels → `signalRedText`, progress bars → `accentTrack`, and the two `.black` shadows → `cardShadow`/`controlShadow`.
- Confirmed the intentional "stays" sites (white labels/sheens, avatars, `.ultraThinMaterial`, calendar hex, native controls) are untouched, with no over-repointing (notes body stays `.ink`).

## Phase 3 — Human visual review (`de4d061`)
- Prepared a surface-by-surface review packet (`phase_plans/phase_3_review_packet.md`) annotating every dark decision and the 8 judgment calls (the `signalRedText`/`accentTrack` splits, the amber non-split, the deliberate flat-where-the-comp-used-gradient simplifications, and `elevatedFill == cardFill`).
- Human signed off on all 8 decisions. One delta folded in: the avatar **outline/ring** was a stark near-white outline that looked out of place in dark mode. Added an adaptive `avatarRing` token (light `#FFFFFF` byte-identical → dark `#1A170F`, matching `cardFill`) so the ring blends into the dark surface as a quiet separator. White initials / white-on-colored-fill elements stay white.

## Testing
- `make test` green (DesignSystem guarantee tests included); `make lint` clean; `make build-app` builds.
- No `Packages/Transcription`, `AudioCapture`, or `LocalLLM` files touched — the manual-test hardware gate is unaffected.
- Dark mode was visually reviewed live (Light↔Dark toggle) on real hardware as the Phase 3 acceptance gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)