### PR TITLE
Meeting Tags

### DIFF
--- a/Packages/BiscottiKit/Package.swift
+++ b/Packages/BiscottiKit/Package.swift
@@ -59,12 +59,15 @@ let package = Package(
         ),
         .target(
             name: "DesignSystem",
+            dependencies: [
+                "DataStore"
+            ],
             resources: [.process("Resources")],
             swiftSettings: warningsAsErrors
         ),
         .testTarget(
             name: "DesignSystemTests",
-            dependencies: ["DesignSystem"],
+            dependencies: ["DesignSystem", "DataStore"],
             swiftSettings: warningsAsErrors
         ),
         .target(

--- a/Packages/BiscottiKit/Sources/DataStore/DataStore+ReadModels.swift
+++ b/Packages/BiscottiKit/Sources/DataStore/DataStore+ReadModels.swift
@@ -17,6 +17,8 @@ public struct MeetingSummary: Sendable, Identifiable, Equatable {
     public let participants: [PersonData]
     /// Total distinct participant count (drives the "+N" badge).
     public let participantCount: Int
+    /// Tags applied to this meeting, sorted alphabetically.
+    public let tags: [TagData]
 
     public init(
         id: UUID,
@@ -25,7 +27,8 @@ public struct MeetingSummary: Sendable, Identifiable, Equatable {
         hasTranscript: Bool,
         recordingDuration: TimeInterval? = nil,
         participants: [PersonData] = [],
-        participantCount: Int = 0
+        participantCount: Int = 0,
+        tags: [TagData] = []
     ) {
         self.id = id
         self.title = title
@@ -34,6 +37,7 @@ public struct MeetingSummary: Sendable, Identifiable, Equatable {
         self.recordingDuration = recordingDuration
         self.participants = participants
         self.participantCount = participantCount
+        self.tags = tags
     }
 }
 
@@ -64,6 +68,8 @@ public struct MeetingDetailData: Sendable, Identifiable, Equatable {
     public let editedSummary: Bool
     /// Whether the user has manually edited the title.
     public let editedTitle: Bool
+    /// Tags applied to this meeting, sorted alphabetically.
+    public let tags: [TagData]
 
     public init(
         id: UUID,
@@ -79,7 +85,8 @@ public struct MeetingDetailData: Sendable, Identifiable, Equatable {
         versions: [TranscriptVersionData] = [],
         summary: String = "",
         editedSummary: Bool = false,
-        editedTitle: Bool = false
+        editedTitle: Bool = false,
+        tags: [TagData] = []
     ) {
         self.id = id
         self.title = title
@@ -95,6 +102,7 @@ public struct MeetingDetailData: Sendable, Identifiable, Equatable {
         self.summary = summary
         self.editedSummary = editedSummary
         self.editedTitle = editedTitle
+        self.tags = tags
     }
 }
 
@@ -292,12 +300,26 @@ public struct TranscriptVersionData: Sendable, Identifiable, Equatable {
     }
 }
 
+/// A tag DTO safe to hold on `@MainActor`.
+public struct TagData: Sendable, Identifiable, Equatable, Hashable {
+    public let id: UUID
+    public let name: String
+    public let colorSlot: Int
+
+    public init(id: UUID, name: String, colorSlot: Int) {
+        self.id = id
+        self.name = name
+        self.colorSlot = colorSlot
+    }
+}
+
 /// Which field a search term matched in.
 public enum SearchField: Sendable, Equatable {
     case title
     case people
     case transcript
     case notes
+    case tags
 }
 
 /// Audio file reference result for a meeting.
@@ -363,6 +385,8 @@ public extension DataStore {
                 PersonData(id: $0.id, name: $0.name, email: $0.email)
             }
 
+            let mappedTags = mapTags(meeting.tags)
+
             return MeetingSummary(
                 id: meeting.id,
                 title: meeting.title,
@@ -370,7 +394,8 @@ public extension DataStore {
                 hasTranscript: meeting.preferredTranscriptID != nil,
                 recordingDuration: meeting.recordingDuration,
                 participants: mappedParticipants,
-                participantCount: deduped.count
+                participantCount: deduped.count,
+                tags: mappedTags
             )
         }
     }
@@ -395,6 +420,8 @@ public extension DataStore {
 
         let hasAudio = !meeting.audioFiles.isEmpty && meeting.audioFiles.contains(where: \.isPresent)
 
+        let mappedTags = mapTags(meeting.tags)
+
         return try MeetingDetailData(
             id: meeting.id,
             title: meeting.title,
@@ -409,7 +436,8 @@ public extension DataStore {
             versions: transcriptVersions(meetingID: id),
             summary: meeting.summary,
             editedSummary: meeting.editedSummary,
-            editedTitle: meeting.editedTitle
+            editedTitle: meeting.editedTitle,
+            tags: mappedTags
         )
     }
 
@@ -674,6 +702,13 @@ public extension DataStore {
                 score += 1
                 fields.insert(.notes)
             }
+            // Tags scored at the same weight as title (3).
+            if meeting.tags.contains(where: {
+                $0.name.lowercased().localizedStandardContains(term)
+            }) {
+                score += 3
+                fields.insert(.tags)
+            }
         }
 
         guard score > 0 else { return nil }
@@ -687,6 +722,13 @@ public extension DataStore {
     }
 
     // MARK: - Private Mappers
+
+    /// Maps a collection of `Tag` models to sorted `TagData` DTOs (alphabetical, case-insensitive).
+    private func mapTags(_ tags: [Tag]) -> [TagData] {
+        tags
+            .map { TagData(id: $0.id, name: $0.name, colorSlot: $0.colorSlot) }
+            .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+    }
 
     private func mapTranscript(_ record: TranscriptRecord) throws -> TranscriptData {
         let sortedSegments = record.segments.sorted(by: { $0.index < $1.index })
@@ -727,9 +769,10 @@ public extension DataStore {
     private func fieldSortOrder(_ field: SearchField) -> Int {
         switch field {
         case .title: 0
-        case .people: 1
-        case .transcript: 2
-        case .notes: 3
+        case .tags: 1
+        case .people: 2
+        case .transcript: 3
+        case .notes: 4
         }
     }
 }

--- a/Packages/BiscottiKit/Sources/DataStore/DataStore+Tags.swift
+++ b/Packages/BiscottiKit/Sources/DataStore/DataStore+Tags.swift
@@ -1,0 +1,85 @@
+import Foundation
+import SwiftData
+
+// MARK: - Tag API
+
+public extension DataStore {
+    /// Returns all tags in the catalogue, sorted alphabetically (case-insensitive).
+    func allTags() throws -> [TagData] {
+        let descriptor = FetchDescriptor<Tag>()
+        let tags = try context.fetch(descriptor)
+        return tags
+            .map { TagData(id: $0.id, name: $0.name, colorSlot: $0.colorSlot) }
+            .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+    }
+
+    /// Creates a new tag with the given name. Returns `nil` if the trimmed name is empty.
+    /// If a tag with the same name (case-insensitive) already exists, returns it instead
+    /// of creating a duplicate. The colour slot is assigned round-robin by catalogue size.
+    func createTag(name: String) throws -> TagData? {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        // Case-insensitive dedup: full-table scan, acceptable at V1 scale
+        let descriptor = FetchDescriptor<Tag>()
+        let existing = try context.fetch(descriptor)
+        if let match = existing.first(where: {
+            $0.name.caseInsensitiveCompare(trimmed) == .orderedSame
+        }) {
+            return TagData(id: match.id, name: match.name, colorSlot: match.colorSlot)
+        }
+
+        let slot = existing.count % 8
+        let tag = Tag(name: trimmed, colorSlot: slot)
+        context.insert(tag)
+        try save()
+        return TagData(id: tag.id, name: tag.name, colorSlot: tag.colorSlot)
+    }
+
+    /// Applies a tag to a meeting. No-op if already applied or if either ID is not found.
+    func applyTag(tagID: UUID, to meetingID: UUID) throws {
+        guard let tag = try fetchTag(id: tagID),
+              let meeting = try meeting(id: meetingID)
+        else { return }
+        // Idempotent: only append if not already linked
+        if !meeting.tags.contains(where: { $0.id == tag.id }) {
+            meeting.tags.append(tag)
+            try save()
+        }
+    }
+
+    /// Removes a tag's application from a meeting. The tag remains in the catalogue.
+    /// No-op if the tag is not applied or if either ID is not found.
+    func removeTag(tagID: UUID, from meetingID: UUID) throws {
+        guard let meeting = try meeting(id: meetingID) else { return }
+        meeting.tags.removeAll(where: { $0.id == tagID })
+        try save()
+    }
+
+    /// Atomically finds-or-creates a tag and applies it to a meeting.
+    /// Returns the tag DTO, or `nil` if the name is empty after trimming.
+    func createTagAndApply(name: String, to meetingID: UUID) throws -> TagData? {
+        guard let tagData = try createTag(name: name) else { return nil }
+        try applyTag(tagID: tagData.id, to: meetingID)
+        return tagData
+    }
+
+    // MARK: - Internal fetch helper
+
+    /// Fetches a `Tag` by ID, or nil if not found.
+    func fetchTag(id tagID: UUID) throws -> Tag? {
+        let descriptor = FetchDescriptor<Tag>(
+            predicate: #Predicate { $0.id == tagID }
+        )
+        return try context.fetch(descriptor).first
+    }
+}
+
+// MARK: - Test Helpers
+
+public extension DataStore {
+    /// Fetches all `Tag` rows in the store (for verification in tests).
+    func fetchAllTags() throws -> [Tag] {
+        try context.fetch(FetchDescriptor<Tag>())
+    }
+}

--- a/Packages/BiscottiKit/Sources/DataStore/Models/Meeting.swift
+++ b/Packages/BiscottiKit/Sources/DataStore/Models/Meeting.swift
@@ -45,6 +45,9 @@ import SwiftData
     public var calendarSnapshot: CalendarSnapshot?
 
     @Relationship
+    public var tags: [Tag] = []
+
+    @Relationship
     public var participants: [Person] = []
 
     @Relationship

--- a/Packages/BiscottiKit/Sources/DataStore/Models/Tag.swift
+++ b/Packages/BiscottiKit/Sources/DataStore/Models/Tag.swift
@@ -1,0 +1,32 @@
+import Foundation
+import SwiftData
+
+// MARK: - Tag
+
+/// A named, colour-coded label that lives in a global catalogue.
+/// Tags exist independently of meetings; the same tag can be applied to
+/// many meetings (many-to-many via `Meeting.tags`).
+@Model public final class Tag {
+    public var id = UUID()
+    /// Trimmed display name (case-insensitively unique in the catalogue).
+    public var name: String = ""
+    /// Stable palette index (0-7), assigned round-robin at creation time.
+    public var colorSlot: Int = 0
+    /// Creation timestamp, used for round-robin ordering.
+    public var createdAt = Date()
+
+    @Relationship(inverse: \Meeting.tags)
+    public var meetings: [Meeting] = []
+
+    public init(
+        id: UUID = UUID(),
+        name: String,
+        colorSlot: Int,
+        createdAt: Date = Date()
+    ) {
+        self.id = id
+        self.name = name
+        self.colorSlot = colorSlot
+        self.createdAt = createdAt
+    }
+}

--- a/Packages/BiscottiKit/Sources/DataStore/Schema/DataStoreSchemaV1.swift
+++ b/Packages/BiscottiKit/Sources/DataStore/Schema/DataStoreSchemaV1.swift
@@ -8,6 +8,7 @@ public enum DataStoreSchemaV1: VersionedSchema {
     public static var models: [any PersistentModel.Type] {
         [
             Meeting.self,
+            Tag.self,
             Person.self,
             TranscriptRecord.self,
             TranscriptSegmentRecord.self,

--- a/Packages/BiscottiKit/Sources/DesignSystem/Color+Theme.swift
+++ b/Packages/BiscottiKit/Sources/DesignSystem/Color+Theme.swift
@@ -248,6 +248,34 @@ public extension Color {
         dark: NSColor(srgbRed: 0.102, green: 0.090, blue: 0.059, alpha: 1)
     )
 
+    // MARK: - List pane
+
+    /// List pane background — a distinct **third** warm ivory, between `paper`
+    /// (main content) and `sidebarTint` (sidebar). Used for the meetings list.
+    /// Light `#F7F3EB` / dark **provisional** `#17140D`.
+    /// provisional dark — eyeball in Phase 5
+    static let listPaneBackground = dynamicColor(
+        light: NSColor(srgbRed: 0.969, green: 0.953, blue: 0.922, alpha: 1),
+        dark: NSColor(srgbRed: 0.090, green: 0.078, blue: 0.051, alpha: 1)
+    )
+
+    // MARK: - On solid-accent (selected) surface tokens
+
+    /// Primary text on a solid-accent (selected) surface — pure white.
+    /// Appearance-independent (white reads on both light and dark `accentFill`).
+    static let onAccent: Color = .white
+
+    /// Secondary text on a solid-accent surface — white @ 72%.
+    /// Used for the when-line and `+N` overflow on selected rows.
+    static let onAccentMuted: Color = .white.opacity(0.72)
+
+    /// Tag pill fill on a solid-accent surface — white @ 18%.
+    static let onAccentChipFill: Color = .white.opacity(0.18)
+
+    /// Tag dot ring on a solid-accent surface — white @ 50%.
+    /// A 0.5px ring around coloured dots so slate/teal/olive stay legible on sage.
+    static let onAccentChipRing: Color = .white.opacity(0.5)
+
     // MARK: - Tag-dot palette (8 swatches)
 
     /// Fixed, ordered palette of 8 adaptive tag-dot colours. Sage is
@@ -372,5 +400,14 @@ public extension ShapeStyle where Self == Color {
 
     static var avatarRing: Color {
         .avatarRing
+    }
+
+    /// On solid-accent (selected) surface tokens
+    static var onAccent: Color {
+        .onAccent
+    }
+
+    static var onAccentMuted: Color {
+        .onAccentMuted
     }
 }

--- a/Packages/BiscottiKit/Sources/DesignSystem/Color+Theme.swift
+++ b/Packages/BiscottiKit/Sources/DesignSystem/Color+Theme.swift
@@ -247,6 +247,58 @@ public extension Color {
         light: NSColor(srgbRed: 1.0, green: 1.0, blue: 1.0, alpha: 1),
         dark: NSColor(srgbRed: 0.102, green: 0.090, blue: 0.059, alpha: 1)
     )
+
+    // MARK: - Tag-dot palette (8 swatches)
+
+    /// Fixed, ordered palette of 8 adaptive tag-dot colours. Sage is
+    /// reserved and absent. Assigned round-robin by creation order; stored
+    /// as a stable `colorSlot` on each tag. Dark values are starting
+    /// proposals -- a human eyeballs them on hardware (Phase 4).
+    static let tagSwatches: [Color] = [
+        // 0: Blue
+        dynamicColor(
+            light: NSColor(srgbRed: 0.243, green: 0.427, blue: 0.659, alpha: 1),
+            dark: NSColor(srgbRed: 0.431, green: 0.604, blue: 0.816, alpha: 1)
+        ),
+        // 1: Clay
+        dynamicColor(
+            light: NSColor(srgbRed: 0.710, green: 0.408, blue: 0.243, alpha: 1),
+            dark: NSColor(srgbRed: 0.816, green: 0.541, blue: 0.369, alpha: 1)
+        ),
+        // 2: Violet
+        dynamicColor(
+            light: NSColor(srgbRed: 0.478, green: 0.416, blue: 0.682, alpha: 1),
+            dark: NSColor(srgbRed: 0.639, green: 0.584, blue: 0.816, alpha: 1)
+        ),
+        // 3: Slate
+        dynamicColor(
+            light: NSColor(srgbRed: 0.420, green: 0.482, blue: 0.525, alpha: 1),
+            dark: NSColor(srgbRed: 0.604, green: 0.667, blue: 0.710, alpha: 1)
+        ),
+        // 4: Red -- reuses signalRed light/dark pair
+        signalRed,
+        // 5: Teal
+        dynamicColor(
+            light: NSColor(srgbRed: 0.165, green: 0.549, blue: 0.494, alpha: 1),
+            dark: NSColor(srgbRed: 0.310, green: 0.702, blue: 0.639, alpha: 1)
+        ),
+        // 6: Amber
+        dynamicColor(
+            light: NSColor(srgbRed: 0.659, green: 0.518, blue: 0.227, alpha: 1),
+            dark: NSColor(srgbRed: 0.796, green: 0.659, blue: 0.369, alpha: 1)
+        ),
+        // 7: Olive
+        dynamicColor(
+            light: NSColor(srgbRed: 0.369, green: 0.549, blue: 0.227, alpha: 1),
+            dark: NSColor(srgbRed: 0.541, green: 0.722, blue: 0.380, alpha: 1)
+        )
+    ]
+
+    /// Returns the tag-dot colour for a given palette slot (0-7).
+    /// Wraps safely for any integer (negative, >7).
+    static func tagSwatch(slot: Int) -> Color {
+        tagSwatches[((slot % 8) + 8) % 8]
+    }
 }
 
 // MARK: - ShapeStyle sugar

--- a/Packages/BiscottiKit/Sources/DesignSystem/FlowLayout.swift
+++ b/Packages/BiscottiKit/Sources/DesignSystem/FlowLayout.swift
@@ -1,0 +1,140 @@
+import SwiftUI
+
+/// A left-to-right wrapping layout. Places children horizontally until
+/// the proposed width is exceeded, then wraps to the next row.
+///
+/// Pure `Layout`-protocol conformance -- no `GeometryReader`, no
+/// `PreferenceKey`. Unit-testable via `sizeThatFits` / `placeSubviews`.
+public struct FlowLayout: Layout {
+    /// Horizontal spacing between items on the same row.
+    public var horizontalSpacing: CGFloat
+
+    /// Vertical spacing between rows.
+    public var verticalSpacing: CGFloat
+
+    public init(
+        horizontalSpacing: CGFloat = 6,
+        verticalSpacing: CGFloat = 6
+    ) {
+        self.horizontalSpacing = horizontalSpacing
+        self.verticalSpacing = verticalSpacing
+    }
+
+    public func sizeThatFits(
+        proposal: ProposedViewSize,
+        subviews: Subviews,
+        cache _: inout ()
+    ) -> CGSize {
+        let rows = computeRows(
+            subviews: subviews,
+            containerWidth: proposal.width ?? .infinity
+        )
+        return layoutSize(rows: rows)
+    }
+
+    public func placeSubviews(
+        in bounds: CGRect,
+        proposal: ProposedViewSize,
+        subviews: Subviews,
+        cache _: inout ()
+    ) {
+        let rows = computeRows(
+            subviews: subviews,
+            containerWidth: proposal.width ?? bounds.width
+        )
+
+        var originY = bounds.minY
+        for row in rows {
+            var originX = bounds.minX
+            for item in row.items {
+                subviews[item.index].place(
+                    at: CGPoint(x: originX, y: originY),
+                    anchor: .topLeading,
+                    proposal: ProposedViewSize(item.size)
+                )
+                originX += item.size.width + horizontalSpacing
+            }
+            originY += row.height + verticalSpacing
+        }
+    }
+
+    // MARK: - Internal geometry
+
+    struct RowItem {
+        let index: Int
+        let size: CGSize
+    }
+
+    struct Row {
+        var items: [RowItem] = []
+        var width: CGFloat = 0
+        var height: CGFloat = 0
+    }
+
+    func computeRows(
+        subviews: LayoutSubviews,
+        containerWidth: CGFloat
+    ) -> [Row] {
+        let sizes = subviews.map { $0.sizeThatFits(.unspecified) }
+        return computeRows(sizes: sizes, containerWidth: containerWidth)
+    }
+
+    /// Pure row-computation that takes concrete sizes instead of opaque
+    /// `LayoutSubviews`. Testable without instantiating real views.
+    func computeRows(
+        sizes: [CGSize],
+        containerWidth: CGFloat
+    ) -> [Row] {
+        var rows: [Row] = []
+        var currentRow = Row()
+
+        for (index, size) in sizes.enumerated() {
+            let neededWidth = currentRow.items.isEmpty
+                ? size.width
+                : currentRow.width + horizontalSpacing + size.width
+
+            if !currentRow.items.isEmpty, neededWidth > containerWidth {
+                rows.append(currentRow)
+                currentRow = Row()
+                // Recompute for the fresh row (item is first, so just its width).
+                let freshWidth = size.width
+                currentRow.items.append(RowItem(index: index, size: size))
+                currentRow.width = freshWidth
+            } else {
+                currentRow.items.append(RowItem(index: index, size: size))
+                currentRow.width = neededWidth
+            }
+            currentRow.height = max(currentRow.height, size.height)
+        }
+
+        if !currentRow.items.isEmpty {
+            rows.append(currentRow)
+        }
+
+        return rows
+    }
+
+    func layoutSize(rows: [Row]) -> CGSize {
+        guard !rows.isEmpty else { return .zero }
+        let totalWidth = rows.map(\.width).max() ?? 0
+        let totalHeight = rows.map(\.height).reduce(0, +)
+            + CGFloat(max(0, rows.count - 1)) * verticalSpacing
+        return CGSize(width: totalWidth, height: totalHeight)
+    }
+}
+
+#if DEBUG
+    #Preview("FlowLayout") {
+        FlowLayout(horizontalSpacing: 6, verticalSpacing: 6) {
+            ForEach(0 ..< 8) { index in
+                Text("Tag \(index)")
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(Color.neutralChip, in: Capsule())
+            }
+        }
+        .frame(width: 200)
+        .padding()
+        .background(Color.paper)
+    }
+#endif

--- a/Packages/BiscottiKit/Sources/DesignSystem/TagPill.swift
+++ b/Packages/BiscottiKit/Sources/DesignSystem/TagPill.swift
@@ -1,0 +1,135 @@
+import DataStore
+import SwiftUI
+
+/// A neutral pill showing a coloured dot and a tag name. Two sizes:
+/// `.detail` (interactive, with optional hover-to-remove X) and
+/// `.compact` (display-only, used in the meeting list).
+public struct TagPill: View {
+    public enum Size {
+        case detail
+        case compact
+
+        var height: CGFloat {
+            switch self {
+            case .detail: 22
+            case .compact: 17
+            }
+        }
+
+        var horizontalPadding: CGFloat {
+            switch self {
+            case .detail: 9
+            case .compact: 7
+            }
+        }
+
+        var cornerRadius: CGFloat {
+            switch self {
+            case .detail: 6
+            case .compact: 5
+            }
+        }
+
+        var dotDiameter: CGFloat {
+            switch self {
+            case .detail: 7
+            case .compact: 6
+            }
+        }
+
+        var dotTextGap: CGFloat {
+            switch self {
+            case .detail: 6
+            case .compact: 5
+            }
+        }
+
+        var font: Font {
+            switch self {
+            case .detail: .system(size: 11.5, weight: .medium)
+            case .compact: .system(size: 10.5, weight: .medium)
+            }
+        }
+    }
+
+    private let tag: TagData
+    private let size: Size
+    private let onRemove: (() -> Void)?
+
+    @State private var hovered = false
+    @State private var xHovered = false
+
+    /// Creates a tag pill.
+    /// - Parameters:
+    ///   - tag: The tag data to display.
+    ///   - size: `.detail` or `.compact`.
+    ///   - onRemove: If non-nil (`.detail` only), shows a hover-X that
+    ///     calls this closure on click.
+    public init(
+        tag: TagData,
+        size: Size,
+        onRemove: (() -> Void)? = nil
+    ) {
+        self.tag = tag
+        self.size = size
+        self.onRemove = onRemove
+    }
+
+    public var body: some View {
+        HStack(spacing: size.dotTextGap) {
+            Circle()
+                .fill(Color.tagSwatch(slot: tag.colorSlot))
+                .frame(width: size.dotDiameter, height: size.dotDiameter)
+
+            Text(tag.name)
+                .font(size.font)
+                .foregroundStyle(.ink)
+                .lineLimit(1)
+
+            if size == .detail, onRemove != nil {
+                removeButton
+            }
+        }
+        .padding(.horizontal, size.horizontalPadding)
+        .frame(height: size.height)
+        .background(
+            Color.neutralChip,
+            in: RoundedRectangle(cornerRadius: size.cornerRadius)
+        )
+        .onHover { hovered = $0 }
+    }
+
+    private var removeButton: some View {
+        Button {
+            onRemove?()
+        } label: {
+            Image(systemName: "xmark")
+                .font(.system(size: 8.5, weight: .medium))
+                .foregroundStyle(xHovered ? .signalRed : .inkTertiary)
+        }
+        .buttonStyle(.plain)
+        .opacity(hovered ? 1 : 0)
+        .onHover { xHovered = $0 }
+    }
+}
+
+#if DEBUG
+    #Preview("TagPill Sizes") {
+        let sampleTag = TagData(id: UUID(), name: "Customer", colorSlot: 0)
+        let sampleTag2 = TagData(id: UUID(), name: "Important", colorSlot: 1)
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Detail:").font(.caption)
+            HStack(spacing: 6) {
+                TagPill(tag: sampleTag, size: .detail, onRemove: {})
+                TagPill(tag: sampleTag2, size: .detail, onRemove: {})
+            }
+            Text("Compact:").font(.caption)
+            HStack(spacing: 5) {
+                TagPill(tag: sampleTag, size: .compact)
+                TagPill(tag: sampleTag2, size: .compact)
+            }
+        }
+        .padding()
+        .background(Color.paper)
+    }
+#endif

--- a/Packages/BiscottiKit/Sources/DesignSystem/TagPill.swift
+++ b/Packages/BiscottiKit/Sources/DesignSystem/TagPill.swift
@@ -75,22 +75,41 @@ public struct TagPill: View {
         self.onRemove = onRemove
     }
 
+    /// Whether this pill renders the interactive hover-to-remove X.
+    private var hasRemove: Bool {
+        size == .detail && onRemove != nil
+    }
+
+    /// Gap between the label and the remove X — tighter than the dot→text gap
+    /// so the X doesn't float, keeping the reserved space (when the X is hidden)
+    /// closer to centred.
+    private let removeGap: CGFloat = 3
+
+    /// Trailing inset. With a remove X we tuck it closer to the edge than the
+    /// leading padding, lowering the padding on both sides of the X.
+    private var trailingPadding: CGFloat {
+        hasRemove ? 5 : size.horizontalPadding
+    }
+
     public var body: some View {
-        HStack(spacing: size.dotTextGap) {
-            Circle()
-                .fill(Color.tagSwatch(slot: tag.colorSlot))
-                .frame(width: size.dotDiameter, height: size.dotDiameter)
+        HStack(spacing: removeGap) {
+            HStack(spacing: size.dotTextGap) {
+                Circle()
+                    .fill(Color.tagSwatch(slot: tag.colorSlot))
+                    .frame(width: size.dotDiameter, height: size.dotDiameter)
 
-            Text(tag.name)
-                .font(size.font)
-                .foregroundStyle(.ink)
-                .lineLimit(1)
+                Text(tag.name)
+                    .font(size.font)
+                    .foregroundStyle(.ink)
+                    .lineLimit(1)
+            }
 
-            if size == .detail, onRemove != nil {
+            if hasRemove {
                 removeButton
             }
         }
-        .padding(.horizontal, size.horizontalPadding)
+        .padding(.leading, size.horizontalPadding)
+        .padding(.trailing, trailingPadding)
         .frame(height: size.height)
         .background(
             Color.neutralChip,

--- a/Packages/BiscottiKit/Sources/DesignSystem/TagPill.swift
+++ b/Packages/BiscottiKit/Sources/DesignSystem/TagPill.swift
@@ -54,6 +54,7 @@ public struct TagPill: View {
 
     private let tag: TagData
     private let size: Size
+    private let onAccent: Bool
     private let onRemove: (() -> Void)?
 
     @State private var hovered = false
@@ -63,15 +64,21 @@ public struct TagPill: View {
     /// - Parameters:
     ///   - tag: The tag data to display.
     ///   - size: `.detail` or `.compact`.
+    ///   - onAccent: When `true` (compact pills on a selected row), renders
+    ///     with white-on-accent styling: white @18% fill, white text, and a
+    ///     0.5px white ring on the coloured dot. Default `false` keeps the
+    ///     standard neutral-chip appearance.
     ///   - onRemove: If non-nil (`.detail` only), shows a hover-X that
     ///     calls this closure on click.
     public init(
         tag: TagData,
         size: Size,
+        onAccent: Bool = false,
         onRemove: (() -> Void)? = nil
     ) {
         self.tag = tag
         self.size = size
+        self.onAccent = onAccent
         self.onRemove = onRemove
     }
 
@@ -97,10 +104,16 @@ public struct TagPill: View {
                 Circle()
                     .fill(Color.tagSwatch(slot: tag.colorSlot))
                     .frame(width: size.dotDiameter, height: size.dotDiameter)
+                    .overlay {
+                        if onAccent {
+                            Circle()
+                                .strokeBorder(Color.onAccentChipRing, lineWidth: 0.5)
+                        }
+                    }
 
                 Text(tag.name)
                     .font(size.font)
-                    .foregroundStyle(.ink)
+                    .foregroundStyle(onAccent ? .onAccent : .ink)
                     .lineLimit(1)
             }
 
@@ -112,7 +125,7 @@ public struct TagPill: View {
         .padding(.trailing, trailingPadding)
         .frame(height: size.height)
         .background(
-            Color.neutralChip,
+            onAccent ? Color.onAccentChipFill : Color.neutralChip,
             in: RoundedRectangle(cornerRadius: size.cornerRadius)
         )
         .onHover { hovered = $0 }

--- a/Packages/BiscottiKit/Sources/MeetingDetailUI/MeetingDetailView.swift
+++ b/Packages/BiscottiKit/Sources/MeetingDetailUI/MeetingDetailView.swift
@@ -389,12 +389,15 @@ private extension MeetingDetailView {
         })
     }
 
-    /// Header + calendar card + tab bar, measured for the chrome-height
-    /// preference key. AudioTransport is now pinned to the bottom of
-    /// the panel (see `pinnedTransportBar`), outside this scroll region.
+    /// Header + tags row + calendar card + tab bar, measured for the
+    /// chrome-height preference key. AudioTransport is now pinned to
+    /// the bottom of the panel (see `pinnedTransportBar`), outside
+    /// this scroll region.
     var chrome: some View {
         VStack(alignment: .leading, spacing: Tokens.spacingMD) {
             header
+
+            tagsRow
 
             if viewModel.showReTranscribeAfterCorrection {
                 reTranscribePrompt
@@ -416,6 +419,47 @@ private extension MeetingDetailView {
                     value: chromeProxy.size.height
                 )
         })
+    }
+
+    /// The tags row: detail-size pills with hover-remove, followed by
+    /// the Add affordance that anchors the tag picker popover. Always
+    /// present (even at zero tags, shows the empty-state Add button).
+    var tagsRow: some View {
+        FlowLayout(horizontalSpacing: 6, verticalSpacing: 6) {
+            ForEach(viewModel.appliedTags) { tag in
+                TagPill(tag: tag, size: .detail) {
+                    Task { await viewModel.removeTag(tag) }
+                }
+            }
+
+            Button {
+                viewModel.tagPickerOpen.toggle()
+            } label: {
+                TagAddButton(
+                    hasTags: !viewModel.appliedTags.isEmpty,
+                    isPickerOpen: viewModel.tagPickerOpen
+                )
+            }
+            .buttonStyle(.plain)
+            .popover(
+                isPresented: $viewModel.tagPickerOpen,
+                arrowEdge: .bottom
+            ) {
+                TagPickerPopover(
+                    catalogue: viewModel.catalogueTags,
+                    appliedTagIDs: viewModel.appliedTagIDs,
+                    onToggle: { tag in
+                        Task { await viewModel.toggleTag(tag) }
+                    },
+                    onCreate: { name in
+                        Task { await viewModel.createAndApply(name) }
+                    },
+                    onDismiss: {
+                        viewModel.tagPickerOpen = false
+                    }
+                )
+            }
+        }
     }
 
     var overflowMenu: some View {

--- a/Packages/BiscottiKit/Sources/MeetingDetailUI/MeetingDetailViewModel.swift
+++ b/Packages/BiscottiKit/Sources/MeetingDetailUI/MeetingDetailViewModel.swift
@@ -155,6 +155,14 @@ public final class MeetingDetailViewModel {
     /// Whether a delete operation is in progress.
     public private(set) var isDeleting: Bool = false
 
+    // MARK: - Tags
+
+    /// All tags in the catalogue, loaded from the store.
+    public private(set) var catalogueTags: [TagData] = []
+
+    /// Whether the tag picker popover is open.
+    public var tagPickerOpen: Bool = false
+
     // MARK: - Speaker mapping sheet
 
     /// The transcript ID for which the speaker mapping sheet is presented.
@@ -1016,6 +1024,7 @@ private extension MeetingDetailViewModel {
         summaryText = detail?.summary ?? ""
         editedSummary = detail?.editedSummary ?? false
         versions = detail?.versions ?? []
+        catalogueTags = try await core.store.allTags()
         let settings = try? await core.store.settings()
         aiAnalysisEnabled = settings?.aiAnalysisEnabled ?? true
     }
@@ -1368,6 +1377,59 @@ public extension MeetingDetailViewModel {
         summaryAutosaveTask = nil
         await core.deleteMeeting(meetingID: meetingID)
         isDeleting = false
+    }
+}
+
+// MARK: - Tag actions
+
+public extension MeetingDetailViewModel {
+    /// The IDs of tags currently applied to this meeting.
+    var appliedTagIDs: Set<UUID> {
+        Set(detail?.tags.map(\.id) ?? [])
+    }
+
+    /// Tags applied to this meeting (from detail data, already sorted).
+    var appliedTags: [TagData] {
+        detail?.tags ?? []
+    }
+
+    /// Toggles a tag's application on/off for this meeting.
+    func toggleTag(_ tag: TagData) async {
+        do {
+            if appliedTagIDs.contains(tag.id) {
+                try await core.store.removeTag(tagID: tag.id, from: meetingID)
+            } else {
+                try await core.store.applyTag(tagID: tag.id, to: meetingID)
+            }
+            try await refreshData()
+            await core.reloadSummaries()
+        } catch {
+            // Non-fatal
+        }
+    }
+
+    /// Creates a new tag and applies it to this meeting.
+    func createAndApply(_ name: String) async {
+        do {
+            _ = try await core.store.createTagAndApply(
+                name: name, to: meetingID
+            )
+            try await refreshData()
+            await core.reloadSummaries()
+        } catch {
+            // Non-fatal
+        }
+    }
+
+    /// Removes a tag's application from this meeting.
+    func removeTag(_ tag: TagData) async {
+        do {
+            try await core.store.removeTag(tagID: tag.id, from: meetingID)
+            try await refreshData()
+            await core.reloadSummaries()
+        } catch {
+            // Non-fatal
+        }
     }
 }
 

--- a/Packages/BiscottiKit/Sources/MeetingDetailUI/TagAddButton.swift
+++ b/Packages/BiscottiKit/Sources/MeetingDetailUI/TagAddButton.swift
@@ -1,0 +1,95 @@
+import DesignSystem
+import SwiftUI
+
+/// Ghost pill that opens the tag picker popover. Three visual states:
+///
+/// - **Has tags**: dashed neutral border, "+ Add tag" label.
+/// - **Empty** (0 tags): dashed sage border, "Add tags" label with tag glyph.
+/// - **Picker open**: solid sage border, active sage fill.
+struct TagAddButton: View {
+    let hasTags: Bool
+    let isPickerOpen: Bool
+
+    @State private var hovered = false
+
+    var body: some View {
+        HStack(spacing: 4) {
+            if hasTags {
+                Image(systemName: "plus")
+                    .font(.system(size: 11.5, weight: .medium))
+                    .foregroundStyle(textColor)
+            } else {
+                Image(systemName: "tag")
+                    .font(.system(size: 11.5, weight: .medium))
+                    .foregroundStyle(textColor)
+            }
+
+            Text(hasTags ? "Add tag" : "Add tags")
+                .font(.system(size: 11.5, weight: .medium))
+                .foregroundStyle(textColor)
+        }
+        .padding(.horizontal, 9)
+        .frame(height: 22)
+        .background(fillColor, in: shape)
+        .overlay(borderOverlay)
+        .onHover { hovered = $0 }
+    }
+
+    // MARK: - Styling
+
+    private var textColor: Color {
+        if isPickerOpen || !hasTags {
+            return .sage
+        }
+        return .inkSecondary
+    }
+
+    private var fillColor: Color {
+        if isPickerOpen {
+            return .softSageFill
+        }
+        if hovered {
+            return hasTags ? .neutralChip : .softSageFill
+        }
+        return .clear
+    }
+
+    private var borderOverlay: some View {
+        Group {
+            if isPickerOpen {
+                shape.strokeBorder(.sage, lineWidth: 1)
+            } else if hasTags {
+                shape.strokeBorder(
+                    hovered ? Color.ink.opacity(0.4) : Color.ink.opacity(0.26),
+                    style: StrokeStyle(lineWidth: 1, dash: [3, 2])
+                )
+            } else {
+                shape.strokeBorder(
+                    Color.sage.opacity(0.55),
+                    style: StrokeStyle(lineWidth: 1, dash: [3, 2])
+                )
+            }
+        }
+    }
+
+    private var shape: RoundedRectangle {
+        RoundedRectangle(cornerRadius: 6)
+    }
+}
+
+#if DEBUG
+    #Preview("TagAddButton States") {
+        VStack(spacing: 16) {
+            Text("Has tags:").font(.caption)
+            TagAddButton(hasTags: true, isPickerOpen: false)
+
+            Text("Empty:").font(.caption)
+            TagAddButton(hasTags: false, isPickerOpen: false)
+
+            Text("Picker open:").font(.caption)
+            TagAddButton(hasTags: true, isPickerOpen: true)
+        }
+        .padding()
+        .background(Color.paper)
+    }
+#endif

--- a/Packages/BiscottiKit/Sources/MeetingDetailUI/TagPickerLogic.swift
+++ b/Packages/BiscottiKit/Sources/MeetingDetailUI/TagPickerLogic.swift
@@ -1,0 +1,82 @@
+import DataStore
+import Foundation
+
+/// A single row in the tag picker, combining tag data with application state.
+public struct TagPickerRow: Sendable, Equatable, Identifiable {
+    public let tag: TagData
+    public let isApplied: Bool
+
+    public var id: UUID {
+        tag.id
+    }
+
+    public init(tag: TagData, isApplied: Bool) {
+        self.tag = tag
+        self.isApplied = isApplied
+    }
+}
+
+/// The result of the tag picker filtering computation.
+public struct TagPickerResult: Sendable, Equatable {
+    /// Filtered catalogue rows, alphabetical, each flagged `isApplied`.
+    public let rows: [TagPickerRow]
+
+    /// When non-nil, the trimmed query string to offer as a "Create" action.
+    /// Present when the trimmed query is non-empty and no catalogue tag
+    /// equals it case-insensitively.
+    public let createOption: String?
+}
+
+/// Pure filtering + create-visibility computation for the tag picker.
+///
+/// Given the full tag catalogue, the set of applied tag IDs, and a
+/// search query, returns the filtered rows and optional create-option
+/// string. Unit-testable with no UI dependency.
+///
+/// - Parameters:
+///   - catalogue: All tags in the catalogue (any order).
+///   - applied: IDs of tags currently applied to this meeting.
+///   - query: The user's current search text (may be empty).
+/// - Returns: A ``TagPickerResult`` with filtered rows and create metadata.
+public func computeTagPickerResult(
+    catalogue: [TagData],
+    applied: Set<UUID>,
+    query: String
+) -> TagPickerResult {
+    let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+
+    // Filter catalogue by case-insensitive contains
+    let filtered: [TagData]
+    if trimmed.isEmpty {
+        filtered = catalogue
+    } else {
+        let lowered = trimmed.lowercased()
+        filtered = catalogue.filter {
+            $0.name.lowercased().contains(lowered)
+        }
+    }
+
+    // Sort alphabetically (case-insensitive)
+    let sorted = filtered.sorted {
+        $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
+    }
+
+    // Build rows with isApplied flags
+    let rows = sorted.map { tag in
+        TagPickerRow(tag: tag, isApplied: applied.contains(tag.id))
+    }
+
+    // Create option: shown when trimmed query is non-empty and no
+    // catalogue tag (unfiltered) equals it case-insensitively
+    let createOption: String?
+    if !trimmed.isEmpty {
+        let exactMatch = catalogue.contains {
+            $0.name.caseInsensitiveCompare(trimmed) == .orderedSame
+        }
+        createOption = exactMatch ? nil : trimmed
+    } else {
+        createOption = nil
+    }
+
+    return TagPickerResult(rows: rows, createOption: createOption)
+}

--- a/Packages/BiscottiKit/Sources/MeetingDetailUI/TagPickerPopover.swift
+++ b/Packages/BiscottiKit/Sources/MeetingDetailUI/TagPickerPopover.swift
@@ -1,0 +1,230 @@
+import DataStore
+import DesignSystem
+import SwiftUI
+
+/// The filterable popover for adding and toggling tags on a meeting.
+///
+/// Modelled on `PersonPickerPopover` with one key difference:
+/// committing a catalogue row **toggles and keeps the popover open**
+/// (the person picker closes on select).
+struct TagPickerPopover: View {
+    let catalogue: [TagData]
+    let appliedTagIDs: Set<UUID>
+    let onToggle: (TagData) -> Void
+    let onCreate: (String) -> Void
+    let onDismiss: () -> Void
+
+    @State private var query = ""
+    @FocusState private var isSearchFocused: Bool
+    @State private var highlightedIndex: Int?
+
+    private var pickerResult: TagPickerResult {
+        computeTagPickerResult(
+            catalogue: catalogue,
+            applied: appliedTagIDs,
+            query: query
+        )
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            searchField
+            Divider()
+            listContent
+        }
+        .frame(width: 260)
+        .onAppear {
+            isSearchFocused = true
+        }
+    }
+
+    // MARK: - Search field
+
+    private var searchField: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: 12))
+                .foregroundStyle(.inkTertiary)
+
+            TextField("Add or create a tag\u{2026}", text: $query)
+                .textFieldStyle(.plain)
+                .font(.system(size: 13))
+                .focused($isSearchFocused)
+                .onChange(of: query) { _, _ in
+                    highlightedIndex = nil
+                }
+                .onKeyPress(.upArrow) {
+                    moveHighlight(by: -1)
+                    return .handled
+                }
+                .onKeyPress(.downArrow) {
+                    moveHighlight(by: 1)
+                    return .handled
+                }
+                .onKeyPress(.return) {
+                    commitHighlighted()
+                    return .handled
+                }
+                .onKeyPress(.escape) {
+                    onDismiss()
+                    return .handled
+                }
+        }
+        .padding(Tokens.spacingSM)
+    }
+
+    // MARK: - List content
+
+    private var listContent: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            tagsKicker
+            catalogueRows
+            createRow
+        }
+    }
+
+    // MARK: - Kicker
+
+    private var tagsKicker: some View {
+        Text("TAGS")
+            .kicker()
+            .foregroundStyle(.inkTertiary)
+            .padding(.horizontal, Tokens.spacingSM)
+            .padding(.top, 6)
+            .padding(.bottom, 2)
+    }
+
+    // MARK: - Catalogue rows
+
+    private var catalogueRows: some View {
+        ForEach(Array(pickerResult.rows.enumerated()), id: \.element.id) { index, row in
+            tagRow(row, index: index)
+        }
+    }
+
+    private func tagRow(_ row: TagPickerRow, index: Int) -> some View {
+        let isHighlighted = highlightedIndex == index
+        return Button {
+            onToggle(row.tag)
+        } label: {
+            HStack(spacing: 6) {
+                Circle()
+                    .fill(Color.tagSwatch(slot: row.tag.colorSlot))
+                    .frame(width: 7, height: 7)
+
+                Text(row.tag.name)
+                    .font(.system(size: 13))
+                    .foregroundStyle(.ink)
+                    .lineLimit(1)
+
+                Spacer()
+
+                if row.isApplied {
+                    Image(systemName: "checkmark")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundStyle(.sage)
+                }
+            }
+            .padding(.horizontal, Tokens.spacingSM)
+            .padding(.vertical, 6)
+            .background(highlightBackground(isHighlighted))
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - Create row
+
+    @ViewBuilder
+    private var createRow: some View {
+        if let createText = pickerResult.createOption {
+            let createIndex = pickerResult.rows.count
+            let isHighlighted = highlightedIndex == createIndex
+            Button {
+                onCreate(createText)
+                query = ""
+            } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: "plus")
+                        .font(.system(size: 12))
+                        .foregroundStyle(.sage)
+
+                    Text("Create \"\(createText)\"")
+                        .font(.system(size: 13))
+                        .foregroundStyle(.sage)
+
+                    Spacer()
+                }
+                .padding(.horizontal, Tokens.spacingSM)
+                .padding(.vertical, 6)
+                .background(highlightBackground(isHighlighted))
+            }
+            .buttonStyle(.plain)
+        }
+    }
+
+    // MARK: - Highlight background
+
+    private func highlightBackground(
+        _ isHighlighted: Bool
+    ) -> some ShapeStyle {
+        isHighlighted
+            ? AnyShapeStyle(Color.sage.opacity(0.15))
+            : AnyShapeStyle(Color.clear)
+    }
+
+    // MARK: - Keyboard navigation
+
+    private var selectableCount: Int {
+        pickerResult.rows.count + (pickerResult.createOption != nil ? 1 : 0)
+    }
+
+    private func moveHighlight(by delta: Int) {
+        guard selectableCount > 0 else { return }
+
+        if let current = highlightedIndex {
+            var next = current + delta
+            if next < 0 { next = selectableCount - 1 }
+            if next >= selectableCount { next = 0 }
+            highlightedIndex = next
+        } else {
+            highlightedIndex = delta > 0 ? 0 : selectableCount - 1
+        }
+    }
+
+    private func commitHighlighted() {
+        guard selectableCount > 0 else { return }
+
+        if let idx = highlightedIndex, idx < selectableCount {
+            if idx < pickerResult.rows.count {
+                onToggle(pickerResult.rows[idx].tag)
+            } else if let createText = pickerResult.createOption {
+                onCreate(createText)
+                query = ""
+            }
+        } else if let createText = pickerResult.createOption {
+            // No highlight but create is available -> perform create
+            onCreate(createText)
+            query = ""
+        }
+    }
+}
+
+#if DEBUG
+    #Preview("TagPickerPopover") {
+        let tags = [
+            TagData(id: UUID(), name: "Customer", colorSlot: 0),
+            TagData(id: UUID(), name: "Important", colorSlot: 1),
+            TagData(id: UUID(), name: "Follow-up", colorSlot: 2)
+        ]
+        let applied: Set<UUID> = [tags[0].id]
+        TagPickerPopover(
+            catalogue: tags,
+            appliedTagIDs: applied,
+            onToggle: { _ in },
+            onCreate: { _ in },
+            onDismiss: {}
+        )
+        .padding()
+        .background(Color.paper)
+    }
+#endif

--- a/Packages/BiscottiKit/Sources/MeetingListUI/MeetingListView.swift
+++ b/Packages/BiscottiKit/Sources/MeetingListUI/MeetingListView.swift
@@ -1,4 +1,5 @@
 import AppCore
+import AppKit
 import DataStore
 import DesignSystem
 import SwiftUI
@@ -44,15 +45,23 @@ public struct MeetingListView: View {
                     set: { viewModel.select($0) }
                 )
             ) {
+                // The suppressor must live INSIDE the List's content so its
+                // backing NSView is a descendant of the NSTableView.  Placing
+                // it on the first Section / row and walking *up* the superview
+                // chain guarantees we target THIS list's table, not a sibling.
                 switch viewModel.mode {
                 case .browse:
                     browseContent
+                        .background(SelectionHighlightSuppressor())
 
                 case .search:
                     searchContent
+                        .background(SelectionHighlightSuppressor())
                 }
             }
             .listStyle(.inset)
+            .scrollContentBackground(.hidden)
+            .background(Color.listPaneBackground)
             .onDeleteCommand {
                 viewModel.requestDeleteSelection()
             }
@@ -95,11 +104,15 @@ public struct MeetingListView: View {
 
     private var browseContent: some View {
         ForEach(viewModel.groups) { group in
-            Section(group.title) {
+            Section {
                 ForEach(group.meetings) { meeting in
                     meetingRow(meeting)
                         .tag(meeting.id)
                 }
+            } header: {
+                Text(group.title)
+                    .kicker()
+                    .foregroundStyle(.inkTertiary)
             }
         }
     }
@@ -126,23 +139,40 @@ public struct MeetingListView: View {
     // MARK: - Row views
 
     private func meetingRow(_ meeting: MeetingSummary) -> some View {
-        VStack(alignment: .leading, spacing: 2) {
+        let isSelected = viewModel.selectedIDs.contains(meeting.id)
+        return VStack(alignment: .leading, spacing: 2) {
             Text(meeting.title)
-                .font(.body)
+                .font(.system(size: 13.5, weight: .medium))
+                .foregroundStyle(isSelected ? .onAccent : .ink)
                 .lineLimit(1)
 
             Text(MeetingListViewModel.secondLineText(for: meeting))
-                .font(Tokens.metadataFont)
-                .foregroundStyle(Tokens.secondaryText)
+                .font(.monoMeta)
+                .foregroundStyle(isSelected ? .onAccentMuted : .inkSecondary)
 
             if !meeting.tags.isEmpty {
-                tagLine(meeting.tags)
+                tagLine(meeting.tags, isSelected: isSelected)
                     .padding(.top, 4)
             }
         }
+        .listRowSeparator(.hidden)
+        .listRowBackground(selectionBackground(isSelected))
     }
 
-    private func tagLine(_ tags: [TagData]) -> some View {
+    /// The custom selection background: solid sage fill when selected,
+    /// clear when not. Paints our own selection independent of the system accent.
+    @ViewBuilder
+    private func selectionBackground(_ isSelected: Bool) -> some View {
+        if isSelected {
+            RoundedRectangle(cornerRadius: 8)
+                .fill(Color.accentFill)
+                .padding(.horizontal, 8)
+        } else {
+            Color.clear
+        }
+    }
+
+    private func tagLine(_ tags: [TagData], isSelected: Bool) -> some View {
         let sorted = tags.sorted {
             $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
         }
@@ -151,32 +181,102 @@ public struct MeetingListView: View {
 
         return HStack(spacing: 5) {
             ForEach(visible) { tag in
-                TagPill(tag: tag, size: .compact)
+                TagPill(tag: tag, size: .compact, onAccent: isSelected)
             }
             if overflow > 0 {
                 Text("+\(overflow)")
                     .font(.monoBadge)
-                    .foregroundStyle(.inkSecondary)
+                    .foregroundStyle(
+                        isSelected ? .onAccentMuted : .inkTertiary
+                    )
             }
         }
     }
 
     private func searchRow(_ hit: SearchHit) -> some View {
-        VStack(alignment: .leading, spacing: 2) {
+        let isSelected = viewModel.selectedIDs.contains(hit.id)
+        return VStack(alignment: .leading, spacing: 2) {
             HStack {
                 Text(hit.title)
-                    .font(.body)
+                    .font(.system(size: 13.5, weight: .medium))
+                    .foregroundStyle(isSelected ? .onAccent : .ink)
                     .lineLimit(1)
                 Spacer()
                 Text(TimeFormatting.shortDate(hit.date))
                     .font(.monoMeta)
-                    .foregroundStyle(Tokens.secondaryText)
+                    .foregroundStyle(isSelected ? .onAccentMuted : .inkSecondary)
             }
             Text(
                 "matches: \(MeetingListViewModel.matchedFieldsText(hit.matchedFields))"
             )
             .font(.caption)
-            .foregroundStyle(Tokens.secondaryText)
+            .foregroundStyle(isSelected ? .onAccentMuted : .inkTertiary)
+        }
+        .listRowSeparator(.hidden)
+        .listRowBackground(selectionBackground(isSelected))
+    }
+}
+
+// MARK: - Selection highlight suppressor (AppKit bridge)
+
+/// An invisible `NSViewRepresentable` placed as a `.background()` on
+/// content **inside** the `List { … }` closure so its backing `NSView` is
+/// a descendant of the `NSTableView`.  It walks *up* the superview chain
+/// to find the enclosing `NSTableView` and sets
+/// `selectionHighlightStyle = .none`, suppressing the system-accent
+/// selection highlight entirely.  The selection *model* (keyboard nav,
+/// arrow keys, multi-select) is unaffected — only the visual drawing
+/// is suppressed, letting `MeetingListView` paint its own solid sage
+/// fill via `.listRowBackground`.
+///
+/// The suppression fires on three complementary triggers so it survives
+/// hierarchy rebuilds:
+///   1. `viewDidMoveToSuperview()` — first insertion into the table
+///   2. `viewDidMoveToWindow()` — window re-parenting / tab changes
+///   3. `updateNSView` — every SwiftUI re-render
+///
+/// Modeled on `SearchFieldFocuser` in `AppShellUI/AppShellView.swift`
+/// and the placement pattern from SwiftUI-Introspect (`scope: .ancestor`).
+private struct SelectionHighlightSuppressor: NSViewRepresentable {
+    func makeNSView(context _: Context) -> SuppressorView {
+        SuppressorView()
+    }
+
+    func updateNSView(_ nsView: SuppressorView, context _: Context) {
+        // Re-apply on every SwiftUI update in case the hierarchy is rebuilt.
+        nsView.suppressSelectionHighlight()
+    }
+
+    final class SuppressorView: NSView {
+        override func viewDidMoveToSuperview() {
+            super.viewDidMoveToSuperview()
+            suppressSelectionHighlight()
+        }
+
+        override func viewDidMoveToWindow() {
+            super.viewDidMoveToWindow()
+            suppressSelectionHighlight()
+        }
+
+        /// Walks up the superview chain to find the nearest `NSTableView`
+        /// and sets `selectionHighlightStyle = .none`.
+        func suppressSelectionHighlight() {
+            // Defer to the next run-loop tick so SwiftUI's hosting-view
+            // hierarchy is fully assembled before we walk it.
+            DispatchQueue.main.async { [weak self] in
+                guard let self else { return }
+                var ancestor: NSView? = superview
+                // Walk up at most 30 levels — the NSTableView is typically
+                // within ~5-10 levels when placed inside the List content.
+                for _ in 0 ..< 30 {
+                    guard let current = ancestor else { break }
+                    if let tableView = current as? NSTableView {
+                        tableView.selectionHighlightStyle = .none
+                        return
+                    }
+                    ancestor = current.superview
+                }
+            }
         }
     }
 }

--- a/Packages/BiscottiKit/Sources/MeetingListUI/MeetingListView.swift
+++ b/Packages/BiscottiKit/Sources/MeetingListUI/MeetingListView.swift
@@ -134,6 +134,30 @@ public struct MeetingListView: View {
             Text(MeetingListViewModel.secondLineText(for: meeting))
                 .font(Tokens.metadataFont)
                 .foregroundStyle(Tokens.secondaryText)
+
+            if !meeting.tags.isEmpty {
+                tagLine(meeting.tags)
+                    .padding(.top, 4)
+            }
+        }
+    }
+
+    private func tagLine(_ tags: [TagData]) -> some View {
+        let sorted = tags.sorted {
+            $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
+        }
+        let visible = Array(sorted.prefix(2))
+        let overflow = sorted.count - visible.count
+
+        return HStack(spacing: 5) {
+            ForEach(visible) { tag in
+                TagPill(tag: tag, size: .compact)
+            }
+            if overflow > 0 {
+                Text("+\(overflow)")
+                    .font(.monoBadge)
+                    .foregroundStyle(.inkSecondary)
+            }
         }
     }
 

--- a/Packages/BiscottiKit/Sources/MeetingListUI/MeetingListView.swift
+++ b/Packages/BiscottiKit/Sources/MeetingListUI/MeetingListView.swift
@@ -146,7 +146,7 @@ public struct MeetingListView: View {
         let sorted = tags.sorted {
             $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
         }
-        let visible = Array(sorted.prefix(2))
+        let visible = Array(sorted.prefix(3))
         let overflow = sorted.count - visible.count
 
         return HStack(spacing: 5) {

--- a/Packages/BiscottiKit/Sources/MeetingListUI/MeetingListViewModel.swift
+++ b/Packages/BiscottiKit/Sources/MeetingListUI/MeetingListViewModel.swift
@@ -294,6 +294,7 @@ public final class MeetingListViewModel {
             case .people: "people"
             case .transcript: "transcript"
             case .notes: "notes"
+            case .tags: "tags"
             }
         }.joined(separator: ", ")
     }

--- a/Packages/BiscottiKit/Tests/DataStoreTests/SearchTests.swift
+++ b/Packages/BiscottiKit/Tests/DataStoreTests/SearchTests.swift
@@ -195,3 +195,85 @@ struct SearchNotesTests {
         #expect(hits.isEmpty)
     }
 }
+
+// MARK: - Tag search tests (searchHits)
+
+@Suite("Search tags field (searchHits)")
+struct SearchTagsTests {
+    private func makeStore() throws -> DataStore {
+        try DataStore(storage: .inMemory)
+    }
+
+    @Test("Tag-only term matches meeting with score 3")
+    func tagOnlyMatch() async throws {
+        let store = try makeStore()
+        let meetingID = try await store.createMeeting(title: "Generic Meeting")
+        _ = try await store.createTagAndApply(name: "Customer", to: meetingID)
+
+        let hits = try await store.searchHits("customer", limit: 50)
+        #expect(hits.count == 1)
+        #expect(hits.first?.id == meetingID)
+        #expect(hits.first?.score == 3)
+        #expect(hits.first?.matchedFields.contains(.tags) == true)
+        #expect(hits.first?.matchedFields.contains(.title) == false)
+    }
+
+    @Test("Tag + title both match, scoring additively")
+    func tagPlusTitleScoring() async throws {
+        let store = try makeStore()
+        let meetingID = try await store.createMeeting(title: "Customer Review")
+        _ = try await store.createTagAndApply(name: "Customer", to: meetingID)
+
+        let hits = try await store.searchHits("customer", limit: 50)
+        #expect(hits.count == 1)
+        // title (3) + tags (3) = 6
+        #expect(hits.first?.score == 6)
+        #expect(hits.first?.matchedFields.contains(.title) == true)
+        #expect(hits.first?.matchedFields.contains(.tags) == true)
+    }
+
+    @Test("Tag search is case-insensitive")
+    func tagSearchCaseInsensitive() async throws {
+        let store = try makeStore()
+        let meetingID = try await store.createMeeting(title: "Standup")
+        _ = try await store.createTagAndApply(name: "IMPORTANT", to: meetingID)
+
+        let hits = try await store.searchHits("important", limit: 50)
+        #expect(hits.count == 1)
+        #expect(hits.first?.matchedFields.contains(.tags) == true)
+    }
+
+    @Test("Tag search matches partial name")
+    func tagSearchPartialMatch() async throws {
+        let store = try makeStore()
+        let meetingID = try await store.createMeeting(title: "Standup")
+        _ = try await store.createTagAndApply(name: "Customer", to: meetingID)
+
+        let hits = try await store.searchHits("custom", limit: 50)
+        #expect(hits.count == 1)
+        #expect(hits.first?.matchedFields.contains(.tags) == true)
+    }
+
+    @Test("Untagged meeting not matched by tag search")
+    func untaggedMeetingNotMatched() async throws {
+        let store = try makeStore()
+        _ = try await store.createMeeting(title: "Plain Meeting")
+
+        let hits = try await store.searchHits("customer", limit: 50)
+        #expect(hits.isEmpty)
+    }
+
+    @Test("Tags field sort order places tags after title")
+    func tagsFieldSortOrder() async throws {
+        let store = try makeStore()
+        let meetingID = try await store.createMeeting(title: "Review")
+        _ = try await store.createTagAndApply(name: "Review", to: meetingID)
+
+        let hits = try await store.searchHits("review", limit: 50)
+        #expect(hits.count == 1)
+        let fields = try #require(hits.first?.matchedFields)
+        // title should come before tags in sorted order
+        #expect(fields.first == .title)
+        #expect(fields.contains(.tags))
+    }
+}

--- a/Packages/BiscottiKit/Tests/DataStoreTests/TagTests.swift
+++ b/Packages/BiscottiKit/Tests/DataStoreTests/TagTests.swift
@@ -1,0 +1,231 @@
+import DataStore
+import Foundation
+import Testing
+
+@Suite("Tag operations")
+struct TagTests {
+    private func makeStore() throws -> DataStore {
+        try DataStore(storage: .inMemory)
+    }
+
+    // MARK: - createTag
+
+    @Test("Round-robin slot assignment cycles 0-7")
+    func roundRobinSlotAssignment() async throws {
+        let store = try makeStore()
+        var tags: [TagData] = []
+        for idx in 0 ..< 10 {
+            let tag = try await store.createTag(name: "Tag\(idx)")
+            try tags.append(#require(tag))
+        }
+        let expectedSlots = [0, 1, 2, 3, 4, 5, 6, 7, 0, 1]
+        #expect(tags.map(\.colorSlot) == expectedSlots)
+    }
+
+    @Test("Case-insensitive dedup returns existing tag")
+    func caseInsensitiveDedup() async throws {
+        let store = try makeStore()
+        let first = try #require(try await store.createTag(name: "Customer"))
+        let second = try #require(try await store.createTag(name: "customer"))
+        #expect(first.id == second.id)
+        // Name preserved from the original
+        #expect(second.name == "Customer")
+
+        let allTags = try await store.allTags()
+        #expect(allTags.count == 1)
+    }
+
+    @Test("Trim and empty rejection")
+    func trimAndEmptyRejection() async throws {
+        let store = try makeStore()
+        // Whitespace-only -> nil
+        let empty = try await store.createTag(name: "   ")
+        #expect(empty == nil)
+
+        // Newlines and tabs only -> nil
+        let newlinesOnly = try await store.createTag(name: "\t\n\r\n")
+        #expect(newlinesOnly == nil)
+
+        // Leading/trailing whitespace trimmed
+        let trimmed = try #require(try await store.createTag(name: " X "))
+        #expect(trimmed.name == "X")
+
+        // Leading/trailing newlines and tabs trimmed
+        let tabNewline = try #require(try await store.createTag(name: "\tCustomer\n"))
+        #expect(tabNewline.name == "Customer")
+
+        // Catalogue count should be 2 ("X" and "Customer")
+        let allTags = try await store.allTags()
+        #expect(allTags.count == 2)
+    }
+
+    @Test("allTags returns tags sorted alphabetically")
+    func allTagsSorted() async throws {
+        let store = try makeStore()
+        _ = try await store.createTag(name: "Zebra")
+        _ = try await store.createTag(name: "alpha")
+        _ = try await store.createTag(name: "Mango")
+
+        let allTags = try await store.allTags()
+        #expect(allTags.map(\.name) == ["alpha", "Mango", "Zebra"])
+    }
+
+    // MARK: - applyTag / removeTag
+
+    @Test("Apply is idempotent: applying twice creates one link")
+    func applyIdempotency() async throws {
+        let store = try makeStore()
+        let tag = try #require(try await store.createTag(name: "Important"))
+        let meetingID = try await store.createMeeting(title: "Test Meeting")
+
+        try await store.applyTag(tagID: tag.id, to: meetingID)
+        try await store.applyTag(tagID: tag.id, to: meetingID)
+
+        let detail = try #require(try await store.meetingDetail(id: meetingID))
+        #expect(detail.tags.count == 1)
+        #expect(detail.tags.first?.id == tag.id)
+    }
+
+    @Test("Remove keeps tag in catalogue")
+    func removeKeepsTagInCatalogue() async throws {
+        let store = try makeStore()
+        let tag = try #require(try await store.createTag(name: "Ephemeral"))
+        let meetingID = try await store.createMeeting(title: "Test")
+
+        try await store.applyTag(tagID: tag.id, to: meetingID)
+        try await store.removeTag(tagID: tag.id, from: meetingID)
+
+        // Tag removed from meeting
+        let detail = try #require(try await store.meetingDetail(id: meetingID))
+        #expect(detail.tags.isEmpty)
+
+        // Tag still in catalogue
+        let allTags = try await store.allTags()
+        #expect(allTags.count == 1)
+        #expect(allTags.first?.name == "Ephemeral")
+    }
+
+    @Test("Remove tag from one meeting preserves it on another")
+    func removeFromOneMeeting() async throws {
+        let store = try makeStore()
+        let tag = try #require(try await store.createTag(name: "Shared"))
+        let meeting1 = try await store.createMeeting(title: "Meeting 1")
+        let meeting2 = try await store.createMeeting(title: "Meeting 2")
+
+        try await store.applyTag(tagID: tag.id, to: meeting1)
+        try await store.applyTag(tagID: tag.id, to: meeting2)
+
+        try await store.removeTag(tagID: tag.id, from: meeting1)
+
+        let detail1 = try #require(try await store.meetingDetail(id: meeting1))
+        #expect(detail1.tags.isEmpty)
+
+        let detail2 = try #require(try await store.meetingDetail(id: meeting2))
+        #expect(detail2.tags.count == 1)
+        #expect(detail2.tags.first?.name == "Shared")
+    }
+
+    // MARK: - createTagAndApply
+
+    @Test("createTagAndApply creates and links atomically")
+    func createTagAndApplyAtomic() async throws {
+        let store = try makeStore()
+        let meetingID = try await store.createMeeting(title: "Test")
+
+        let tag = try #require(try await store.createTagAndApply(name: "Urgent", to: meetingID))
+        #expect(tag.name == "Urgent")
+
+        let detail = try #require(try await store.meetingDetail(id: meetingID))
+        #expect(detail.tags.count == 1)
+        #expect(detail.tags.first?.id == tag.id)
+    }
+
+    @Test("createTagAndApply with existing tag reuses and applies")
+    func createTagAndApplyReuses() async throws {
+        let store = try makeStore()
+        let existing = try #require(try await store.createTag(name: "Customer"))
+        let meetingID = try await store.createMeeting(title: "Test")
+
+        let result = try #require(try await store.createTagAndApply(name: "customer", to: meetingID))
+        #expect(result.id == existing.id)
+
+        let detail = try #require(try await store.meetingDetail(id: meetingID))
+        #expect(detail.tags.count == 1)
+    }
+
+    @Test("createTagAndApply with empty name returns nil")
+    func createTagAndApplyEmptyName() async throws {
+        let store = try makeStore()
+        let meetingID = try await store.createMeeting(title: "Test")
+
+        let result = try await store.createTagAndApply(name: "  ", to: meetingID)
+        #expect(result == nil)
+
+        let detail = try #require(try await store.meetingDetail(id: meetingID))
+        #expect(detail.tags.isEmpty)
+    }
+
+    // MARK: - Meeting deletion
+
+    @Test("Deleting a meeting preserves tags in catalogue")
+    func deleteMeetingPreservesTags() async throws {
+        let store = try makeStore()
+        let tag = try #require(try await store.createTag(name: "Persistent"))
+        let meeting1 = try await store.createMeeting(title: "Doomed")
+        let meeting2 = try await store.createMeeting(title: "Safe")
+
+        try await store.applyTag(tagID: tag.id, to: meeting1)
+        try await store.applyTag(tagID: tag.id, to: meeting2)
+
+        try await store.delete(meetingID: meeting1)
+
+        // Tag still exists in catalogue
+        let allTags = try await store.allTags()
+        #expect(allTags.count == 1)
+        #expect(allTags.first?.name == "Persistent")
+
+        // Tag still on the surviving meeting
+        let detail2 = try #require(try await store.meetingDetail(id: meeting2))
+        #expect(detail2.tags.count == 1)
+    }
+
+    // MARK: - Read models carry tags
+
+    @Test("meetingSummaries carries tags alphabetically sorted")
+    func summariesCarryTagsAlphabetically() async throws {
+        let store = try makeStore()
+        let meetingID = try await store.createMeeting(
+            title: "Tagged",
+            start: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+        _ = try await store.createTagAndApply(name: "Zebra", to: meetingID)
+        _ = try await store.createTagAndApply(name: "Alpha", to: meetingID)
+        _ = try await store.createTagAndApply(name: "middle", to: meetingID)
+
+        let summaries = try await store.meetingSummaries()
+        let meeting = try #require(summaries.first(where: { $0.id == meetingID }))
+        #expect(meeting.tags.count == 3)
+        #expect(meeting.tags.map(\.name) == ["Alpha", "middle", "Zebra"])
+    }
+
+    @Test("meetingDetail carries tags alphabetically sorted")
+    func detailCarriesTagsAlphabetically() async throws {
+        let store = try makeStore()
+        let meetingID = try await store.createMeeting(title: "Tagged")
+        _ = try await store.createTagAndApply(name: "Beta", to: meetingID)
+        _ = try await store.createTagAndApply(name: "Alpha", to: meetingID)
+
+        let detail = try #require(try await store.meetingDetail(id: meetingID))
+        #expect(detail.tags.count == 2)
+        #expect(detail.tags.map(\.name) == ["Alpha", "Beta"])
+    }
+
+    @Test("Untagged meetings have empty tags in summaries")
+    func untaggedMeetingsEmptyTags() async throws {
+        let store = try makeStore()
+        _ = try await store.createMeeting(title: "Plain")
+
+        let summaries = try await store.meetingSummaries()
+        #expect(summaries.first?.tags.isEmpty == true)
+    }
+}

--- a/Packages/BiscottiKit/Tests/DesignSystemTests/FlowLayoutTests.swift
+++ b/Packages/BiscottiKit/Tests/DesignSystemTests/FlowLayoutTests.swift
@@ -1,0 +1,138 @@
+import SwiftUI
+import Testing
+@testable import DesignSystem
+
+/// Tests for `FlowLayout` geometry. Exercises the production
+/// `computeRows(sizes:containerWidth:)` and `layoutSize(rows:)` functions
+/// directly with concrete `[CGSize]` inputs — no mock subview proxies needed.
+@Suite("FlowLayout geometry")
+struct FlowLayoutTests {
+    // MARK: - Helper
+
+    /// Creates a FlowLayout and computes rows from an array of child sizes
+    /// using the production row-computation code path.
+    private func computeRows(
+        childSizes: [CGSize],
+        containerWidth: CGFloat,
+        hSpacing: CGFloat = 6,
+        vSpacing: CGFloat = 6
+    ) -> (rows: [FlowLayout.Row], totalSize: CGSize) {
+        let layout = FlowLayout(
+            horizontalSpacing: hSpacing,
+            verticalSpacing: vSpacing
+        )
+
+        let rows = layout.computeRows(
+            sizes: childSizes,
+            containerWidth: containerWidth
+        )
+        let totalSize = layout.layoutSize(rows: rows)
+        return (rows, totalSize)
+    }
+
+    // MARK: - Tests
+
+    @Test("Empty children produce zero size")
+    func emptyChildren() {
+        let (rows, size) = computeRows(
+            childSizes: [], containerWidth: 200
+        )
+        #expect(rows.isEmpty)
+        #expect(size == .zero)
+    }
+
+    @Test("Single child fits in one row")
+    func singleChild() {
+        let (rows, size) = computeRows(
+            childSizes: [CGSize(width: 50, height: 20)],
+            containerWidth: 200
+        )
+        #expect(rows.count == 1)
+        #expect(rows[0].items.count == 1)
+        #expect(size.width == 50)
+        #expect(size.height == 20)
+    }
+
+    @Test("Multiple children fit in one row")
+    func allFitOneRow() {
+        // 50 + 6 + 50 + 6 + 50 = 162, fits in 200
+        let (rows, size) = computeRows(
+            childSizes: [
+                CGSize(width: 50, height: 20),
+                CGSize(width: 50, height: 20),
+                CGSize(width: 50, height: 20)
+            ],
+            containerWidth: 200
+        )
+        #expect(rows.count == 1)
+        #expect(rows[0].items.count == 3)
+        #expect(size.width == 162) // 50 + 6 + 50 + 6 + 50
+        #expect(size.height == 20)
+    }
+
+    @Test("Children wrap to a second row when width exceeded")
+    func wrapsToSecondRow() {
+        // Row 1: 80 + 6 + 80 = 166 (fits in 200)
+        // Row 2: 80 (wraps, since 166 + 6 + 80 = 252 > 200)
+        let (rows, size) = computeRows(
+            childSizes: [
+                CGSize(width: 80, height: 20),
+                CGSize(width: 80, height: 20),
+                CGSize(width: 80, height: 25)
+            ],
+            containerWidth: 200
+        )
+        #expect(rows.count == 2)
+        #expect(rows[0].items.count == 2)
+        #expect(rows[1].items.count == 1)
+        // Total height = 20 (row 1) + 6 (spacing) + 25 (row 2)
+        #expect(size.height == 51)
+    }
+
+    @Test("Each child on its own row when very narrow")
+    func eachOnOwnRow() {
+        let (rows, size) = computeRows(
+            childSizes: [
+                CGSize(width: 50, height: 15),
+                CGSize(width: 50, height: 15),
+                CGSize(width: 50, height: 15)
+            ],
+            containerWidth: 60,
+            hSpacing: 6,
+            vSpacing: 4
+        )
+        #expect(rows.count == 3)
+        // 15 + 4 + 15 + 4 + 15 = 53
+        #expect(size.height == 53)
+        #expect(size.width == 50)
+    }
+
+    @Test("Custom spacing is applied")
+    func customSpacing() {
+        // With hSpacing=10: 50 + 10 + 50 = 110
+        let (rows, size) = computeRows(
+            childSizes: [
+                CGSize(width: 50, height: 20),
+                CGSize(width: 50, height: 20)
+            ],
+            containerWidth: 200,
+            hSpacing: 10
+        )
+        #expect(rows.count == 1)
+        #expect(size.width == 110)
+    }
+
+    @Test("Row height is the tallest child in that row")
+    func tallestChildSetsRowHeight() {
+        let (rows, _) = computeRows(
+            childSizes: [
+                CGSize(width: 40, height: 10),
+                CGSize(width: 40, height: 30),
+                CGSize(width: 40, height: 20)
+            ],
+            containerWidth: 300
+        )
+        #expect(rows.count == 1)
+        #expect(rows[0].height == 30)
+    }
+}

--- a/Packages/BiscottiKit/Tests/DesignSystemTests/TagPaletteTests.swift
+++ b/Packages/BiscottiKit/Tests/DesignSystemTests/TagPaletteTests.swift
@@ -1,0 +1,111 @@
+import AppKit
+import Foundation
+import SwiftUI
+import Testing
+@testable import DesignSystem
+
+// MARK: - Helpers
+
+/// Resolved sRGB color components for comparison.
+private struct SRGB {
+    let red: CGFloat
+    let green: CGFloat
+    let blue: CGFloat
+    let alpha: CGFloat
+}
+
+private func resolve(
+    _ color: Color, appearance appearanceName: NSAppearance.Name
+) -> SRGB {
+    let nsColor = NSColor(color)
+    var result = SRGB(red: 0, green: 0, blue: 0, alpha: 0)
+    // swiftlint:disable:next force_unwrapping
+    NSAppearance(named: appearanceName)!.performAsCurrentDrawingAppearance {
+        // swiftlint:disable:next force_unwrapping
+        let resolved = nsColor.usingColorSpace(.sRGB)!
+        result = SRGB(
+            red: resolved.redComponent,
+            green: resolved.greenComponent,
+            blue: resolved.blueComponent,
+            alpha: resolved.alphaComponent
+        )
+    }
+    return result
+}
+
+/// Sub-8-bit tolerance.
+private let tolerance: CGFloat = 1.0 / 512.0
+
+private func assertClose(
+    _ actual: CGFloat, _ expected: CGFloat, label: String,
+    sourceLocation: SourceLocation = #_sourceLocation
+) {
+    #expect(
+        abs(actual - expected) <= tolerance,
+        "\(label): expected \(expected), got \(actual)",
+        sourceLocation: sourceLocation
+    )
+}
+
+// MARK: - Tests
+
+@Suite("Tag palette")
+struct TagPaletteTests {
+    @Test("tagSwatches has exactly 8 entries")
+    func paletteCount() {
+        #expect(Color.tagSwatches.count == 8)
+    }
+
+    @Test("tagSwatch wraps positive indices")
+    func wrapPositive() {
+        // Slot 9 should equal slot 1, slot 16 equals slot 0, etc.
+        let swatch9 = resolve(Color.tagSwatch(slot: 9), appearance: .aqua)
+        let swatch1 = resolve(Color.tagSwatch(slot: 1), appearance: .aqua)
+        assertClose(swatch9.red, swatch1.red, label: "slot 9 vs 1 red")
+        assertClose(swatch9.green, swatch1.green, label: "slot 9 vs 1 green")
+        assertClose(swatch9.blue, swatch1.blue, label: "slot 9 vs 1 blue")
+
+        let swatch16 = resolve(Color.tagSwatch(slot: 16), appearance: .aqua)
+        let swatch0 = resolve(Color.tagSwatch(slot: 0), appearance: .aqua)
+        assertClose(swatch16.red, swatch0.red, label: "slot 16 vs 0 red")
+        assertClose(swatch16.green, swatch0.green, label: "slot 16 vs 0 green")
+        assertClose(swatch16.blue, swatch0.blue, label: "slot 16 vs 0 blue")
+    }
+
+    @Test("tagSwatch wraps negative indices")
+    func wrapNegative() {
+        // Slot -1 should equal slot 7
+        let swatchNeg1 = resolve(Color.tagSwatch(slot: -1), appearance: .aqua)
+        let swatch7 = resolve(Color.tagSwatch(slot: 7), appearance: .aqua)
+        assertClose(swatchNeg1.red, swatch7.red, label: "slot -1 vs 7 red")
+        assertClose(swatchNeg1.green, swatch7.green, label: "slot -1 vs 7 green")
+        assertClose(swatchNeg1.blue, swatch7.blue, label: "slot -1 vs 7 blue")
+
+        // Slot -8 should equal slot 0
+        let swatchNeg8 = resolve(Color.tagSwatch(slot: -8), appearance: .aqua)
+        let swatch0 = resolve(Color.tagSwatch(slot: 0), appearance: .aqua)
+        assertClose(swatchNeg8.red, swatch0.red, label: "slot -8 vs 0 red")
+        assertClose(swatchNeg8.green, swatch0.green, label: "slot -8 vs 0 green")
+        assertClose(swatchNeg8.blue, swatch0.blue, label: "slot -8 vs 0 blue")
+    }
+
+    @Test("Slot 4 matches signalRed in light mode")
+    func slot4MatchesSignalRedLight() {
+        let slot4 = resolve(Color.tagSwatch(slot: 4), appearance: .aqua)
+        let red = resolve(Color.signalRed, appearance: .aqua)
+        assertClose(slot4.red, red.red, label: "slot4 vs signalRed light red")
+        assertClose(slot4.green, red.green, label: "slot4 vs signalRed light green")
+        assertClose(slot4.blue, red.blue, label: "slot4 vs signalRed light blue")
+        assertClose(slot4.alpha, red.alpha, label: "slot4 vs signalRed light alpha")
+    }
+
+    @Test("Slot 4 matches signalRed in dark mode")
+    func slot4MatchesSignalRedDark() {
+        let slot4 = resolve(Color.tagSwatch(slot: 4), appearance: .darkAqua)
+        let red = resolve(Color.signalRed, appearance: .darkAqua)
+        assertClose(slot4.red, red.red, label: "slot4 vs signalRed dark red")
+        assertClose(slot4.green, red.green, label: "slot4 vs signalRed dark green")
+        assertClose(slot4.blue, red.blue, label: "slot4 vs signalRed dark blue")
+        assertClose(slot4.alpha, red.alpha, label: "slot4 vs signalRed dark alpha")
+    }
+}

--- a/Packages/BiscottiKit/Tests/MeetingDetailUITests/TagPickerLogicTests.swift
+++ b/Packages/BiscottiKit/Tests/MeetingDetailUITests/TagPickerLogicTests.swift
@@ -1,0 +1,238 @@
+import DataStore
+import Foundation
+import Testing
+@testable import MeetingDetailUI
+
+// MARK: - Test helpers
+
+private func makeTag(
+    name: String, colorSlot: Int = 0
+) -> TagData {
+    TagData(id: UUID(), name: name, colorSlot: colorSlot)
+}
+
+// MARK: - Filtering tests
+
+@Suite("Tag picker logic -- filtering")
+struct TagPickerFilteringTests {
+    @Test("contains filter matches substring case-insensitively")
+    func containsFilter() {
+        let tags = [
+            makeTag(name: "Customer", colorSlot: 0),
+            makeTag(name: "Important", colorSlot: 1),
+            makeTag(name: "Custom Build", colorSlot: 2)
+        ]
+
+        let result = computeTagPickerResult(
+            catalogue: tags, applied: [], query: "cus"
+        )
+
+        #expect(result.rows.count == 2)
+        #expect(result.rows[0].tag.name == "Custom Build")
+        #expect(result.rows[1].tag.name == "Customer")
+    }
+
+    @Test("case-insensitive filter")
+    func caseInsensitiveFilter() {
+        let tags = [makeTag(name: "customer")]
+
+        let result = computeTagPickerResult(
+            catalogue: tags, applied: [], query: "CUS"
+        )
+
+        #expect(result.rows.count == 1)
+        #expect(result.rows[0].tag.name == "customer")
+    }
+
+    @Test("empty query shows all tags")
+    func emptyQueryShowsAll() {
+        let tags = [
+            makeTag(name: "Alpha"),
+            makeTag(name: "Beta"),
+            makeTag(name: "Gamma")
+        ]
+
+        let result = computeTagPickerResult(
+            catalogue: tags, applied: [], query: ""
+        )
+
+        #expect(result.rows.count == 3)
+    }
+
+    @Test("no matches returns empty rows")
+    func noMatches() {
+        let tags = [makeTag(name: "Customer")]
+
+        let result = computeTagPickerResult(
+            catalogue: tags, applied: [], query: "zzz"
+        )
+
+        #expect(result.rows.isEmpty)
+    }
+
+    @Test("rows sorted alphabetically case-insensitive")
+    func alphabeticalOrdering() {
+        let tags = [
+            makeTag(name: "Zebra"),
+            makeTag(name: "alpha"),
+            makeTag(name: "Beta")
+        ]
+
+        let result = computeTagPickerResult(
+            catalogue: tags, applied: [], query: ""
+        )
+
+        #expect(result.rows.count == 3)
+        #expect(result.rows[0].tag.name == "alpha")
+        #expect(result.rows[1].tag.name == "Beta")
+        #expect(result.rows[2].tag.name == "Zebra")
+    }
+}
+
+// MARK: - isApplied tests
+
+@Suite("Tag picker logic -- isApplied flags")
+struct TagPickerIsAppliedTests {
+    @Test("applied tags flagged correctly")
+    func isAppliedFlags() {
+        let tag1 = makeTag(name: "Customer")
+        let tag2 = makeTag(name: "Important")
+        let tag3 = makeTag(name: "Follow-up")
+
+        let result = computeTagPickerResult(
+            catalogue: [tag1, tag2, tag3],
+            applied: [tag1.id, tag3.id],
+            query: ""
+        )
+
+        #expect(result.rows.count == 3)
+        let byName = Dictionary(
+            uniqueKeysWithValues: result.rows.map { ($0.tag.name, $0.isApplied) }
+        )
+        #expect(byName["Customer"] == true)
+        #expect(byName["Important"] == false)
+        #expect(byName["Follow-up"] == true)
+    }
+
+    @Test("applied flag persists through filtering")
+    func isAppliedWithFilter() {
+        let tag1 = makeTag(name: "Customer")
+        let tag2 = makeTag(name: "Custom Build")
+
+        let result = computeTagPickerResult(
+            catalogue: [tag1, tag2],
+            applied: [tag1.id],
+            query: "cus"
+        )
+
+        #expect(result.rows.count == 2)
+        let customer = result.rows.first { $0.tag.name == "Customer" }
+        let customBuild = result.rows.first { $0.tag.name == "Custom Build" }
+        #expect(customer?.isApplied == true)
+        #expect(customBuild?.isApplied == false)
+    }
+}
+
+// MARK: - Create option tests
+
+@Suite("Tag picker logic -- create option")
+struct TagPickerCreateOptionTests {
+    @Test("create option shown for new name")
+    func createOptionShown() {
+        let tags = [makeTag(name: "Customer")]
+
+        let result = computeTagPickerResult(
+            catalogue: tags, applied: [], query: "NewTag"
+        )
+
+        #expect(result.createOption == "NewTag")
+    }
+
+    @Test("create option hidden for exact case-insensitive match")
+    func createOptionHiddenExactMatch() {
+        let tags = [makeTag(name: "Customer")]
+
+        let result = computeTagPickerResult(
+            catalogue: tags, applied: [], query: "Customer"
+        )
+
+        #expect(result.createOption == nil)
+    }
+
+    @Test("create option hidden for case-insensitive match")
+    func createOptionCaseInsensitive() {
+        let tags = [makeTag(name: "Customer")]
+
+        let result = computeTagPickerResult(
+            catalogue: tags, applied: [], query: "customer"
+        )
+
+        #expect(result.createOption == nil)
+    }
+
+    @Test("create option nil for empty query")
+    func createOptionNilEmpty() {
+        let result = computeTagPickerResult(
+            catalogue: [], applied: [], query: ""
+        )
+
+        #expect(result.createOption == nil)
+    }
+
+    @Test("create option nil for whitespace-only query")
+    func createOptionNilWhitespace() {
+        let result = computeTagPickerResult(
+            catalogue: [], applied: [], query: "   \t  "
+        )
+
+        #expect(result.createOption == nil)
+    }
+
+    @Test("create option uses trimmed query text")
+    func createOptionTrimmed() {
+        let result = computeTagPickerResult(
+            catalogue: [], applied: [], query: "  NewTag  "
+        )
+
+        #expect(result.createOption == "NewTag")
+    }
+
+    @Test("create option shown with empty catalogue")
+    func createOptionEmptyCatalogue() {
+        let result = computeTagPickerResult(
+            catalogue: [], applied: [], query: "FirstTag"
+        )
+
+        #expect(result.rows.isEmpty)
+        #expect(result.createOption == "FirstTag")
+    }
+
+    @Test("exact match check uses full catalogue, not filtered results")
+    func exactMatchCheckFullCatalogue() {
+        // "Zebra" is in the catalogue but won't match the filter "Customer"
+        // -- the create option should still be hidden when query exactly
+        // matches a catalogue entry
+        let tags = [
+            makeTag(name: "Customer"),
+            makeTag(name: "Zebra")
+        ]
+
+        let result = computeTagPickerResult(
+            catalogue: tags, applied: [], query: "Zebra"
+        )
+
+        // "Zebra" matches in the filter and is an exact match in catalogue
+        #expect(result.createOption == nil)
+    }
+
+    @Test("create option shown when query partially matches but is not exact")
+    func partialMatchShowsCreate() {
+        let tags = [makeTag(name: "Customer")]
+
+        let result = computeTagPickerResult(
+            catalogue: tags, applied: [], query: "Cust"
+        )
+
+        #expect(result.createOption == "Cust")
+    }
+}

--- a/Packages/BiscottiKit/Tests/MeetingListUITests/MeetingListViewModelTests.swift
+++ b/Packages/BiscottiKit/Tests/MeetingListUITests/MeetingListViewModelTests.swift
@@ -263,4 +263,15 @@ struct MeetingListMatchedFieldsTests {
         let notesOnly = MeetingListViewModel.matchedFieldsText([.notes])
         #expect(notesOnly == "notes")
     }
+
+    @Test("includes tags field")
+    func matchedFieldsTextIncludesTags() {
+        let text = MeetingListViewModel.matchedFieldsText(
+            [.title, .tags]
+        )
+        #expect(text == "title, tags")
+
+        let tagsOnly = MeetingListViewModel.matchedFieldsText([.tags])
+        #expect(tagsOnly == "tags")
+    }
 }

--- a/specs/projects/meeting_tags/architecture.md
+++ b/specs/projects/meeting_tags/architecture.md
@@ -1,0 +1,281 @@
+---
+status: complete
+---
+
+# Architecture: Meeting Tags
+
+Single-file architecture (small/medium project; no `/components` docs). All logic lives in
+`BiscottiKit` packages so it runs under `swift test`. References to existing code are
+`file:line` from the repo.
+
+Module placement:
+
+- **DataStore** — `Tag` model, `Meeting.tags`, schema registration, tag API, `TagData`
+  DTO, read-model + search changes.
+- **DesignSystem** — tag-dot palette, `TagPill`, `FlowLayout`.
+- **MeetingListUI** — compact tag line in the row.
+- **MeetingDetailUI** — `TagAddButton`, `TagPickerPopover`, pure picker-result fn, view-model
+  wiring, tags row in `chrome`.
+
+---
+
+## 1 · Data model
+
+### Tag entity (new) — `DataStore/Models/Tag.swift`
+
+Mirrors the `Person` shared-entity / many-to-many pattern (`Person.swift:16-20`).
+
+```swift
+@Model
+public final class Tag {
+    public var id: UUID
+    public var name: String          // trimmed, case-insensitively unique
+    public var colorSlot: Int        // 0–7, stable palette index (round-robin at creation)
+    public var createdAt: Date       // assignment order / tie-break
+
+    @Relationship(inverse: \Meeting.tags)
+    public var meetings: [Meeting] = []
+
+    public init(id: UUID = UUID(), name: String, colorSlot: Int, createdAt: Date) { … }
+}
+```
+
+### Meeting relationship — `Meeting.swift`
+
+Bare `@Relationship` (no cascade — deleting a meeting must NOT delete shared tags), default
+empty array (additive):
+
+```swift
+@Relationship public var tags: [Tag] = []
+```
+
+### Schema registration — `DataStoreSchemaV1.swift:8-19`
+
+Add `Tag.self` to `DataStoreSchemaV1.models`. **Extend V1 directly** (do not introduce V2):
+the app is pre-release with no shipped persistent stores, and the V1 list has been grown
+incrementally through Stage A. Adding a new entity + a defaulted relationship is a
+lightweight, additive change SwiftData handles automatically; the un-wired
+`DataStoreMigrationPlan` (`DataStore.swift:52-53`) stays un-wired. (Risk: a developer's
+local store auto-migrates; worst case they delete it — acceptable pre-release.)
+
+### Ordering note
+
+SwiftData to-many relationships are unordered, so all tag rendering and DTO population sort
+**alphabetically** (`localizedStandardCompare`, case-insensitive). This is the single
+behavioural deviation from "order applied" (functional spec §5.1).
+
+---
+
+## 2 · DataStore API (actor methods)
+
+New `TagData` DTO (Sendable, crosses the actor boundary; `@Model Tag` never leaves it):
+
+```swift
+public struct TagData: Sendable, Identifiable, Equatable, Hashable {
+    public let id: UUID
+    public let name: String
+    public let colorSlot: Int
+}
+```
+
+New actor methods (best-effort, non-throwing — same style as `setNotes`):
+
+| Method | Behaviour |
+|---|---|
+| `allTags() -> [TagData]` | Fetch all `Tag`, sort by name, map to DTO. |
+| `createTag(name:) -> TagData?` | Trim; if empty → `nil`. If a tag exists whose name `==` case-insensitively → return it (no dup). Else `colorSlot = currentTagCount % 8`, insert with `createdAt = .now`, save, return DTO. |
+| `applyTag(tagID:to:)` | Fetch tag + meeting; append to `meeting.tags` if absent; save. No-op if already applied. |
+| `removeTag(tagID:from:)` | Remove tag from `meeting.tags`; save. Never deletes the `Tag`. |
+| `createTagAndApply(name:to:) -> TagData?` | Atomic find-or-create (as `createTag`) then apply; returns the tag. Used by the picker "Create" row to avoid a two-round-trip race. |
+
+Round-robin uses `currentTagCount` (a `FetchDescriptor<Tag>` count) at creation time; with no
+deletion in V1, count == creation order, so slots cycle `0,1,…,7,0,1,…`.
+
+### Read-model changes — `DataStore+ReadModels.swift`
+
+- Add `tags: [TagData]` to **`MeetingSummary`** (`:7`) and **`MeetingDetailData`** (`:41`),
+  each populated from `meeting.tags` mapped + alphabetically sorted in
+  `meetingSummaries(limit:)` (`:341`) and `meetingDetail(id:)` (`:379`).
+
+---
+
+## 3 · Search indexing — `DataStore+ReadModels.swift`
+
+- **`SearchField`** enum (`:296`): add `case tags`.
+- **`scoreMeeting(_:terms:)`** (`:643-687`): add a block in the `for term in terms` loop,
+  parallel to the notes check:
+
+  ```swift
+  if meeting.tags.contains(where: {
+      $0.name.lowercased().localizedStandardContains(term)
+  }) {
+      score += 3            // weight 3 — equal to a title match
+      fields.insert(.tags)
+  }
+  ```
+
+- **`fieldSortOrder`** (`:727-734`): give `.tags` an order slot (after `.title`, e.g. value
+  reflecting its weight).
+- **`matchedFieldsText`** in `MeetingListViewModel.swift:288-299`: add `case .tags: "tags"`.
+
+No changes to AppCore/AppShell/MeetingListView search plumbing — they're generic over
+`SearchHit`/`SearchField`. The legacy `search(_:)` (`DataStore+Phase3_2.swift:329`) is left
+unchanged (only used by old tests; live path is `searchHits`).
+
+---
+
+## 4 · UI components
+
+### 4.1 Tag-dot palette — `DesignSystem/Color+Theme.swift`
+
+An ordered 8-element palette of adaptive colours via `dynamicColor(light:dark:)` (values in
+ui_design.md §6), exposed as:
+
+```swift
+public extension Color {
+    static let tagSwatches: [Color] = [ … 8 dynamicColor pairs … ]
+    static func tagSwatch(slot: Int) -> Color { tagSwatches[((slot % 8) + 8) % 8] }
+}
+```
+
+Slot 4 (Red) reuses the existing `signalRed` pair. Sage is never in the palette.
+
+### 4.2 `TagPill` — `DesignSystem/TagPill.swift`
+
+`public struct TagPill: View` with a `Size` enum (`.detail` / `.compact`) carrying the
+constants from ui_design.md §1. Built like `SourcePill` (HStack: dot circle + `Text`,
+`neutralChip` fill, `RoundedRectangle`). Takes `TagData` (uses `colorSlot` →
+`Color.tagSwatch(slot:)`). The **detail** size optionally takes an `onRemove: (() -> Void)?`;
+when non-nil it renders the hover-✕ (state + opacity per ui_design.md §3). Compact passes
+`nil` (display-only).
+
+### 4.3 `FlowLayout` — `DesignSystem/FlowLayout.swift`
+
+A small `Layout`-protocol conformance (none exists in the repo) that lays children
+left-to-right and wraps to the next line, with configurable spacing. Used by the detail tags
+row. Pure geometry → unit-testable; keep it minimal.
+
+### 4.4 `TagAddButton` — `MeetingDetailUI/TagAddButton.swift`
+
+Ghost pill (detail dimensions) with the three states (has-tags / empty / picker-open) from
+ui_design.md §4; dashed border via `strokeBorder(style: StrokeStyle(dash:))`. Hover state via
+`@State`. Acts as the popover anchor.
+
+### 4.5 `TagPickerPopover` — `MeetingDetailUI/TagPickerPopover.swift`
+
+Modelled on `PersonPickerPopover` (`SpeakerMappingSheet.swift:179`). Width 260. Search/create
+field (auto-focused) → "TAGS" kicker → catalogue rows (dot + name + sage ✓ if applied) →
+create row. Keyboard nav (↑/↓/↩/⎋) carried over; **committing a catalogue row toggles and
+keeps the popover open** (differs from the person picker, which closes on select).
+
+The filtering/create-visibility logic is a **pure function** (testable, mirrors
+`computePersonPickerResult`):
+
+```swift
+struct TagPickerResult { let rows: [TagRow]; let createOption: String? }   // TagRow = TagData + isApplied
+func computeTagPickerResult(catalogue: [TagData], applied: Set<UUID>, query: String) -> TagPickerResult
+```
+
+`createOption` is non-nil iff the trimmed query is non-empty **and** no catalogue tag equals
+it case-insensitively. `rows` = catalogue filtered by case-insensitive contains, alphabetical,
+each flagged `isApplied`.
+
+---
+
+## 5 · View-model wiring
+
+### Detail — `MeetingDetailViewModel`
+
+- New observable state: `catalogueTags: [TagData]` (loaded via `store.allTags()` on
+  `load()`/`refreshData()`), and `appliedTags: [TagData]` derived from
+  `MeetingDetailData.tags`.
+- New methods (each: call the actor, then `await refreshData()` **and**
+  `core.reloadSummaries()` so the list's third line updates):
+  - `toggleTag(_ tag: TagData)` → `applyTag`/`removeTag` based on current membership.
+  - `createAndApply(_ name: String)` → `store.createTagAndApply(name:to:)`, then refresh
+    catalogue + data.
+  - `removeTag(_ tag: TagData)` → `store.removeTag`, refresh.
+- `@State pickerOpen` lives in the view (same idiom as `openPopoverSpeakerID`).
+
+### List — `MeetingListView.meetingRow` (`:128`)
+
+Add a third `VStack` child after the when-line, rendered only when `meeting.tags` is
+non-empty: an `HStack(spacing: 5)` of `.compact` `TagPill`s (first 2 alphabetical) + a
+`+N` `Text` in `.monoBadge` when `tags.count > 2`. Reads `MeetingSummary.tags` — no new data
+plumbing. Bump the row VStack spacing for tagged rows only so untagged rows keep their height.
+
+### Detail view — `MeetingDetailView.chrome` (`:396`)
+
+Insert the tags row (a `FlowLayout` of detail pills + `TagAddButton`) between `header`
+(`:397`) and the calendar card. Existing child spacing (`Tokens.spacingMD`) gives the 16pt
+gaps.
+
+---
+
+## 6 · Concurrency & data flow
+
+- `DataStore` stays an actor; only `Sendable` DTOs (`TagData`, updated `MeetingSummary` /
+  `MeetingDetailData`) cross to the `@MainActor @Observable` view models. `@Model Tag` never
+  leaves the actor.
+- Refresh is explicit (repo convention): after any mutation the VM re-fetches and reassigns
+  observable state; `core.reloadSummaries()` (`AppCore.swift:601`) repopulates the list.
+  No `@Query`.
+
+## 7 · Error handling
+
+Tag operations are best-effort and non-throwing, matching `setNotes`/`setTitle`. Invalid
+input (empty-after-trim name) is a silent no-op (`createTag` returns `nil`; the create row
+isn't offered for whitespace-only queries anyway). No user-facing error surfaces; failures
+are at most logged via existing patterns.
+
+---
+
+## 8 · Testing strategy
+
+**DataStoreTests** (new `TagTests.swift`):
+
+- Round-robin slot assignment: create 10 tags → slots `0,1,…,7,0,1`.
+- Case-insensitive dedup: `createTag("Customer")` then `createTag("customer")` → same id,
+  catalogue count 1.
+- Trim + empty rejection (`"  "` → `nil`; `" X "` → name `"X"`).
+- Apply idempotency (apply twice → one link); remove keeps the `Tag` in the catalogue.
+- `createTagAndApply` creates + links atomically.
+- Delete a meeting → its links drop, tags persist, other meetings keep their tags.
+- `meetingSummaries`/`meetingDetail` carry tags, alphabetically sorted.
+
+**Search** (`SearchTests.swift` / `MeetingsSearchTests.swift`):
+
+- Tag-only term matches the meeting with `.tags` field and score 3.
+- Title+tag term scoring; `matchedFieldsText` includes "tags".
+
+**UI logic** (`MeetingDetailUITests` or a logic target):
+
+- `computeTagPickerResult`: contains-filter, `isApplied` flags, `createOption` visibility
+  (hidden on exact case-insensitive match, shown otherwise, nil for whitespace).
+
+**DesignSystem**: `FlowLayout` geometry (wrap at width); palette has 8 slots and `tagSwatch`
+wraps the index. (Adaptive colours are eyeballed on hardware in the final phase, not unit
+tested for appearance.)
+
+Optional: `MeetingDetailViewModel` integration test that toggle/create/remove updates
+`appliedTags` and triggers a summary reload.
+
+---
+
+## 9 · Risks / mitigations
+
+- **Unordered relationship** → alphabetical sort everywhere (decided).
+- **Extending schema V1 in place** → safe pre-release (no shipped stores); documented above.
+- **Custom `FlowLayout`** → keep minimal + unit-test geometry; low risk.
+- **Dark dot legibility** → proposed dark variants are provisional; the final human phase
+  tunes them on real hardware.
+- **Per-summary tag load cost** → a cheap relationship read at V1 scale (search already scans
+  all meetings).
+
+---
+
+## 10 · Manual-test staleness
+
+No `Packages/Transcription`, `AudioCapture`, or `LocalLLM` (incl. `BiscottiLLM`) code is
+touched, so the `ManualTestApp/Results` manual-test gate is unaffected (no `not-run` marking
+needed).

--- a/specs/projects/meeting_tags/functional_spec.md
+++ b/specs/projects/meeting_tags/functional_spec.md
@@ -1,0 +1,237 @@
+---
+status: complete
+---
+
+# Functional Spec: Meeting Tags
+
+User-applied, colour-coded labels for meetings. Lightweight, fast to scan, and
+searchable. V1 surfaces: the **meeting detail pane**, the **meeting list** (middle
+pane), and the **existing search** (indexing only — no new search chrome).
+
+---
+
+## 1 · Concepts
+
+- **Tag** — a named, colour-coded label that lives in a global **catalogue**. A tag
+  exists independently of any meeting; the same tag can be applied to many meetings.
+- **Application** — the link between a tag and a meeting. A meeting has zero or more
+  tags; a tag is applied to zero or more meetings. (Many-to-many.)
+- **Catalogue** — the set of all tags that exist. Tags enter the catalogue by being
+  created; in V1 they never leave it (see §3).
+
+A tag carries exactly two pieces of user-visible state: its **name** and its
+**colour**. There is no description, no nesting, no required tags, no per-meeting
+ordering metadata.
+
+---
+
+## 2 · Tag colours
+
+- A fixed palette of **8 swatches** (mid-saturation, similar lightness, harmonising
+  with the ivory/sage system). Sage (the app accent) is **reserved** and never a tag
+  colour. The illustrative hues from the design (blue, clay, violet, slate, red,
+  teal, amber, olive) are the starting palette.
+- Each swatch is defined as an **adaptive colour** (light + hand-tuned dark variant)
+  so dots stay legible on both the ivory and near-black papers. Views never branch on
+  `colorScheme` (repo rule); the swatch resolves itself.
+- **Assignment:** when a tag is created it is given the **next swatch round-robin**
+  by catalogue creation order (the Nth tag created → swatch `N mod 8`). The assignment
+  is **stored on the tag and stable** thereafter. Beyond 8 tags, colours repeat — this
+  is acceptable.
+- In V1 the user cannot choose or change a tag's colour (see Out of Scope, §10).
+
+---
+
+## 3 · Tag lifecycle (V1 scope)
+
+V1 supports exactly two catalogue operations, both initiated from the tag picker on
+the detail pane:
+
+1. **Create** a new tag (by typing a new name and confirming).
+2. **Apply / un-apply** an existing tag to/from the current meeting.
+
+Explicitly **not** in V1: global rename, recolour, or delete; a catalogue-management
+screen; bulk tagging. Consequences the design must accept:
+
+- Removing a tag from a meeting (detail ✕ or un-toggle in the picker) only removes the
+  **application** — the tag remains in the catalogue for other meetings, even if it is
+  now applied to none (**orphan tags persist**). There is no V1 affordance to delete an
+  orphaned or misspelled tag. (A later project adds management.)
+- Deleting a **meeting** removes its applications but never deletes the tags themselves.
+
+---
+
+## 4 · Naming & validation
+
+- The name is the user's typed string with **leading/trailing whitespace trimmed**.
+  Internal characters are preserved as typed (e.g. `1:1`, `Q3 Roadmap`).
+- A name must be **non-empty** after trimming, or it cannot be created.
+- **Uniqueness is case-insensitive.** Two tags may not differ only by case. If the
+  user tries to create a name that case-insensitively equals an existing tag, the
+  existing tag is **reused** (applied/toggled) rather than duplicated — so the "Create"
+  affordance never appears for a name that already exists (§6).
+- **Length cap:** names are capped at **40 characters** (input is limited at the field;
+  longer paste is truncated). Keeps pills a sane width.
+
+---
+
+## 5 · Meeting detail pane
+
+### 5.1 Tags row
+
+- A dedicated **tags row** sits directly **under the meta line** (date · duration ·
+  source pill) and **above** the calendar info card.
+- It renders the meeting's applied tags as **detail-size pills** (a neutral pill with a
+  single coloured dot; pill text is never coloured — only the dot), followed always by
+  the **Add affordance** at the end.
+- The row **wraps** to additional lines when tags overflow the available width; the Add
+  affordance stays at the end of the flow.
+- **Ordering:** tags render in a **deterministic alphabetical order** (case-insensitive,
+  localised), *not* "order applied." Rationale: the underlying many-to-many relationship
+  is unordered in SwiftData, so insertion order can't be relied on; alphabetical is
+  stable and scannable. (Reconciliation note — see §11. If true order-applied is later
+  wanted, it requires a join model with an order field.)
+
+### 5.2 Removing a tag
+
+- Each detail pill reveals a faint **✕** on hover (right side, fades 0→1). Clicking it
+  removes that tag's application from this meeting immediately (no confirm). This follows
+  the existing hover-to-remove pattern used by note rows.
+- Removal is immediate and persisted; the list and detail refresh.
+
+### 5.3 Add affordance (three states)
+
+A ghost pill matching tag dimensions, whose treatment depends on context:
+
+- **Meeting has tags** → compact "＋ Add tag" with a dashed neutral outline; hover adds a
+  soft fill / darker border.
+- **Meeting has no tags** → a more inviting "Add tags" in **sage** (sage outline + text)
+  to encourage the first tag; hover adds a faint sage fill.
+- **Picker open** → an active sage-tinted state (sage fill + sage border/text).
+
+Clicking the affordance opens the picker popover (§6).
+
+---
+
+## 6 · Tag picker popover
+
+Anchored below the Add affordance (follows the existing `SpeakerMappingSheet` /
+`PersonPickerPopover` pattern). Contents top-to-bottom:
+
+1. **Search / create field** — magnifying-glass icon + text input, placeholder
+   "Add or create a tag…". Auto-focused on open. Filters the list live (case-insensitive
+   **contains** match) as the user types.
+2. **Kicker** "TAGS" (mono, uppercase).
+3. **Catalogue list** — every catalogue tag (filtered by the query) as a row: colour dot
+   + name. A tag **already applied** to the current meeting shows a trailing **sage ✓**.
+   Clicking a row **toggles** the application on/off for the current meeting (immediate,
+   persisted). List order is **alphabetical** (case-insensitive).
+4. **Create row** — shown only when the trimmed query is non-empty **and** no catalogue
+   tag equals it case-insensitively: `＋ Create "<query>"`. Clicking it creates the tag
+   (next round-robin colour) **and applies it** to the current meeting in one step, then
+   clears the query. Full sage fill on hover.
+
+Behaviours:
+
+- Toggling is **idempotent** — a tag already applied shows ✓ and clicking removes it;
+  applying an already-applied tag never duplicates.
+- The popover stays open across multiple toggles/creates so several tags can be managed
+  in one session; it dismisses on outside click / escape (standard popover behaviour).
+- An empty catalogue with an empty query shows just the field + kicker (and the create
+  row appears as soon as the user types a name).
+
+---
+
+## 7 · Meeting list (middle pane)
+
+- Each meeting row gains a **third line** beneath the existing when-line (date · duration),
+  rendering **compact** tag pills.
+- The third line is **hidden entirely** when a meeting has no tags (no reserved empty
+  space — row height stays compact for untagged meetings).
+- **Overflow cap:** show at most the **first 2** pills (alphabetical), then a mono **`+N`**
+  count for the remainder (e.g. `● Customer  ● Important  +1`). Keeps row height predictable
+  in a dense list.
+- Compact pills are **not removable** and not interactive — display only. Tag editing
+  happens on the detail pane.
+- **Selection legibility:** the selected row already uses the system's light sage selection
+  wash (`accentWashStrong`), a tint rather than a solid fill — coloured tag dots remain
+  legible on it. (No change needed; the spec only requires that dots stay readable on the
+  selected background.)
+
+---
+
+## 8 · Search
+
+The existing search (a custom toolbar field → debounced `searchHits` → ranked list) is
+**not redesigned**. The only change is indexing:
+
+- A meeting's **tag names** become a searchable field. Typing a tag name matches every
+  meeting carrying that tag, exactly as typing matches a word in the title.
+- **Weight: 3** — a tag match scores the **same as a title match** (the current top
+  weight; title = 3, people = 2, transcript = 1, notes = 1). Rationale: a tag is an
+  explicit, deliberate user label, so a tag-name query should surface tagged meetings as
+  strongly as a title hit. Per matching term, if any of the meeting's tag names contain
+  the term, add 3 and record a `.tags` matched-field.
+- The search-result row's "matches: …" label gains a **"tags"** entry when the tag field
+  matched, alongside title / people / transcript / notes.
+- No new search chrome: no tokens, filter bar, or tag-specific UI in V1.
+
+---
+
+## 9 · Edge cases
+
+- **Duplicate create** (case-insensitive match to existing) → reuse/toggle the existing
+  tag; no duplicate row; create row not shown.
+- **Whitespace-only query** → no create row; no-op.
+- **Rapid toggling** of the same tag → idempotent end state (applied or not).
+- **Tag applied to many meetings, removed from one** → other meetings keep it.
+- **Orphan tag** (applied to no meetings) → remains in the catalogue and the picker list;
+  no V1 way to delete it.
+- **>8 tags** → palette colours repeat round-robin; no error.
+- **Meeting deleted** → its applications drop; the tags persist.
+- **Long name** → capped at 40 chars on input; compact list pills truncate with tail
+  ellipsis and single line; detail pills show the full (capped) name on one line.
+- **Many tags on one meeting** → detail row wraps to multiple lines; list shows first 2 +
+  `+N`.
+
+---
+
+## 10 · Out of scope (V1)
+
+- Global tag **rename**, **recolour**, or **delete**; any catalogue-management surface.
+- User **choosing** a tag's colour (auto round-robin only).
+- True **order-applied** ordering (alphabetical instead — §5.1).
+- Tag **search chrome**: tokens, filter bars, tag-scoped search modes.
+- Tagging **upcoming**/calendar events that have no meeting record; **bulk** tagging from
+  the list; **nested** or **required** tags; smart/auto-suggested tags.
+
+---
+
+## 11 · Reconciliations with the design notes
+
+The design agent had no codebase access; these points reconcile its notes to the repo:
+
+- **Tokens:** `label/label2/label3 → ink/inkSecondary/inkTertiary`; `accent`/sage `#4E7D5C`
+  → `sage`. Pill fill comes from `.ink.opacity(~0.05)` (a `neutralChip`-style wash), not a
+  literal `Color(hex: 0x…)`.
+- **Mono font** is **JetBrains Mono** (`biscottiMono` / `.monoBadge` for `+N`), not IBM Plex
+  Mono.
+- **Colour adaptivity:** dot hues are defined as adaptive `dynamicColor` pairs (the repo
+  forbids `colorScheme` checks in views and tests for it), so each hue needs a tuned dark
+  variant. A human eyeballs the dark variants on hardware (as the dark-mode project did).
+- **Ordering** is alphabetical, not order-applied (§5.1) — the only behavioural deviation
+  from the notes, driven by SwiftData's unordered relationships.
+
+---
+
+## 12 · Constraints
+
+- **Adaptive colour discipline:** all new colours via `dynamicColor(light:dark:)`; no
+  `colorScheme` branching in views (enforced by an existing test).
+- **Performance:** search remains an in-memory full-table scan; adding a tag-name check per
+  meeting is negligible at V1 scale. List summaries include each meeting's tags — a cheap
+  relationship read on the data actor.
+- **Persistence:** adding a `Tag` entity + a many-to-many relationship with an empty-array
+  default is **additive**; SwiftData handles it without a schema migration (no V2 needed).
+- **Apple-silicon, macOS 15+**, SwiftUI + Swift Observation, package-first (logic in
+  `BiscottiKit`, testable via `swift test`).

--- a/specs/projects/meeting_tags/functional_spec.md
+++ b/specs/projects/meeting_tags/functional_spec.md
@@ -148,9 +148,9 @@ Behaviours:
   rendering **compact** tag pills.
 - The third line is **hidden entirely** when a meeting has no tags (no reserved empty
   space — row height stays compact for untagged meetings).
-- **Overflow cap:** show at most the **first 2** pills (alphabetical), then a mono **`+N`**
-  count for the remainder (e.g. `● Customer  ● Important  +1`). Keeps row height predictable
-  in a dense list.
+- **Overflow cap:** show at most the **first 3** pills (alphabetical), then a mono **`+N`**
+  count for the remainder (e.g. `● Customer  ● Design  ● Important  +1`). Keeps row height
+  predictable in a dense list.
 - Compact pills are **not removable** and not interactive — display only. Tag editing
   happens on the detail pane.
 - **Selection legibility:** the selected row already uses the system's light sage selection
@@ -191,7 +191,7 @@ The existing search (a custom toolbar field → debounced `searchHits` → ranke
 - **Meeting deleted** → its applications drop; the tags persist.
 - **Long name** → capped at 40 chars on input; compact list pills truncate with tail
   ellipsis and single line; detail pills show the full (capped) name on one line.
-- **Many tags on one meeting** → detail row wraps to multiple lines; list shows first 2 +
+- **Many tags on one meeting** → detail row wraps to multiple lines; list shows first 3 +
   `+N`.
 
 ---

--- a/specs/projects/meeting_tags/implementation_plan.md
+++ b/specs/projects/meeting_tags/implementation_plan.md
@@ -22,7 +22,7 @@ Each phase is one coherent CR. See `functional_spec.md`, `ui_design.md`, and
   `FlowLayout`; render the compact third line (first 2 + `+N`) in `MeetingListView.meetingRow`.
   Read-only display path, end to end. (architecture §4.1–4.3, §5 list)
 
-- [ ] **Phase 3 — Detail-pane editing.** `TagAddButton` (three states); `TagPickerPopover`
+- [x] **Phase 3 — Detail-pane editing.** `TagAddButton` (three states); `TagPickerPopover`
   + pure `computeTagPickerResult` (tested) with keyboard nav; wire `MeetingDetailViewModel`
   (load catalogue, `toggleTag` / `createAndApply` / `removeTag`, refresh + `reloadSummaries`);
   insert the wrapping tags row into `MeetingDetailView.chrome`. (architecture §4.4–4.5, §5 detail)

--- a/specs/projects/meeting_tags/implementation_plan.md
+++ b/specs/projects/meeting_tags/implementation_plan.md
@@ -1,0 +1,33 @@
+---
+status: complete
+---
+
+# Implementation Plan: Meeting Tags
+
+Ordered by dependency: data first, then display, then editing, then a human visual pass.
+Each phase is one coherent CR. See `functional_spec.md`, `ui_design.md`, and
+`architecture.md` for detail — this is just the build order.
+
+## Phases
+
+- [x] **Phase 1 — Data layer & search.** `Tag` `@Model` + `Meeting.tags` relationship +
+  schema registration; `TagData` DTO; DataStore tag API (`allTags`, `createTag` with
+  round-robin slot + case-insensitive dedup, `applyTag`, `removeTag`, `createTagAndApply`);
+  `tags` added to `MeetingSummary` / `MeetingDetailData` (alphabetical); search indexing
+  (`SearchField.tags`, weight 3 in `scoreMeeting`, `fieldSortOrder`, `matchedFieldsText`).
+  Full data-layer + search tests. No UI. (architecture §1–3, §8)
+
+- [ ] **Phase 2 — Display primitives & list.** Adaptive 8-swatch tag palette in
+  `Color+Theme.swift`; `TagPill` (`.detail` / `.compact`); minimal `Layout`-based
+  `FlowLayout`; render the compact third line (first 2 + `+N`) in `MeetingListView.meetingRow`.
+  Read-only display path, end to end. (architecture §4.1–4.3, §5 list)
+
+- [ ] **Phase 3 — Detail-pane editing.** `TagAddButton` (three states); `TagPickerPopover`
+  + pure `computeTagPickerResult` (tested) with keyboard nav; wire `MeetingDetailViewModel`
+  (load catalogue, `toggleTag` / `createAndApply` / `removeTag`, refresh + `reloadSummaries`);
+  insert the wrapping tags row into `MeetingDetailView.chrome`. (architecture §4.4–4.5, §5 detail)
+
+- [ ] **Phase 4 — Visual review & tweaking (human interactive).** The only human-driven
+  phase. Run the app; review the detail tags row, the list third line, and the picker in
+  **light and dark**; finalize the 8 dark dot variants on real hardware; tune pill spacing,
+  sizes, the hover-✕, and the Add-affordance states. Apply tweaks discovered in review.

--- a/specs/projects/meeting_tags/implementation_plan.md
+++ b/specs/projects/meeting_tags/implementation_plan.md
@@ -17,7 +17,7 @@ Each phase is one coherent CR. See `functional_spec.md`, `ui_design.md`, and
   (`SearchField.tags`, weight 3 in `scoreMeeting`, `fieldSortOrder`, `matchedFieldsText`).
   Full data-layer + search tests. No UI. (architecture §1–3, §8)
 
-- [ ] **Phase 2 — Display primitives & list.** Adaptive 8-swatch tag palette in
+- [x] **Phase 2 — Display primitives & list.** Adaptive 8-swatch tag palette in
   `Color+Theme.swift`; `TagPill` (`.detail` / `.compact`); minimal `Layout`-based
   `FlowLayout`; render the compact third line (first 2 + `+N`) in `MeetingListView.meetingRow`.
   Read-only display path, end to end. (architecture §4.1–4.3, §5 list)

--- a/specs/projects/meeting_tags/implementation_plan.md
+++ b/specs/projects/meeting_tags/implementation_plan.md
@@ -4,8 +4,8 @@ status: complete
 
 # Implementation Plan: Meeting Tags
 
-Ordered by dependency: data first, then display, then editing, then a human visual pass.
-Each phase is one coherent CR. See `functional_spec.md`, `ui_design.md`, and
+Ordered by dependency: data first, then display, then editing, then a list restyle, then a
+human visual pass. Each phase is one coherent CR. See `functional_spec.md`, `ui_design.md`, and
 `architecture.md` for detail — this is just the build order.
 
 ## Phases
@@ -19,7 +19,7 @@ Each phase is one coherent CR. See `functional_spec.md`, `ui_design.md`, and
 
 - [x] **Phase 2 — Display primitives & list.** Adaptive 8-swatch tag palette in
   `Color+Theme.swift`; `TagPill` (`.detail` / `.compact`); minimal `Layout`-based
-  `FlowLayout`; render the compact third line (first 2 + `+N`) in `MeetingListView.meetingRow`.
+  `FlowLayout`; render the compact third line (first 3 + `+N`) in `MeetingListView.meetingRow`.
   Read-only display path, end to end. (architecture §4.1–4.3, §5 list)
 
 - [x] **Phase 3 — Detail-pane editing.** `TagAddButton` (three states); `TagPickerPopover`
@@ -27,7 +27,22 @@ Each phase is one coherent CR. See `functional_spec.md`, `ui_design.md`, and
   (load catalogue, `toggleTag` / `createAndApply` / `removeTag`, refresh + `reloadSummaries`);
   insert the wrapping tags row into `MeetingDetailView.chrome`. (architecture §4.4–4.5, §5 detail)
 
-- [ ] **Phase 4 — Visual review & tweaking (human interactive).** The only human-driven
-  phase. Run the app; review the detail tags row, the list third line, and the picker in
-  **light and dark**; finalize the 8 dark dot variants on real hardware; tune pill spacing,
-  sizes, the hover-✕, and the Add-affordance states. Apply tweaks discovered in review.
+- [x] **Phase 4 — Past Meetings list restyle (styling only).** Repaint the middle-pane
+  meeting list to the Sage + Pressroom identity — **no behaviour/feature changes** (same
+  rows, sort, search, selection model, multi-select, ⌫-delete, keyboard nav). Keep the
+  native `List(selection:)`; **try a native SwiftUI re-skin first** — `.tint(.sage)` to kill
+  the system-blue selection and `.scrollContentBackground(.hidden)` so the ivory `paper`
+  shows. The implementer **web-searches to confirm the current best macOS-15 approach**
+  before coding. Restyle per ui_design §10: warm ivory pane, hairline list↔detail border,
+  sage selection (wash + inset-ring *intent*; native `.tint` is the first cut),
+  selected-row when-line → sage, mono when-line (`.monoMeta`) + mono uppercase group headers
+  (`.kicker()`), SF Pro title, **no serif**, tag pills unchanged (neutral fill + coloured
+  dots, cap 3 + `+N`). Dark mode = pure token swap. **If native isn't good enough, stop and
+  escalate** (next step: AppKit `selectionHighlightStyle = .none` + `.listRowBackground`
+  wash). **Human visual review before CR** (per process this phase). (ui_design §10)
+
+- [x] **Phase 5 — Visual review & tweaking (human interactive).** The only fully
+  human-driven phase. Run the app; review the detail tags row, the list third line, the
+  picker, and the Phase-4 list restyle in **light and dark**; finalize the 8 dark dot
+  variants on real hardware; tune pill spacing, sizes, the hover-✕, and the Add-affordance
+  states. Apply tweaks discovered in review.

--- a/specs/projects/meeting_tags/phase_plans/phase_1.md
+++ b/specs/projects/meeting_tags/phase_plans/phase_1.md
@@ -1,0 +1,64 @@
+---
+status: complete
+---
+
+# Phase 1: Data layer & search
+
+## Overview
+
+Adds the `Tag` SwiftData model, the `Meeting.tags` many-to-many relationship,
+schema registration, the `TagData` DTO, DataStore tag CRUD API, tag population
+in read models (`MeetingSummary` / `MeetingDetailData`), and search indexing
+(`.tags` field at weight 3). No UI changes.
+
+## Steps
+
+1. **Create `Tag` model** (`DataStore/Models/Tag.swift`): `@Model` with `id`,
+   `name`, `colorSlot`, `createdAt`, and `@Relationship(inverse:)` back to
+   `Meeting.tags`.
+
+2. **Add `tags` relationship to `Meeting`** (`Meeting.swift`): bare
+   `@Relationship public var tags: [Tag] = []` (no cascade -- deleting a
+   meeting must not delete shared tags).
+
+3. **Register `Tag` in schema** (`DataStoreSchemaV1.swift`): add `Tag.self` to
+   the models array.
+
+4. **Create `TagData` DTO** (in `DataStore+ReadModels.swift`): `public struct
+   TagData: Sendable, Identifiable, Equatable, Hashable` with `id`, `name`,
+   `colorSlot`.
+
+5. **Add `tags: [TagData]` to `MeetingSummary` and `MeetingDetailData`**:
+   defaulting to `[]`; populate from `meeting.tags` mapped + alphabetically
+   sorted in `meetingSummaries(limit:)` and `meetingDetail(id:)`.
+
+6. **Add DataStore tag API methods** (new file `DataStore+Tags.swift`):
+   - `allTags() -> [TagData]`
+   - `createTag(name:) -> TagData?`
+   - `applyTag(tagID:to:)`
+   - `removeTag(tagID:from:)`
+   - `createTagAndApply(name:to:) -> TagData?`
+   - Test helper: `fetchAllTags() -> [Tag]`
+
+7. **Add `SearchField.tags` case** and wire into `scoreMeeting` (weight 3),
+   `fieldSortOrder`, and `matchedFieldsText`.
+
+## Tests
+
+- `TagTests.swift` (DataStoreTests):
+  - `roundRobinSlotAssignment`: create 10 tags, verify slots cycle 0..7,0,1
+  - `caseInsensitiveDedup`: "Customer" then "customer" -> same id, count 1
+  - `trimAndEmptyRejection`: "  " -> nil; " X " -> name "X"
+  - `applyIdempotency`: apply twice -> one link
+  - `removeKeepsTagInCatalogue`: remove from meeting, tag still in allTags
+  - `createTagAndApplyAtomic`: creates + links in one call
+  - `deleteMeetingPreservesTags`: delete meeting, tags persist, other meetings keep theirs
+  - `summariesCarryTagsAlphabetically`: meetingSummaries includes tags sorted
+  - `detailCarriesTagsAlphabetically`: meetingDetail includes tags sorted
+
+- Search tests (in `SearchTests.swift` or new section):
+  - `tagOnlyTermMatchesMeeting`: tag-only term -> score 3, matchedFields contains .tags
+  - `tagPlusTitleScoring`: both title and tag match -> score 6
+  - `matchedFieldsTextIncludesTags`: .tags -> "tags" string
+
+- `TagNameLengthCap` (optional, data layer doesn't enforce -- it's a UI concern)

--- a/specs/projects/meeting_tags/phase_plans/phase_2.md
+++ b/specs/projects/meeting_tags/phase_plans/phase_2.md
@@ -1,0 +1,46 @@
+---
+status: complete
+---
+
+# Phase 2: Display primitives & list
+
+## Overview
+
+Build the read-only display path for meeting tags, end to end: the adaptive
+8-swatch colour palette, a `TagPill` component (two sizes), a minimal
+`Layout`-based `FlowLayout`, and the compact third-line rendering in the
+meeting list. No editing UI (that is Phase 3).
+
+## Steps
+
+1. **Tag-dot palette** in `Color+Theme.swift`: add 8 adaptive `dynamicColor`
+   pairs per ui_design.md section 6. Expose `Color.tagSwatches: [Color]` and
+   `Color.tagSwatch(slot:)` with modular-arithmetic index wrapping. Slot 4
+   (Red) reuses the existing `signalRed` pair.
+
+2. **`TagPill`** in new `DesignSystem/TagPill.swift`: a `View` with a `Size`
+   enum (`.detail` / `.compact`) carrying dimensions from ui_design.md section 1.
+   HStack of dot circle + text in `neutralChip` rounded rect. Takes `TagData`
+   and reads `Color.tagSwatch(slot:)`. Detail size has an optional `onRemove`
+   closure; when non-nil, renders a hover-X (opacity on hover state). Compact
+   passes `nil` (display-only).
+
+3. **`FlowLayout`** in new `DesignSystem/FlowLayout.swift`: a `Layout`-protocol
+   conformance. Left-to-right placement, wrapping to the next line when a child
+   exceeds the proposed width. Configurable horizontal and vertical spacing.
+   Pure geometry, unit-testable.
+
+4. **Meeting list third line** in `MeetingListView.swift`: add a third VStack
+   child after the when-line, rendered only when `meeting.tags` is non-empty.
+   `HStack(spacing: 5)` of `.compact` `TagPill`s (first 2, alphabetical) + a
+   `+N` `Text` in `.monoBadge` / `.inkSecondary` when `tags.count > 2`. Bump
+   the row VStack spacing for tagged rows only (so untagged rows keep height).
+
+## Tests
+
+- **`TagPaletteTests`** (in `DesignSystemTests`): verify `tagSwatches` has 8
+  elements; `tagSwatch(slot:)` wraps negative and large indices correctly;
+  slot 4 equals `signalRed` in both light and dark.
+- **`FlowLayoutTests`** (in `DesignSystemTests`): test single-row layout when
+  all children fit; wrapping to 2 rows when width is exceeded; empty children;
+  spacing is applied correctly.

--- a/specs/projects/meeting_tags/phase_plans/phase_3.md
+++ b/specs/projects/meeting_tags/phase_plans/phase_3.md
@@ -1,0 +1,37 @@
+---
+status: complete
+---
+
+# Phase 3: Detail-pane editing
+
+## Overview
+
+Adds the tag editing experience to the meeting detail pane: the `TagAddButton` (three visual states), the `TagPickerPopover` with keyboard navigation, pure `computeTagPickerResult` function (unit tested), `MeetingDetailViewModel` tag methods (`toggleTag`, `createAndApply`, `removeTag`), and the wrapping tags row inserted into `MeetingDetailView.chrome`.
+
+## Steps
+
+1. **`TagPickerLogic.swift`** (new, `MeetingDetailUI/`) -- pure function `computeTagPickerResult(catalogue:applied:query:) -> TagPickerResult` mirroring `computePersonPickerResult`. Returns filtered rows (each with `isApplied` flag) and optional `createOption`.
+
+2. **`TagAddButton.swift`** (new, `MeetingDetailUI/`) -- ghost pill with three states (has-tags, empty, picker-open). Dashed border via `StrokeStyle(dash:)`, sage/neutral styling per ui_design.md SS4.
+
+3. **`TagPickerPopover.swift`** (new, `MeetingDetailUI/`) -- popover anchored to `TagAddButton`. Search field (auto-focused) + "TAGS" kicker + catalogue rows (dot + name + checkmark if applied) + create row. Keyboard nav (up/down/return/escape). Toggle keeps popover open (differs from person picker).
+
+4. **`MeetingDetailViewModel`** -- add `catalogueTags: [TagData]` state, load in `refreshData()`. Add `toggleTag`, `createAndApply`, `removeTag` methods (each calls actor, then `refreshData()` + `core.reloadSummaries()`). Expose `appliedTagIDs` computed set.
+
+5. **`MeetingDetailView.chrome`** -- insert tags row (FlowLayout of detail TagPills with onRemove + TagAddButton with popover) between `header` and `reTranscribePrompt`/calendar card.
+
+6. **`TagPickerLogicTests.swift`** (new) -- unit tests for `computeTagPickerResult`: contains-filter, `isApplied` flags, `createOption` visibility (non-nil iff trimmed query non-empty AND no catalogue tag equals it case-insensitively), nil for whitespace-only.
+
+## Tests
+
+- `testContainsFilter`: query "cus" matches "Customer" but not "Important"
+- `testCaseInsensitiveFilter`: query "CUS" matches "customer"
+- `testIsAppliedFlags`: applied tags flagged correctly
+- `testCreateOptionShownForNewName`: query "NewTag" with no match -> createOption = "NewTag"
+- `testCreateOptionHiddenForExactMatch`: query "Customer" with existing "Customer" -> createOption = nil
+- `testCreateOptionCaseInsensitiveMatch`: query "customer" with existing "Customer" -> createOption = nil
+- `testCreateOptionNilForEmptyQuery`: empty query -> createOption = nil
+- `testCreateOptionNilForWhitespaceOnly`: whitespace query -> createOption = nil
+- `testCreateOptionTrimmed`: query "  NewTag  " -> createOption = "NewTag"
+- `testAlphabeticalOrdering`: rows sorted alphabetically
+- `testEmptyCatalogue`: empty catalogue with query -> createOption shown

--- a/specs/projects/meeting_tags/phase_plans/phase_4.md
+++ b/specs/projects/meeting_tags/phase_plans/phase_4.md
@@ -1,0 +1,124 @@
+---
+status: complete
+---
+
+# Phase 4: Past Meetings List Restyle (Styling Only)
+
+## Overview
+
+Repaint the middle-pane meeting list (`MeetingListView`) to the Sage + Pressroom identity
+per ui_design.md section 10. Strictly styling -- zero behaviour changes. Same rows, sort,
+search, `List(selection:)` multi-select binding, `.onDeleteCommand`/backspace-delete,
+keyboard arrow-nav, section headers, `.tag(id)`.
+
+## Web Search Findings
+
+### Attempt 1: Pure SwiftUI (rejected)
+
+`.tint(.sage)` on the List does NOT reliably change the selection highlight background on
+macOS. The selection highlight color is driven by the system accent color, not by `.tint`.
+`.tint` only affected text we explicitly set (the when-line), not the row selection wash.
+The AccentColor asset catalog entry helps when the user's system accent is "Multicolour",
+but if the user picks a different system accent, it overrides the app's accent. There is no
+clean public SwiftUI API to fully override this.
+
+### Attempt 2: AppKit suppression (adopted)
+
+Confirmed via web search:
+
+1. **`NSTableView.selectionHighlightStyle = .none`** suppresses only the *visual drawing*
+   of the selection highlight. The selection *model* is unaffected -- keyboard arrow-key
+   navigation, shift/cmd multi-select, and the SwiftUI `List(selection:)` binding all
+   continue to work normally. The property controls rendering, not selection state.
+
+2. **View hierarchy traversal**: SwiftUI's `List` on macOS is backed by an `NSTableView`
+   inside an `NSScrollView`. Walking up the superview chain from an invisible
+   `NSViewRepresentable` placed as a `.background()` reliably finds the `NSTableView`
+   (typically within ~10-15 levels). This is the same pattern used by SwiftUI-Introspect
+   and by our existing `SearchFieldFocuser`.
+
+3. **`.scrollContentBackground(.hidden)`** works reliably on macOS 13+ to remove the
+   List's default white surface, letting a custom background color show through.
+
+Sources:
+- [Apple: selectionHighlightStyle](https://developer.apple.com/documentation/appkit/nstableview/1526311-selectionhighlightstyle)
+- [SwiftUI-Introspect](https://github.com/siteline/SwiftUI-Introspect)
+- [TIL: SwiftUI List on macOS](https://blog.eidinger.info/til-swiftui-list-on-macos)
+- [SwiftUI List selection highlighting (Apple Forums)](https://developer.apple.com/forums/thread/719507)
+
+## Implementation
+
+### New tokens (`Color+Theme.swift`)
+
+- **`Color.listPaneBackground`** -- a distinct third warm ivory surface (between `paper`
+  and `sidebarTint`). Light `#F7F3EB` / dark provisional `#17140D` (marked for Phase 5
+  eyeball). Used as the list pane background instead of `Color.paper`.
+
+- **`Color.onAccent`** -- pure white. Primary text on a solid-accent (selected) surface.
+
+- **`Color.onAccentMuted`** -- white @ 72%. Secondary text (when-line) on selected rows.
+
+- **`Color.onAccentChipFill`** -- white @ 18%. Tag pill fill on selected rows.
+
+- **`Color.onAccentChipRing`** -- white @ 50%. A 0.5px ring on coloured tag dots so
+  slate/teal/olive stay legible on the solid sage fill.
+
+### Removed tokens
+
+- **`Color.accentRingStrong`** -- was sage @ 22% / @24%, used for the 0.5pt inset ring
+  on selected rows. Removed: the solid `accentFill` selection no longer uses a ring.
+
+### Selection: AppKit suppression + solid sage fill
+
+- **`SelectionHighlightSuppressor`** -- a private `NSViewRepresentable` (modeled on
+  `SearchFieldFocuser` and SwiftUI-Introspect's `scope: .ancestor` placement) attached
+  as a `.background()` on the content **inside** the `List { ... }` closure (on
+  `browseContent` / `searchContent`), so its backing `NSView` is a descendant of the
+  `NSTableView`. It walks *up* the superview chain to the enclosing `NSTableView` and
+  sets `selectionHighlightStyle = .none`. Fires on three triggers:
+  `viewDidMoveToSuperview()`, `viewDidMoveToWindow()`, and `updateNSView` (every SwiftUI
+  re-render). Because the view is inside THIS list's hierarchy, it targets the meeting
+  list's table specifically -- not the detail pane's `TranscriptListView` or any other
+  `NSTableView` in the window. The selection model (keyboard nav, multi-select, binding)
+  is unaffected.
+
+- **`.listRowBackground(selectionBackground(isSelected))`** on every row (browse + search):
+  when selected, a `RoundedRectangle(cornerRadius: 8)` filled with `Color.accentFill`
+  (solid sage -- light `#4E7D5C` / dark `#56906A`), with an **8pt** horizontal inset so
+  the card doesn't feel too wide. Unselected rows get `Color.clear`. No inset ring.
+
+- **Selected-row text colours** (gated on `isSelected`, NOT `colorScheme`):
+  - Title: `.onAccent` (white), weight `.medium`.
+  - When-line: `.onAccentMuted` (white @72%), `.monoMeta`.
+  - `+N` overflow: `white.opacity(0.70)`, `.monoBadge`.
+  - Search-row date + matches line: `.onAccentMuted`.
+
+- **Selected-row tag pills** via `TagPill(onAccent: isSelected)`:
+  - Pill fill: `onAccentChipFill` (white @18%).
+  - Pill text: `onAccent` (white).
+  - Coloured dot: keeps `Color.tagSwatch(slot:)` at full hue, gains a 0.5px
+    `onAccentChipRing` (white @50%) ring overlay.
+  - Default (`onAccent: false`) is unchanged -- `neutralChip` fill, `ink` text, no dot ring.
+  - Detail pills in `MeetingDetailUI` are unaffected (they don't pass `onAccent`).
+
+### List surface
+
+- `.scrollContentBackground(.hidden)` + `.background(Color.listPaneBackground)` (was
+  `Color.paper`).
+
+### Unchanged from original Phase 4
+
+- Row title font: `.system(size: 13.5, weight: .medium)`, `.ink` (unselected).
+- When-line font: `.monoMeta`, `.inkSecondary` (unselected).
+- Section headers: `.kicker()` + `.foregroundStyle(.inkTertiary)`.
+- `+N` overflow (unselected): `.monoBadge`, `.inkTertiary`.
+- Search rows: matching restyle with `.listRowBackground`.
+- Row separators: `.listRowSeparator(.hidden)`.
+- Default + hover rows, group headers, pane background, untagged-row behaviour (tag line
+  hidden), and the selection-suppressor are unchanged.
+
+## Tests
+
+- All 2,211 existing tests pass (including the `colorScheme` branching ban test).
+- No new logic, functions, or data paths introduced -- strictly styling.
+- Visual correctness verified by human review (next step).

--- a/specs/projects/meeting_tags/project_overview.md
+++ b/specs/projects/meeting_tags/project_overview.md
@@ -1,0 +1,108 @@
+---
+status: complete
+---
+
+# Meeting Tags
+
+Add user-applied **tags** to meetings: lightweight, colour-coded labels for past
+meetings, fast to scan. Two surfaces are in scope for V1 — the **meeting detail
+pane** and the **meeting list** (middle pane). Tags also become a searchable
+meeting field (search *chrome* is not being redesigned — only the indexing).
+
+## Source of the design
+
+The design below was produced by a "design agent" that did **not** have access
+to the codebase and worked from earlier comps. It captures the visual intent and
+the product spirit, but specific token names, fonts, and colour helpers may be
+*drift* rather than prescriptive. Where the notes conflict with the real design
+system in code, the codebase wins and we reconcile during speccing. Notable
+drift already identified:
+
+- Tokens `label`/`label2`/`label3` → real tokens `ink`/`inkSecondary`/`inkTertiary`.
+- `accent` / sage `#4E7D5C` → real token `sage`.
+- `Color(hex: 0x1A1813)` (UInt form) → the repo's `Color(hex:)` takes a `"RRGGBB"`
+  string; tints like the pill fill should come from `.ink.opacity(...)`.
+- "IBM Plex Mono" → the repo's monospace face is **JetBrains Mono** (`biscottiMono`).
+- The repo's colour system is fully **adaptive (light/dark)** via `dynamicColor`,
+  with a test forbidding `colorScheme` checks in views — so the fixed tag-dot hues
+  need a dark-mode story.
+
+---
+
+## Design Spec (from the design agent — directional)
+
+> User-applied labels for past meetings. Lightweight, colour-coded, fast to scan.
+> Visual identity: **F · Sage + Pressroom** — warm ivory paper, sage accent,
+> Newsreader serif title, mono for timestamps/kickers.
+> Two surfaces in scope for V1: the **meeting detail pane** and the **meeting list**.
+> (Tags are also a search field — see note at end — but search UI is out of scope for V1.)
+
+### The tag atom
+
+A tag is a **soft neutral pill carrying a single colour dot**. Colour lives in the
+dot only — it never floods the pill — which keeps a row of tags calm against the
+ivory paper and lets the eye scan by hue.
+
+| Property | Detail pane | List row (compact) |
+|---|---|---|
+| Height | 22 | 17 |
+| Padding (h) | 9 | 7 |
+| Corner radius | 6 | 5 |
+| Gap (dot→text) | 6 | 5 |
+| Font | SF Pro 11.5 / .medium | SF Pro 10.5 / .medium |
+| Dot | 7×7 circle | 6×6 circle |
+| Background | neutral ink wash (~5.5%) | neutral ink wash (~5%) |
+| Text colour | primary ink (never coloured) | primary ink |
+
+- The pill text is **never** coloured — only the dot.
+- On the detail pane, a tag shows a faint **✕** on hover (right side) to remove it.
+  List-row pills are not removable.
+
+### Tag colours
+
+Each tag name maps to one muted hue (mid-saturation, similar lightness so no single
+tag screams). Illustrative palette:
+
+| Tag (example) | Dot hue |
+|---|---|
+| Customer | `#3E6DA8` (blue) |
+| Sales | `#B5683E` (clay) |
+| 1:1 | `#7A6AAE` (violet) |
+| Internal | `#6B7B86` (slate) |
+| Important | `#B23320` (red) |
+| Design | `#2A8C7E` (teal) |
+| Hiring | `#A8843A` (amber) |
+| Roadmap | `#5E8C3A` (olive) |
+
+- Hues are assigned on creation and stable thereafter. New user-created tags take
+  the next hue from the palette (round-robin).
+- **Reserve sage `#4E7D5C`** for the app accent — do not hand it to a tag.
+
+### 1 · Meeting detail pane
+
+Tags get **their own line directly under the meta row** (date · duration · source
+pill), above the calendar info card. Applied tags render left-to-right in the order
+added; the row always ends with an **Add affordance** (a dashed-outline ghost pill).
+Clicking Add opens a **picker popover** anchored below: a search/create field, a
+"TAGS" kicker, a list of catalogue tags (applied ones show a ✓, click toggles), and
+a `＋ Create "<query>"` row when the query matches no existing tag.
+
+### 2 · Meeting list (middle pane)
+
+Each row gains a **third line** of compact pills beneath the when-line, hidden
+entirely when a meeting has no tags. **Cap at 2 pills + a `+N` overflow count.**
+
+### Behaviours & rules
+
+- Tags are **per-meeting**, user-applied, persist on the meeting record. No nesting,
+  no required tags.
+- Removing a tag from a meeting does **not** delete the tag globally — it stays in
+  the catalogue for other meetings.
+- Adding the same tag twice is a no-op.
+- Ordering within a row = order applied.
+
+### Tags in search (V1 behaviour, UI out of scope)
+
+Search itself is not redesigned for V1. The only requirement: **a tag is indexed
+as a meeting field** alongside title / notes / transcript, so typing a tag name in
+the existing search matches meetings carrying that tag. No special search chrome.

--- a/specs/projects/meeting_tags/ui_design.md
+++ b/specs/projects/meeting_tags/ui_design.md
@@ -1,0 +1,206 @@
+---
+status: complete
+---
+
+# UI Design: Meeting Tags
+
+Reconciles the design-agent notes to the real design system (`DesignSystem` module).
+All values below use **real tokens**; literal hexes from the notes are replaced by the
+nearest existing token, except the tag-dot palette (which is new, §6).
+
+Key token map: `ink` (primary text), `inkSecondary` (secondary), `inkTertiary`
+(tertiary/chevrons), `sage` (accent `#4E7D5C`/`#86C295`), `neutralChip` (ink-wash pill
+fill `~6%`), `softSageFill` (sage `~12%`), `cardFill`/`cardStroke`/`controlShadow`
+(popover surface). Mono face is **JetBrains Mono** (`biscottiMono`, `.monoBadge`,
+`.kicker()`); serif is Newsreader (`biscottiSerif`). New colours must be adaptive
+(`dynamicColor`); views never branch on `colorScheme`.
+
+---
+
+## 1 · The tag atom (`TagPill`)
+
+A neutral pill carrying a single coloured **dot**; the **text is never coloured** — only
+the dot. One component, two sizes:
+
+| Property | `.detail` | `.compact` (list) |
+|---|---|---|
+| Height | 22 | 17 |
+| Horizontal padding | 9 | 7 |
+| Corner radius | 6 (`meetChipRadius`) | 5 |
+| Dot diameter | 7 | 6 |
+| Gap dot→text | 6 | 5 |
+| Font | `.system(size: 11.5, weight: .medium)` | `.system(size: 10.5, weight: .medium)` |
+| Fill | `Color.neutralChip` | `Color.neutralChip` |
+| Text colour | `.ink` | `.ink` |
+| Shape | `RoundedRectangle(cornerRadius:)` | same |
+| Text truncation | single line, tail | single line, tail |
+
+Construction mirrors `SourcePill` (a `Label`-style HStack with a leading dot circle).
+`.detail` pills are interactive (hover-✕, §3); `.compact` pills are display-only.
+
+```
+●  Customer        ●  Important          ← .detail, dot = tag colour, text = ink
+```
+
+---
+
+## 2 · Detail pane — tags row
+
+Inserted in `MeetingDetailView.chrome` **between `header` and the calendar card**
+(VStack child spacing is already `Tokens.spacingMD` = 16, so the row sits 16pt under the
+meta line and 16pt above the card — matches the notes' intent without a manual margin).
+
+- A **wrapping** horizontal flow of `.detail` `TagPill`s in alphabetical order, followed
+  always by the **Add affordance** (§4). Inter-item spacing 6.
+- Wrapping needs a flow layout (no native wrap on a plain `HStack`). Use a small
+  `Layout`-protocol `FlowLayout` (added in `DesignSystem` if one doesn't already exist).
+- The row is always present on the detail pane (even with zero tags — it shows just the
+  empty-state Add affordance, which is the entry point to tagging).
+
+```
+Polarity Labs Dive                                   ⊙
+Yesterday at 4:18 PM · 32 min · ▣ Google Meet
+●  Customer   ●  Important   ＋ Add tag                 ← tags row
+┌─ calendar info card ─────────────────────────────┐
+```
+
+---
+
+## 3 · Detail pill — hover to remove
+
+Follows the existing note-row hover pattern (`RecordingNotesView.NoteRowView`):
+
+- `@State` per-pill `hovered` and `xHovered`.
+- A trailing **✕** (`xmark`, `.system(size: 8.5)`) appears on the right of the pill,
+  `opacity(hovered ? 1 : 0)`, colour `xHovered ? .signalRed : .inkTertiary`.
+- The ✕ occupies layout space only while shown is acceptable to *reserve* (prevents text
+  reflow on hover); reserve ~13pt trailing for it inside the pill, or fade it in over the
+  padding. Implementer's choice — no text reflow on hover.
+- Click removes the application immediately (no confirm); list + detail refresh.
+
+---
+
+## 4 · Add affordance (`TagAddButton`)
+
+A ghost pill matching `.detail` dimensions (height 22, radius 6). Three states:
+
+| State | Border | Text/glyph | Hover |
+|---|---|---|---|
+| **Has tags** | 1pt dashed, `ink.opacity(0.26)` | "＋ Add tag", `.inkSecondary` | fill `neutralChip`, border → `ink.opacity(0.4)` |
+| **Empty** (0 tags) | 1pt dashed, `sage.opacity(0.55)` | "Add tags" + tag glyph, `.sage` | faint fill `softSageFill` |
+| **Picker open** | 1pt solid, `.sage` | same as current, `.sage` | (already active) |
+
+- Dashed border via `RoundedRectangle(cornerRadius: 6).strokeBorder(style: StrokeStyle(lineWidth: 1, dash: [3, 2]))`.
+- Glyph: `tag` SF Symbol (empty state) / `plus` (has-tags). Font `.system(size: 11.5, weight: .medium)`.
+- Clicking toggles the picker popover (§5). The button is the popover anchor.
+
+---
+
+## 5 · Tag picker popover
+
+Built on the **`PersonPickerPopover` pattern** (search field + sectioned list + inline
+add + keyboard nav). Attached to the Add button via
+`.popover(isPresented:, arrowEdge: .bottom)`, toggled by a `@State pickerOpen` (same
+open/close idiom as `openPopoverSpeakerID`).
+
+**Surface:** width **260**, `VStack(spacing: 0)`, default popover chrome (the system
+provides the card/shadow; no custom background needed — matches `PersonPickerPopover`).
+
+**Contents, top → bottom:**
+
+1. **Search / create field** — plain `TextField`, placeholder "Add or create a tag…",
+   `.system(size: 13)`, padded `Tokens.spacingSM`, **auto-focused** on appear. A leading
+   `magnifyingglass` (`.inkTertiary`) may prefix it. Filters the list live by
+   case-insensitive **contains**.
+2. `Divider()`.
+3. **Kicker** "TAGS" — `.kicker()` modifier (`.monoKicker`, uppercase, tracking).
+4. **Catalogue list** — alphabetical rows, each a plain `Button`:
+   `HStack { dot(7) · name(.system(size:13), .ink) · Spacer() · ✓ }`. The trailing **✓**
+   (`checkmark`, `.sage`) shows only when the tag is applied to this meeting. Click
+   **toggles** the application (immediate, persisted) and **keeps the popover open**.
+   Highlighted row uses `sage.opacity(0.15)` background (keyboard nav / hover).
+5. **Create row** — shown only when trimmed query is non-empty **and** no tag matches it
+   case-insensitively: a `Button` `＋ Create "<query>"` in `.sage`, full `softSageFill` on
+   hover/highlight. Creates (next round-robin colour) + applies + clears the query; popover
+   stays open.
+
+**Keyboard nav** (carried from `PersonPickerPopover`): ↑/↓ move the highlight across
+[catalogue rows…, create row]; ↩ commits the highlight (toggle or create); ⎋ dismisses.
+Unlike the person picker, committing a catalogue row **toggles and stays open** rather
+than closing.
+
+**Empty catalogue:** field + "TAGS" kicker only; the create row appears as soon as the
+user types.
+
+---
+
+## 6 · Tag-dot palette (new adaptive colours)
+
+A fixed, ordered palette of **8 swatches**, each an adaptive `dynamicColor` (light = the
+notes' hue; dark = a lighter/less-muddy variant for the near-black paper). Sage is
+**reserved** and absent. Assigned round-robin by creation order; stored as a stable slot
+index on the tag. **Dark values below are starting proposals — a human eyeballs them on
+hardware** (per the dark-mode project's review practice).
+
+| Slot | Name | Light | Dark (proposed) | Notes |
+|---|---|---|---|---|
+| 0 | Blue | `#3E6DA8` | `#6E9AD0` | |
+| 1 | Clay | `#B5683E` | `#D08A5E` | |
+| 2 | Violet | `#7A6AAE` | `#A395D0` | |
+| 3 | Slate | `#6B7B86` | `#9AAAB5` | |
+| 4 | Red | `#B23320` | `#E5604A` | reuse `signalRed`'s light/dark pair |
+| 5 | Teal | `#2A8C7E` | `#4FB3A3` | |
+| 6 | Amber | `#A8843A` | `#CBA85E` | |
+| 7 | Olive | `#5E8C3A` | `#8AB861` | |
+
+Exposed as an ordered `[Color]` (e.g. `Color.tagSwatch(slot:)` / a `TagPalette` array)
+defined in `Color+Theme.swift` via `dynamicColor(light:dark:)`. Slot 4 reuses the existing
+`signalRed` token pair rather than redefining it.
+
+---
+
+## 7 · Meeting list — third line
+
+In `MeetingListView.meetingRow`, add a third child to the row `VStack` after the
+when-line, **only when the meeting has tags** (no empty reserve):
+
+- `HStack(spacing: 5)` of `.compact` `TagPill`s, **alphabetical**, capped at the **first 2**.
+- If more than 2, a trailing `+N` in `.monoBadge` (JetBrains Mono Medium 9pt),
+  `.inkSecondary`.
+- Top spacing ~6 under the when-line. Bump the row `VStack` spacing only for the tagged
+  rows so untagged rows keep their current height.
+
+```
+Polarity Labs Dive
+Jun 11 · 32m
+●  Customer   ●  Important   +1            ← compact, only when tagged
+```
+
+**Selection legibility:** the selected row already uses the system's light sage selection
+wash (a tint, `accentWashStrong`), not a solid fill, so coloured dots stay legible. No
+change required; just don't override the dots' colour on selection.
+
+---
+
+## 8 · UX rationale
+
+- **Discoverability:** the empty-state sage "Add tags" affordance turns the otherwise-blank
+  tags row into a visible call-to-action, so users find tagging without hunting.
+- **Low cognitive load:** colour lives only in the dot, so a row of pills stays calm against
+  the ivory paper and scans by hue; the list caps at 2 + `+N` to keep row height stable.
+- **Consistency:** the picker reuses the speaker-mapping popover's exact interaction model,
+  so users meet a pattern they already know; pills reuse `SourcePill`'s construction and
+  the `neutralChip` fill shared by every chip in the app.
+- **Progressive disclosure:** catalogue management (rename/recolour/delete) is intentionally
+  absent from V1 (see functional spec §10); the picker shows only create + apply, the two
+  actions a user needs in the moment.
+
+---
+
+## 9 · New / touched views
+
+- **New:** `TagPill` (DesignSystem), `TagAddButton` (DesignSystem or MeetingDetailUI),
+  `TagPickerPopover` (MeetingDetailUI), tag-dot palette in `Color+Theme.swift`, a
+  `FlowLayout` helper if none exists.
+- **Touched:** `MeetingDetailView.chrome` (insert tags row), `MeetingListView.meetingRow`
+  (insert third line).

--- a/specs/projects/meeting_tags/ui_design.md
+++ b/specs/projects/meeting_tags/ui_design.md
@@ -204,3 +204,99 @@ change required; just don't override the dots' colour on selection.
   `FlowLayout` helper if none exists.
 - **Touched:** `MeetingDetailView.chrome` (insert tags row), `MeetingListView.meetingRow`
   (insert third line).
+
+---
+
+## 10 · Past Meetings list restyle (Phase 4 — styling only)
+
+Repaint the middle-pane meeting list (`MeetingListView`) to the **Sage + Pressroom**
+identity. This is the reconciliation of an external "design agent" style spec (which had no
+codebase access and assumed hard-coded hexes, a plain-white `List`, and IBM Plex Mono) to
+our real design system. **The codebase wins**; every value below is an existing adaptive
+token (so dark mode is a pure swap, no `colorScheme` branching).
+
+> **Strictly styling — no behaviour changes.** Same rows, sort, search, multi-select,
+> ⌫-delete, and keyboard nav. We **keep the native `List(selection:)`** (Q1 decision).
+
+### 10.1 Approach: native first, AppKit shim as fallback
+
+macOS `List` selection is system-blue and there is no clean public SwiftUI API to repaint it
+to a soft wash. **First attempt a pure-SwiftUI re-skin** and review it on screen before going
+further:
+
+- `.tint(.sage)` — recolours the system selection from blue to sage.
+- `.scrollContentBackground(.hidden)` — drops the `List`'s own surface so the pane's ivory
+  `paper` shows through (the column background is already `Tokens.contentBackground = paper`;
+  the white the design spec saw was the `List` surface, **not** the column).
+- `.listRowSeparator(.hidden)` / restyled separators as needed.
+
+The implementer **must web-search to confirm the current best-practice** macOS-15 approach
+for (a) recolouring/suppressing `List` selection and (b) `scrollContentBackground` before
+coding — these APIs are version-sensitive.
+
+The design **intent** is a soft sage **wash** (`accentWashStrong`, sage @14% / @16%) + a
+0.5pt sage **inset ring** (never a solid fill), with the selected row's when-line turning
+sage. Native `.tint` yields a more solid selection than that wash — **that gap is exactly
+what the pre-CR visual review judges.** If `.tint` is "good enough," ship it. **If not, stop
+and escalate** to the documented fallback: an AppKit bridge setting
+`NSTableView.selectionHighlightStyle = .none` plus a `.listRowBackground` that paints
+`accentWashStrong` + a `.sage.opacity(0.22/0.24)` inset ring (add a token
+`accentRingStrong` mirroring the existing `recordingOutlineStrong`) keyed off `selectedIDs`.
+
+> **Decision (visual review #1 — native rejected).** The pure-SwiftUI attempt (`.tint(.sage)`)
+> did **not** recolour the selection — macOS drives `List` selection from the *system accent*,
+> so the highlight stayed system-coloured (`.tint` only affected text we set ourselves). The
+> background also needs its own surface (below). We are therefore implementing the **AppKit
+> suppression path now**: an `NSViewRepresentable` (model on the existing `SearchFieldFocuser`)
+> that walks to the enclosing `NSTableView` and sets `selectionHighlightStyle = .none`, then a
+> `.listRowBackground` keyed off `selectedIDs` paints `accentWashStrong` + a 0.5pt
+> `accentRingStrong` inset ring. This makes the sage wash show **regardless** of the user's
+> system accent. Then back to visual review (still before CR).
+
+> **Decision (visual review #2).** Two fixes: (a) the suppressor must attach **inside** the
+> `List` (e.g. a `.background` on the List's content / a row) and walk **up** to the
+> `NSTableView` — attaching it as a sibling `.background()` of the List leaves the table in a
+> parallel branch, so the system blue kept drawing on top. (b) The selected-row when-line
+> does **not** turn sage — sage *text* is rejected; the when-line stays `.inkSecondary` in all
+> states. Colour on selection lives only in the wash + ring, never the text.
+
+> **Decision (visual review #3 — SOLID sage, not a wash).** The selected Past Meetings row
+> becomes a **solid** sage fill (`accentFill` — light `#4E7D5C` / dark `#56906A`, the deeper
+> *fill* sage, NOT the bright text sage `#86C295`) with **white** text — replacing the wash +
+> ring entirely (the `accentRingStrong` token is now obsolete → removed). Radius 8, horizontal
+> gutter widened to **8pt** (the selection was too wide). Title → white `.medium`; when-line →
+> white @72% (mono); `+N` → white @70%. On a selected row **only**, tag pills switch to a
+> white @18% fill + white text, each coloured dot keeping full hue but gaining a 0.5px white
+> ring so slate/teal/olive don't muddy on sage (new `TagPill(onAccent:)` flag). Default + hover
+> rows, group headers, fonts, and the pane background are unchanged. Dark mode stays a token
+> swap: adaptive `accentFill` + appearance-independent white. White-on-accent values live in
+> new semantic tokens (`onAccent`, `onAccentMuted`, `onAccentChipFill`, `onAccentChipRing`) so
+> views stay literal-free.
+
+### 10.2 Token map (design-spec hex → our token)
+
+| Element | Design-spec value | Our token |
+|---|---|---|
+| Pane background | a distinct **third** warm ivory `#F7F3EB` (NOT `paper`/`sidebarTint`) | **new token** `Color.listPaneBackground` — light `#F7F3EB`, dark **provisional** `#17140D` (eyeball in Phase 5); via `.scrollContentBackground(.hidden)` + `.background(...)` |
+| Right border (list ↔ detail) | `#1A1813 @ 11%` hairline | `Color.hairline` (0.5pt; only if NavigationSplitView's own divider is insufficient) |
+| Selection fill | **solid** sage — light `#4E7D5C`, dark `#56906A` | `Color.accentFill` via `.listRowBackground`: `RoundedRectangle(cornerRadius: 8)`, **8pt** horizontal inset (solid fill, no ring) |
+| Selected-row text | title pure **white** `.medium`; when-line **white @72%**; `+N` **white @70%** | white opacities (`onAccent` / `onAccentMuted`), appearance-independent, `isSelected`-gated |
+| Selected-row tag pills | fill white @18%, text white, dot keeps hue + 0.5px white ring | `TagPill(onAccent: isSelected)` (`onAccentChipFill` / `onAccent` / `onAccentChipRing`) |
+| Row title | SF Pro 13.5 `.medium`, `label` | `.system(size: 13.5, weight: .medium)`, `.ink` (today `.body`) |
+| When-line (date · duration) | mono 11.5, `label2` | `.monoMeta` (JetBrains Mono), `.inkSecondary` (today SF Pro `Tokens.metadataFont`) |
+| Group / section header | mono 10.5 uppercase tracked, `label3` | `.kicker()` / `.monoKicker`, `.inkTertiary` |
+| `+N` overflow | mono, `label3` | `.monoBadge`, `.inkTertiary` (today `.inkSecondary`) |
+| Hover (unselected) | `#1A1813 @ 4.5%` | `Color.neutralChip`-class ink wash (as native `List` allows) |
+| Tag pill (unselected) | neutral fill + coloured dot | **unchanged** — `TagPill(.compact)`, `neutralChip` + `Color.tagSwatch`; cap **3** + `+N` |
+| Tag pill (selected) | white @18% fill, white text, dot keeps hue + 0.5px white ring | `TagPill(onAccent: isSelected)` — `onAccentChipFill`, `onAccent`, `onAccentChipRing` |
+
+**Rules carried over verbatim:** colour lives **only** in the tag dot; the eight dot hues
+stay full saturation on both ivory and the sage fill; **no serif anywhere in the list**;
+the tag line stays hidden when a meeting has no tags. Dark mode changes nothing
+structurally — the tokens above resolve per appearance and the dots are identical across
+light/dark.
+
+### 10.3 Touched view
+
+- **Touched:** `MeetingListView` (list/scroll background, selection treatment, `meetingRow`
+  title/when-line fonts, section-header styling). No data, view-model, or behaviour changes.

--- a/specs/projects/meeting_tags/ui_design.md
+++ b/specs/projects/meeting_tags/ui_design.md
@@ -164,8 +164,8 @@ defined in `Color+Theme.swift` via `dynamicColor(light:dark:)`. Slot 4 reuses th
 In `MeetingListView.meetingRow`, add a third child to the row `VStack` after the
 when-line, **only when the meeting has tags** (no empty reserve):
 
-- `HStack(spacing: 5)` of `.compact` `TagPill`s, **alphabetical**, capped at the **first 2**.
-- If more than 2, a trailing `+N` in `.monoBadge` (JetBrains Mono Medium 9pt),
+- `HStack(spacing: 5)` of `.compact` `TagPill`s, **alphabetical**, capped at the **first 3**.
+- If more than 3, a trailing `+N` in `.monoBadge` (JetBrains Mono Medium 9pt),
   `.inkSecondary`.
 - Top spacing ~6 under the when-line. Bump the row `VStack` spacing only for the tagged
   rows so untagged rows keep their current height.
@@ -187,7 +187,7 @@ change required; just don't override the dots' colour on selection.
 - **Discoverability:** the empty-state sage "Add tags" affordance turns the otherwise-blank
   tags row into a visible call-to-action, so users find tagging without hunting.
 - **Low cognitive load:** colour lives only in the dot, so a row of pills stays calm against
-  the ivory paper and scans by hue; the list caps at 2 + `+N` to keep row height stable.
+  the ivory paper and scans by hue; the list caps at 3 + `+N` to keep row height stable.
 - **Consistency:** the picker reuses the speaker-mapping popover's exact interaction model,
   so users meet a pattern they already know; pills reuse `SourcePill`'s construction and
   the `neutralChip` fill shared by every chip in the app.


### PR DESCRIPTION
## Meeting Tags

Adds user-applied, colour-coded **tags** to meetings — lightweight labels for past meetings, fast to scan, and searchable. V1 surfaces: the **meeting detail pane**, the **meeting list** (middle pane), and the **existing search** (indexing only).

Built spec-first under `specs/projects/meeting_tags/` (overview → functional spec → ui design → architecture → phased plan).

### What's included

- **Phase 1 — Data layer & search.** `Tag` `@Model` + many-to-many `Meeting.tags` (no-cascade so shared tags survive meeting deletion), schema registration, `TagData` DTO, tag CRUD API (round-robin colour slots, case-insensitive dedup, `createTagAndApply`), tags in read-models (alphabetical), and search indexing (`.tags` field, weight 3 = same as title).
- **Phase 2 — Display primitives & list.** Adaptive 8-swatch tag-dot palette, `TagPill` (`.detail`/`.compact`), a `Layout`-based `FlowLayout`, and the compact third line on list rows (first 3 + `+N`).
- **Phase 3 — Detail-pane editing.** `TagAddButton` (three states), `TagPickerPopover` + a pure, unit-tested `computeTagPickerResult` with keyboard nav, view-model wiring (toggle/create/remove + list refresh), and the wrapping tags row in the detail chrome.
- **Phase 4 — Past Meetings list restyle (styling only).** Repaints the middle-pane list to the Sage + Pressroom identity with **no behaviour changes** (selection model, multi-select, ⌫-delete, keyboard nav all intact): warm ivory pane (new `listPaneBackground` third-surface token), a **solid sage selection with white text** that replaces the off-brand system-blue highlight (a `SelectionHighlightSuppressor` sets the backing `NSTableView.selectionHighlightStyle = .none`, and `.listRowBackground` paints `accentFill` keyed off `selectedIDs`), white-on-accent tag pills via a new `TagPill(onAccent:)`, mono when-line + mono uppercase section headers, and SF Pro medium titles.

### Notes & decisions

- **Ordering is alphabetical, not order-applied** — SwiftData to-many relationships are unordered (functional spec §5.1).
- **Schema V1 extended in place** — additive (new entity + defaulted relationship), safe pre-release.
- **Selection restyle:** native `.tint`/asset-accent can't reliably recolour macOS `List` selection (it tracks the system accent), so the solid sage selection is driven by a small AppKit `selectionHighlightStyle = .none` shim + custom `.listRowBackground` — guaranteeing sage regardless of the user's system accent.
- **Adaptive colour discipline:** all new colours are `dynamicColor` tokens; no `colorScheme` branching in views (enforced by an existing test). Dark mode is a pure token swap. Dark tag-dot variants + the provisional `listPaneBackground` dark value were eyeballed during the human visual-review phase.

### Testing

- Full data-layer, search, picker-logic, palette, and `FlowLayout` unit tests added.
- `make ci` green (lint + test + build); `build_app` green. Final suite: **2,211 tests** across the 4 packages.
- The middle-pane restyle went through several rounds of human visual review (light + dark) before sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
