### PR TITLE
Speed up LocalLLM model downloads: chunked streaming download (fixes ~8 MB/s cap)

### DIFF
--- a/ManualTestApp/Results/manual_test_results.json
+++ b/ManualTestApp/Results/manual_test_results.json
@@ -71,115 +71,92 @@
     "timestamp" : "2026-06-19T16:18:54Z"
   },
   "llm_action_items_quality" : {
-    "status" : "pass",
-    "stepID" : "llm_action_items_quality",
-    "timestamp" : "2026-06-23T18:42:01Z"
+    "status" : "not-run",
+    "stepID" : "llm_action_items_quality"
   },
   "llm_action_items_run" : {
-    "status" : "pass",
-    "stepID" : "llm_action_items_run",
-    "timestamp" : "2026-06-23T18:41:59Z"
+    "status" : "not-run",
+    "stepID" : "llm_action_items_run"
   },
   "llm_ai_tests_passed" : {
-    "status" : "pass",
-    "stepID" : "llm_ai_tests_passed",
-    "timestamp" : "2026-06-23T18:41:20Z"
+    "status" : "not-run",
+    "stepID" : "llm_ai_tests_passed"
   },
   "llm_chat_system" : {
-    "status" : "pass",
-    "stepID" : "llm_chat_system",
-    "timestamp" : "2026-06-23T18:41:34Z"
+    "status" : "not-run",
+    "stepID" : "llm_chat_system"
   },
   "llm_chat_system_quality" : {
-    "status" : "pass",
-    "stepID" : "llm_chat_system_quality",
-    "timestamp" : "2026-06-23T18:41:36Z"
+    "status" : "not-run",
+    "stepID" : "llm_chat_system_quality"
   },
   "llm_e2b_download" : {
-    "status" : "pass",
-    "stepID" : "llm_e2b_download",
-    "timestamp" : "2026-06-23T18:10:28Z"
+    "status" : "not-run",
+    "stepID" : "llm_e2b_download"
   },
   "llm_e2b_kv_reuse" : {
-    "status" : "pass",
-    "stepID" : "llm_e2b_kv_reuse",
-    "timestamp" : "2026-06-23T19:18:57Z"
+    "status" : "not-run",
+    "stepID" : "llm_e2b_kv_reuse"
   },
   "llm_e2b_kv_reuse_quality" : {
-    "status" : "pass",
-    "stepID" : "llm_e2b_kv_reuse_quality",
-    "timestamp" : "2026-06-23T19:19:01Z"
+    "status" : "not-run",
+    "stepID" : "llm_e2b_kv_reuse_quality"
   },
   "llm_kv_reuse" : {
-    "status" : "pass",
-    "stepID" : "llm_kv_reuse",
-    "timestamp" : "2026-06-23T19:18:44Z"
+    "status" : "not-run",
+    "stepID" : "llm_kv_reuse"
   },
   "llm_kv_reuse_quality" : {
-    "status" : "pass",
-    "stepID" : "llm_kv_reuse_quality",
-    "timestamp" : "2026-06-23T19:18:51Z"
+    "status" : "not-run",
+    "stepID" : "llm_kv_reuse_quality"
   },
   "llm_model_disk" : {
-    "status" : "pass",
-    "stepID" : "llm_model_disk",
-    "timestamp" : "2026-06-23T17:57:50Z"
+    "status" : "not-run",
+    "stepID" : "llm_model_disk"
   },
   "llm_model_download" : {
-    "status" : "pass",
-    "stepID" : "llm_model_download",
-    "timestamp" : "2026-06-23T18:30:01Z"
+    "status" : "not-run",
+    "stepID" : "llm_model_download"
   },
   "llm_reclamation" : {
-    "note" : "No BiscottiLLM service process found (reclaimed)",
-    "status" : "pass",
-    "stepID" : "llm_reclamation",
-    "timestamp" : "2026-06-23T19:19:05Z"
+    "status" : "not-run",
+    "stepID" : "llm_reclamation"
   },
   "llm_speaker_names_quality" : {
-    "status" : "pass",
-    "stepID" : "llm_speaker_names_quality",
-    "timestamp" : "2026-06-23T18:42:16Z"
+    "status" : "not-run",
+    "stepID" : "llm_speaker_names_quality"
   },
   "llm_speaker_names_run" : {
-    "status" : "pass",
-    "stepID" : "llm_speaker_names_run",
-    "timestamp" : "2026-06-23T18:42:13Z"
+    "status" : "not-run",
+    "stepID" : "llm_speaker_names_run"
   },
   "llm_streaming_channels" : {
-    "status" : "pass",
-    "stepID" : "llm_streaming_channels",
-    "timestamp" : "2026-06-23T19:17:23Z"
+    "status" : "not-run",
+    "stepID" : "llm_streaming_channels"
   },
   "llm_streaming_run" : {
-    "status" : "pass",
-    "stepID" : "llm_streaming_run",
-    "timestamp" : "2026-06-23T19:17:40Z"
+    "status" : "not-run",
+    "stepID" : "llm_streaming_run"
   },
   "llm_summarize_quality" : {
-    "status" : "pass",
-    "stepID" : "llm_summarize_quality",
-    "timestamp" : "2026-06-23T18:41:48Z"
+    "status" : "not-run",
+    "stepID" : "llm_summarize_quality"
   },
   "llm_summarize_run" : {
-    "status" : "pass",
-    "stepID" : "llm_summarize_run",
-    "timestamp" : "2026-06-23T18:41:46Z"
+    "status" : "not-run",
+    "stepID" : "llm_summarize_run"
   },
   "llm_thinking_mode" : {
-    "status" : "pass",
-    "stepID" : "llm_thinking_mode",
-    "timestamp" : "2026-06-23T19:17:13Z"
+    "status" : "not-run",
+    "stepID" : "llm_thinking_mode"
   },
   "llm_thinking_run" : {
-    "status" : "pass",
-    "stepID" : "llm_thinking_run",
-    "timestamp" : "2026-06-23T18:42:58Z"
+    "status" : "not-run",
+    "stepID" : "llm_thinking_run"
   },
   "llm_xpc_inference" : {
-    "status" : "pass",
-    "stepID" : "llm_xpc_inference",
-    "timestamp" : "2026-06-23T18:41:29Z"
+    "status" : "not-run",
+    "stepID" : "llm_xpc_inference"
   },
   "tx_ai_test_passed" : {
     "status" : "not-run",

--- a/Packages/LocalLLM/Sources/LocalLLM/ModelDownloader.swift
+++ b/Packages/LocalLLM/Sources/LocalLLM/ModelDownloader.swift
@@ -128,29 +128,18 @@ public struct ModelDownloader: Sendable {
     // MARK: - Network (isolated for testability)
 
     /// Returns the server's expected content length (nil if not provided).
+    ///
+    /// Streams the response to disk in whole `Data` chunks via a `URLSessionDataDelegate`.
+    /// The previous implementation iterated `URLSession.AsyncBytes` one `UInt8` at a time,
+    /// which is CPU-bound (billions of async-sequence iterations for a multi-GB file) and
+    /// capped throughput far below the link speed. Delegate `didReceive` chunks let the
+    /// transfer run at network speed while still reporting progress.
     @discardableResult
     private func performDownload(
         from source: URL,
         to destination: URL,
         progress: @Sendable @escaping (_ bytes: Int64, _ total: Int64?) -> Void
     ) async throws -> Int64? {
-        let request = URLRequest(url: source)
-        let (asyncBytes, response) = try await URLSession.shared.bytes(for: request)
-
-        guard let httpResponse = response as? HTTPURLResponse,
-              (200 ... 299).contains(httpResponse.statusCode)
-        else {
-            let code = (response as? HTTPURLResponse)?.statusCode ?? -1
-            throw LocalLLMError.downloadFailed(
-                url: source, underlying: "HTTP \(code)"
-            )
-        }
-
-        let totalBytes: Int64? = {
-            let length = httpResponse.expectedContentLength
-            return length > 0 ? length : nil
-        }()
-
         guard FileManager.default.createFile(atPath: destination.path, contents: nil) else {
             throw LocalLLMError.downloadFailed(
                 url: source, underlying: "Failed to create file at \(destination.path)"
@@ -158,29 +147,146 @@ public struct ModelDownloader: Sendable {
         }
         let fileHandle = try FileHandle(forWritingTo: destination)
 
-        defer { try? fileHandle.close() }
+        let delegate = StreamingDownloadDelegate(
+            source: source, fileHandle: fileHandle, progress: progress
+        )
+        // A delegate cannot be attached to `URLSession.shared`, so we spin up a dedicated
+        // session and tear it down when the transfer completes (breaks the session→delegate
+        // retain cycle).
+        let session = URLSession(configuration: .default, delegate: delegate, delegateQueue: nil)
+        defer { session.finishTasksAndInvalidate() }
 
-        var downloaded: Int64 = 0
-        var buffer = Data()
-        let flushThreshold = 1024 * 1024 // 1 MB chunks
+        return try await delegate.run(session: session, request: URLRequest(url: source))
+    }
+}
 
-        for try await byte in asyncBytes {
-            buffer.append(byte)
-            downloaded += 1
+/// Bridges a `URLSessionDataTask` to async/await, streaming response chunks straight to a
+/// `FileHandle` and reporting progress.
+///
+/// All callbacks arrive serially on the session's delegate queue; mutable state is still guarded
+/// by `lock` to publish safely to the awaiting task and to satisfy Swift 6 `Sendable`.
+private final class StreamingDownloadDelegate: NSObject, URLSessionDataDelegate, @unchecked Sendable {
+    private let source: URL
+    private let fileHandle: FileHandle
+    private let progress: @Sendable (Int64, Int64?) -> Void
 
-            if buffer.count >= flushThreshold {
-                try fileHandle.write(contentsOf: buffer)
-                buffer.removeAll(keepingCapacity: true)
-                progress(downloaded, totalBytes)
+    private let lock = NSLock()
+    private var downloaded: Int64 = 0
+    private var total: Int64?
+    private var failure: Error?
+    private var continuation: CheckedContinuation<Int64?, Error>?
+    private var finished = false
+
+    init(
+        source: URL,
+        fileHandle: FileHandle,
+        progress: @escaping @Sendable (Int64, Int64?) -> Void
+    ) {
+        self.source = source
+        self.fileHandle = fileHandle
+        self.progress = progress
+    }
+
+    /// Starts the data task and suspends until the transfer completes (or fails).
+    ///
+    /// Cooperative cancellation: if the enclosing Swift `Task` is cancelled, the
+    /// `onCancel` handler calls `dataTask.cancel()`, which triggers the delegate's
+    /// `didCompleteWithError` with `NSURLErrorCancelled` — that resumes the
+    /// continuation normally, so the exactly-once guarantee is preserved.
+    /// - Returns: the server's `Content-Length` (nil if unknown).
+    func run(session: URLSession, request: URLRequest) async throws -> Int64? {
+        // Create the task synchronously so the cancellation handler can capture it.
+        // `task` is a `let` — safe to read from the concurrent `onCancel` closure
+        // without additional synchronisation.
+        let task = session.dataTask(with: request)
+
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Int64?, Error>) in
+                lock.lock()
+                continuation = cont
+                lock.unlock()
+                task.resume()
             }
+        } onCancel: {
+            task.cancel()
         }
+    }
 
-        // Flush remaining
-        if !buffer.isEmpty {
-            try fileHandle.write(contentsOf: buffer)
+    func urlSession(
+        _: URLSession,
+        dataTask _: URLSessionDataTask,
+        didReceive response: URLResponse,
+        completionHandler: @escaping (URLSession.ResponseDisposition) -> Void
+    ) {
+        guard let http = response as? HTTPURLResponse,
+              (200 ... 299).contains(http.statusCode)
+        else {
+            let code = (response as? HTTPURLResponse)?.statusCode ?? -1
+            recordFailure(LocalLLMError.downloadFailed(url: source, underlying: "HTTP \(code)"))
+            completionHandler(.cancel)
+            return
         }
-        progress(downloaded, totalBytes)
+        let length = http.expectedContentLength
+        lock.lock()
+        total = length > 0 ? length : nil
+        lock.unlock()
+        completionHandler(.allow)
+    }
 
-        return totalBytes
+    func urlSession(_: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
+        lock.lock()
+        if failure != nil {
+            lock.unlock()
+            return
+        }
+        do {
+            try fileHandle.write(contentsOf: data)
+        } catch {
+            failure = error
+            lock.unlock()
+            dataTask.cancel()
+            return
+        }
+        downloaded += Int64(data.count)
+        let bytes = downloaded
+        let totalBytes = total
+        lock.unlock()
+        // Reported outside the lock to avoid re-entrancy with caller-side throttling.
+        progress(bytes, totalBytes)
+    }
+
+    func urlSession(_: URLSession, task _: URLSessionTask, didCompleteWithError error: Error?) {
+        lock.lock()
+        if finished {
+            lock.unlock()
+            return
+        }
+        finished = true
+        let cont = continuation
+        continuation = nil
+        let storedFailure = failure
+        let totalBytes = total
+        lock.unlock()
+
+        // Close the file handle outside the lock (no deadlock risk either way, but
+        // clearer separation). Must happen before resuming the continuation so the
+        // outer atomic-move sees a flushed/closed file.
+        try? fileHandle.close()
+
+        if let storedFailure {
+            cont?.resume(throwing: storedFailure)
+        } else if let error {
+            cont?.resume(throwing: LocalLLMError.downloadFailed(
+                url: source, underlying: error.localizedDescription
+            ))
+        } else {
+            cont?.resume(returning: totalBytes)
+        }
+    }
+
+    private func recordFailure(_ error: Error) {
+        lock.lock()
+        if failure == nil { failure = error }
+        lock.unlock()
     }
 }

--- a/hooks_mcp.yaml
+++ b/hooks_mcp.yaml
@@ -24,6 +24,9 @@ actions:
   - name: "test"
     description: "Gating: run the package test suite (swift test)"
     command: "bash -c 'set -o pipefail; make test 2>&1 | tail -n 400'"
+    # Full cross-package suite (including LocalLLM's XCFramework fetch) exceeds
+    # the default timeout; 300s matches build/build_llm/test_llm.
+    timeout: 300
 
   - name: "lint"
     description: "Check formatting + lint (non-mutating)"


### PR DESCRIPTION
## Problem

LocalLLM model downloads were capped at ~8 MB/s on a 310 Mbps connection.

## Root cause

`ModelDownloader` hand-rolled its download with `URLSession.shared.bytes(for:)` and iterated the `AsyncBytes` sequence **one `UInt8` at a time** (`for try await byte in asyncBytes`, appending each byte to a `Data` buffer). For a multi-GB GGUF that is *billions* of async-sequence iterations — CPU-bound, and the real throughput ceiling. The single-connection hypothesis was secondary; the byte-by-byte loop was the dominant cost.

## Fix (Tier 1)

Replace the byte-by-byte loop with a chunked, streaming `URLSessionDataDelegate` (`StreamingDownloadDelegate`) that writes whole `Data` chunks straight to the file handle and reports progress per chunk. No new dependencies. The transfer now runs at network speed.

Cooperative cancellation is preserved via `withTaskCancellationHandler`: cancelling the enclosing `Task` calls `dataTask.cancel()`, which fires `didCompleteWithError` and resumes the continuation through the existing exactly-once path. All other behaviors are unchanged: skip-if-present, temp-then-move atomicity, Content-Length size validation, HTTP status checks, progress reporting, and error mapping to `LocalLLMError.downloadFailed`. The public `ModelDownloader` API is unchanged.

> Tier 2 (true multi-connection HTTP Range parallelism) was intentionally **not** done — Tier 1 alone resolves the throughput cap. Revisit only if a single connection later proves to be CDN-throttled.

## Also in this PR

- `hooks_mcp.yaml`: bump the `test` action timeout to 300s (the full cross-package suite exceeds the default).
- `ManualTestApp/Results/manual_test_results.json`: mark all 22 recordable `llm_*` manual-test steps `not-run` per the repo's manual-test staleness rule (touched `Packages/LocalLLM`). This makes the non-gating `manual-tests-check` job RED until a human re-runs the LLM manual tests on hardware.

## Verification

- `make build` green, `make lint` green, LocalLLM `ModelDownloaderTests` green.
- **User confirmed the speed fix on real hardware.**
- One pre-existing flaky test (`MeetingDetection — Mic Stop Self-Verify`, a timing-sensitive debounce test) fails identically on clean `main`; unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)