### PR TITLE
Add "Connect a calendar" affordance to onboarding and Settings

### DIFF
--- a/Packages/BiscottiKit/Sources/DesignSystem/ConnectCalendarSheet.swift
+++ b/Packages/BiscottiKit/Sources/DesignSystem/ConnectCalendarSheet.swift
@@ -1,0 +1,168 @@
+import AppKit
+import SwiftUI
+
+/// Instructional sheet guiding the user to add a calendar account to the
+/// macOS Calendar app. Shared between Onboarding and Settings.
+///
+/// Mirrors the established `AlertsHelpSheet` pattern: native `.sheet`,
+/// numbered steps, Cancel + primary action footer.
+public struct ConnectCalendarSheet: View {
+    @Environment(\.dismiss) private var dismiss
+
+    public init() {}
+
+    public var body: some View {
+        VStack(alignment: .leading, spacing: Tokens.spacingMD) {
+            // Title
+            Text("Connect a calendar")
+                .font(.serifHeadline)
+                .foregroundStyle(.ink)
+
+            // Subtitle
+            Text(
+                "Biscotti reads your schedule from the Mac\u{2019}s Calendar app. "
+                    + "Add your account there once and your calendars appear here automatically."
+            )
+            .foregroundStyle(.inkSecondary)
+
+            // Numbered steps
+            VStack(alignment: .leading, spacing: Tokens.spacingSM) {
+                stepRow(number: 1, text: "Open the Calendar app on your Mac.")
+                menuPathStep
+                stepRow(
+                    number: 3,
+                    text: "Pick Google (or your provider) and sign in."
+                )
+                stepRow(
+                    number: 4,
+                    text: "Make sure the calendars you want are checked in Calendar\u{2019}s sidebar."
+                )
+            }
+
+            // Footer
+            HStack {
+                Spacer()
+                Button("Cancel") {
+                    dismiss()
+                }
+                .keyboardShortcut(.cancelAction)
+
+                Button {
+                    openCalendarApp()
+                    dismiss()
+                } label: {
+                    HStack(spacing: 4) {
+                        Text("Open Calendar")
+                        Image(systemName: "arrow.up.right")
+                            .font(.system(size: 10, weight: .semibold))
+                    }
+                }
+                .keyboardShortcut(.defaultAction)
+                .buttonStyle(.borderedProminent)
+                .tint(.sage)
+            }
+        }
+        .padding(Tokens.spacingLG)
+        .frame(width: 520)
+    }
+
+    // MARK: - Step rows
+
+    private func stepRow(number: Int, text: String) -> some View {
+        HStack(alignment: .top, spacing: Tokens.spacingSM) {
+            Text("\(number).")
+                .monospacedDigit()
+            Text(text)
+        }
+    }
+
+    /// Step 2 with the mono chip for the menu path.
+    private var menuPathStep: some View {
+        HStack(alignment: .top, spacing: Tokens.spacingSM) {
+            Text("2.")
+                .monospacedDigit()
+
+            // Wrapping text + inline chip
+            Text("In the menu bar, choose ")
+                + Text("Calendar \u{25B8} Add Account\u{2026}")
+                .font(.biscottiMono(12))
+                + Text(".")
+        }
+    }
+
+    // MARK: - Actions
+
+    private func openCalendarApp() {
+        if let url = NSWorkspace.shared.urlForApplication(
+            withBundleIdentifier: "com.apple.iCal"
+        ) {
+            NSWorkspace.shared.open(url)
+        }
+    }
+}
+
+// MARK: - More Info Link
+
+/// A sage "More info >" link button. Shared between the quiet hint and
+/// empty-state views to open the ConnectCalendarSheet.
+public struct MoreInfoLink: View {
+    private let action: () -> Void
+
+    public init(action: @escaping () -> Void) {
+        self.action = action
+    }
+
+    public var body: some View {
+        Button(action: action) {
+            HStack(spacing: 3) {
+                Text("More info")
+                    .font(.system(size: 13, weight: .semibold))
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 9, weight: .bold))
+            }
+            .foregroundStyle(.sage)
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+// MARK: - Missing Calendars Hint
+
+/// Quiet informational line shown beneath a populated calendar list.
+/// Reads "Missing calendars? Connect them in the Apple Calendar app."
+/// with a "More info >" link that opens the ConnectCalendarSheet.
+///
+/// Do **not** show alongside the empty-state view (the empty state
+/// carries its own "More info" trigger).
+public struct MissingCalendarsHint: View {
+    private let onMoreInfo: () -> Void
+
+    public init(onMoreInfo: @escaping () -> Void) {
+        self.onMoreInfo = onMoreInfo
+    }
+
+    public var body: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "info.circle")
+                .font(.system(size: 13))
+                .foregroundStyle(.inkTertiary)
+
+            Text("Missing calendars? Connect them in the Apple Calendar app.")
+                .font(.system(size: 13))
+                .foregroundStyle(.inkSecondary)
+
+            MoreInfoLink(action: onMoreInfo)
+        }
+    }
+}
+
+#Preview("ConnectCalendarSheet") {
+    ConnectCalendarSheet()
+        .frame(height: 400)
+}
+
+#Preview("MissingCalendarsHint") {
+    MissingCalendarsHint(onMoreInfo: {})
+        .padding()
+        .background(Tokens.contentBackground)
+}

--- a/Packages/BiscottiKit/Sources/OnboardingUI/OnboardingStepViews.swift
+++ b/Packages/BiscottiKit/Sources/OnboardingUI/OnboardingStepViews.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Calendar
 import DesignSystem
 import ModelManagementUI
@@ -213,8 +214,18 @@ extension OnboardingView {
                 .foregroundStyle(.inkSecondary)
                 .padding(.top, 12)
 
-            calendarToggles
-                .padding(.top, 20)
+            if viewModel.calendarGroups.isEmpty {
+                calendarEmptyState
+                    .padding(.top, 20)
+            } else {
+                calendarToggles
+                    .padding(.top, 20)
+
+                MissingCalendarsHint(onMoreInfo: {
+                    viewModel.showConnectCalendarSheet = true
+                })
+                .padding(.top, Tokens.spacingSM)
+            }
 
             Button("Continue") {
                 Task { await viewModel.advance() }
@@ -222,6 +233,50 @@ extension OnboardingView {
             .buttonStyle(OnboardingPrimaryButtonStyle())
             .padding(.top, 24)
         }
+        .sheet(isPresented: $viewModel.showConnectCalendarSheet) {
+            ConnectCalendarSheet()
+        }
+        .onReceive(
+            NotificationCenter.default.publisher(
+                for: NSApplication.didBecomeActiveNotification
+            )
+        ) { _ in
+            Task { await viewModel.reloadCalendars() }
+        }
+    }
+
+    /// Rich empty state for onboarding: icon tile + serif headline + body + "More info".
+    private var calendarEmptyState: some View {
+        VStack(spacing: Tokens.spacingSM) {
+            // Calendar icon tile
+            RoundedRectangle(cornerRadius: Tokens.buttonRadius)
+                .fill(Color.neutralChip)
+                .frame(width: 48, height: 48)
+                .overlay(
+                    Image(systemName: "calendar")
+                        .font(.system(size: 22))
+                        .foregroundStyle(.inkSecondary)
+                )
+
+            Text("No calendars found")
+                .font(.serifHeadline)
+                .foregroundStyle(.ink)
+
+            Text(
+                "If you use Google Calendar in the browser, add your Google account to the Mac\u{2019}s Calendar app so Biscotti can see your events."
+            )
+            .font(.system(size: 14))
+            .foregroundStyle(.inkSecondary)
+            .multilineTextAlignment(.center)
+            .frame(maxWidth: 400)
+
+            MoreInfoLink(action: {
+                viewModel.showConnectCalendarSheet = true
+            })
+        }
+        .padding(Tokens.spacingLG)
+        .homeCard()
+        .frame(maxWidth: 520)
     }
 
     private var calendarToggles: some View {

--- a/Packages/BiscottiKit/Sources/OnboardingUI/OnboardingViewModel.swift
+++ b/Packages/BiscottiKit/Sources/OnboardingUI/OnboardingViewModel.swift
@@ -98,6 +98,9 @@ public final class OnboardingViewModel {
     /// Presentation state for the "See all options" Manage Models sheet.
     public var showVariantSheet: Bool = false
 
+    /// Presentation state for the "Connect a calendar" how-to sheet.
+    public var showConnectCalendarSheet: Bool = false
+
     // MARK: - Granted-state derivation
 
     /// Whether the microphone permission has been granted in this session.
@@ -282,6 +285,15 @@ public final class OnboardingViewModel {
         }
     }
 
+    /// Reload the calendar list from EventKit. Called when the app
+    /// returns to the foreground while on the calendar-selection step,
+    /// so newly added accounts appear without restarting.
+    public func reloadCalendars() async {
+        guard currentStep == .calendarSelection else { return }
+        let infos = await core.calendar.calendars()
+        calendarGroups = Self.groupCalendars(infos)
+    }
+
     /// Open System Settings for a denied permission.
     public func openSettings(for kind: PermissionKind) {
         let url = core.permissions.settingsURL(for: kind)
@@ -321,6 +333,7 @@ public final class OnboardingViewModel {
         transcriptionDownloaded = false
         isPreparingModelStep = false
         showVariantSheet = false
+        showConnectCalendarSheet = false
         hasSufficientDisk = true
     }
 

--- a/Packages/BiscottiKit/Sources/SettingsUI/SettingsCalendarSection.swift
+++ b/Packages/BiscottiKit/Sources/SettingsUI/SettingsCalendarSection.swift
@@ -1,0 +1,68 @@
+import Calendar
+import DesignSystem
+import Permissions
+import SwiftUI
+
+// MARK: - Calendar section (extracted for type_body_length)
+
+extension SettingsView {
+    var calendarSection: some View {
+        Section(Self.sectionTitles[4]) {
+            if viewModel.calendarState == .authorized {
+                if viewModel.calendarGroups.isEmpty {
+                    settingsCalendarEmptyState
+                } else {
+                    ForEach(viewModel.calendarGroups) { group in
+                        Section(header: Text(group.sourceTitle)) {
+                            ForEach(group.calendars) { cal in
+                                calendarRow(cal)
+                            }
+                        }
+                    }
+
+                    MissingCalendarsHint(onMoreInfo: {
+                        showConnectCalendar = true
+                    })
+                }
+            } else {
+                Text("Calendar access not granted.")
+                    .font(Tokens.metadataFont)
+                    .foregroundStyle(Tokens.secondaryText)
+                permissionActionButton(
+                    state: viewModel.calendarState,
+                    kind: .calendar
+                )
+            }
+        }
+        .sheet(isPresented: $showConnectCalendar) {
+            ConnectCalendarSheet()
+        }
+        .onReceive(
+            NotificationCenter.default.publisher(
+                for: NSApplication.didBecomeActiveNotification
+            )
+        ) { _ in
+            Task { await viewModel.reloadCalendars() }
+        }
+    }
+
+    /// Lighter empty state for Settings: headline + one line + "More info",
+    /// fitting the grouped Form aesthetic without the big icon tile.
+    var settingsCalendarEmptyState: some View {
+        VStack(alignment: .leading, spacing: Tokens.spacingXS) {
+            Text("No calendars found")
+                .font(.headline)
+
+            Text(
+                "If you use Google Calendar in the browser, add your account to the Mac\u{2019}s Calendar app."
+            )
+            .font(Tokens.metadataFont)
+            .foregroundStyle(Tokens.secondaryText)
+
+            MoreInfoLink(action: {
+                showConnectCalendar = true
+            })
+            .padding(.top, 2)
+        }
+    }
+}

--- a/Packages/BiscottiKit/Sources/SettingsUI/SettingsView.swift
+++ b/Packages/BiscottiKit/Sources/SettingsUI/SettingsView.swift
@@ -12,11 +12,15 @@ import SwiftUI
 /// In-window settings screen. General preferences, permissions overview
 /// with inline request/grant actions, and calendar include/exclude.
 public struct SettingsView: View {
-    /// Internal (not private) so the cross-file extension in
-    /// SettingsSystemAudioRow.swift can bind to it.
+    /// Internal (not private) so cross-file extensions in
+    /// SettingsSystemAudioRow.swift and SettingsCalendarSection.swift
+    /// can bind to it.
     @Bindable var viewModel: SettingsViewModel
     @State private var showAlertsHelp = false
     @State private var showManageModels = false
+    /// Internal (not private) so the cross-file calendar section extension
+    /// can present the sheet.
+    @State var showConnectCalendar = false
     @State private var summaryPromptModel: SummaryPromptModel?
 
     public init(viewModel: SettingsViewModel) {
@@ -164,37 +168,9 @@ public struct SettingsView: View {
         )
     }
 
-    // MARK: - Calendar section
+    // MARK: - Calendar helpers (section body is in SettingsCalendarSection.swift)
 
-    private var calendarSection: some View {
-        Section(Self.sectionTitles[4]) {
-            if viewModel.calendarState == .authorized {
-                if viewModel.calendarGroups.isEmpty {
-                    Text("No calendars found.")
-                        .font(Tokens.metadataFont)
-                        .foregroundStyle(Tokens.secondaryText)
-                } else {
-                    ForEach(viewModel.calendarGroups) { group in
-                        Section(header: Text(group.sourceTitle)) {
-                            ForEach(group.calendars) { cal in
-                                calendarRow(cal)
-                            }
-                        }
-                    }
-                }
-            } else {
-                Text("Calendar access not granted.")
-                    .font(Tokens.metadataFont)
-                    .foregroundStyle(Tokens.secondaryText)
-                permissionActionButton(
-                    state: viewModel.calendarState,
-                    kind: .calendar
-                )
-            }
-        }
-    }
-
-    private func calendarRow(_ cal: CalendarInfo) -> some View {
+    func calendarRow(_ cal: CalendarInfo) -> some View {
         Toggle(isOn: calendarBinding(cal.id)) {
             HStack(spacing: Tokens.spacingSM) {
                 Circle()
@@ -205,7 +181,7 @@ public struct SettingsView: View {
         }
     }
 
-    private func calendarBinding(_ id: String) -> Binding<Bool> {
+    func calendarBinding(_ id: String) -> Binding<Bool> {
         Binding(
             get: { viewModel.isCalendarEnabled(id) },
             set: { _ in Task { await viewModel.toggleCalendar(id) } }
@@ -261,7 +237,7 @@ public struct SettingsView: View {
     /// - `.denied` -> "Open Settings" (deep link to System Settings)
     /// - `.authorized` -> no button
     @ViewBuilder
-    private func permissionActionButton(
+    func permissionActionButton(
         state: PermissionState,
         kind: PermissionKind
     ) -> some View {

--- a/Packages/BiscottiKit/Sources/SettingsUI/SettingsViewModel.swift
+++ b/Packages/BiscottiKit/Sources/SettingsUI/SettingsViewModel.swift
@@ -411,6 +411,14 @@ public final class SettingsViewModel {
         calendarGroups = Self.groupCalendars(infos)
     }
 
+    /// Re-fetches the calendar list from EventKit. Called on app-foreground
+    /// so that newly added accounts appear without restarting.
+    public func reloadCalendars() async {
+        guard calendarState == .authorized else { return }
+        let infos = await core.calendar.calendars()
+        calendarGroups = Self.groupCalendars(infos)
+    }
+
     // MARK: - Grouping (pure, testable)
 
     /// Groups CalendarInfo items by sourceTitle.

--- a/Packages/BiscottiKit/Tests/OnboardingUITests/OnboardingViewModelTests.swift
+++ b/Packages/BiscottiKit/Tests/OnboardingUITests/OnboardingViewModelTests.swift
@@ -286,6 +286,69 @@ struct OnboardingViewModelTests {
         #expect(model.transcriptionDownloaded == false)
         #expect(model.isPreparingModelStep == false)
         #expect(model.showVariantSheet == false)
+        #expect(model.showConnectCalendarSheet == false)
         #expect(model.hasSufficientDisk == true)
+    }
+}
+
+// MARK: - Calendar reload on foreground
+
+@Suite("OnboardingViewModel -- calendar reload")
+@MainActor
+struct OnboardingCalendarReloadTests {
+    @Test("reloadCalendars fetches calendars when on calendarSelection step")
+    func reloadCalendarsOnCalendarStep() async throws {
+        let fixture = try makeCoreFixture(
+            calendarAuthStatus: .authorized,
+            calendarInfos: []
+        )
+        defer { fixture.cleanup() }
+
+        let model = OnboardingViewModel(core: fixture.core)
+
+        // Navigate to calendar selection step
+        await model.advance() // welcome -> permissions
+        await model.requestCalendar()
+        await model.advance() // permissions -> calendarSelection
+
+        #expect(model.currentStep == .calendarSelection)
+        #expect(model.calendarGroups.isEmpty)
+
+        // Simulate adding a calendar externally
+        fixture.fakeEventStore.calendarInfos = [
+            CalendarInfo(
+                id: "c1", title: "Work",
+                colorHex: "#0066CC", sourceTitle: "Google"
+            )
+        ]
+
+        await model.reloadCalendars()
+
+        #expect(model.calendarGroups.count == 1)
+        #expect(model.calendarGroups[0].calendars[0].title == "Work")
+    }
+
+    @Test("reloadCalendars is a no-op when not on calendarSelection step")
+    func reloadCalendarsNoOpOnOtherSteps() async throws {
+        let fixture = try makeCoreFixture(
+            calendarAuthStatus: .denied
+        )
+        defer { fixture.cleanup() }
+
+        let model = OnboardingViewModel(core: fixture.core)
+
+        // Stay on welcome step
+        #expect(model.currentStep == .welcome)
+
+        // Even if there are calendars available, reload should not fetch
+        fixture.fakeEventStore.calendarInfos = [
+            CalendarInfo(
+                id: "c1", title: "Work",
+                colorHex: "#0066CC", sourceTitle: "Google"
+            )
+        ]
+
+        await model.reloadCalendars()
+        #expect(model.calendarGroups.isEmpty)
     }
 }

--- a/Packages/BiscottiKit/Tests/SettingsUITests/SettingsViewModelTests.swift
+++ b/Packages/BiscottiKit/Tests/SettingsUITests/SettingsViewModelTests.swift
@@ -576,3 +576,57 @@ struct SettingsSystemAudioTests {
         #expect(viewModel.systemAudioState == .requestedNotVerified)
     }
 }
+
+// MARK: - Calendar reload on foreground
+
+@Suite("SettingsViewModel -- calendar reload")
+@MainActor
+struct SettingsCalendarReloadTests {
+    @Test("reloadCalendars fetches calendars when authorized")
+    func reloadCalendarsWhenAuthorized() async throws {
+        let fixture = try makeCoreFixture(
+            calendarAuthStatus: .authorized,
+            calendarInfos: []
+        )
+        defer { fixture.cleanup() }
+
+        let viewModel = SettingsViewModel(core: fixture.core)
+        await viewModel.load()
+
+        #expect(viewModel.calendarGroups.isEmpty)
+
+        // Simulate adding a calendar externally
+        fixture.fakeEventStore.calendarInfos = [
+            CalendarInfo(
+                id: "c1", title: "Work",
+                colorHex: "#0066CC", sourceTitle: "Google"
+            )
+        ]
+
+        await viewModel.reloadCalendars()
+
+        #expect(viewModel.calendarGroups.count == 1)
+        #expect(viewModel.calendarGroups[0].calendars[0].title == "Work")
+    }
+
+    @Test("reloadCalendars is a no-op when not authorized")
+    func reloadCalendarsNoOpWhenNotAuthorized() async throws {
+        let fixture = try makeCoreFixture(
+            calendarAuthStatus: .denied
+        )
+        defer { fixture.cleanup() }
+
+        let viewModel = SettingsViewModel(core: fixture.core)
+
+        // Even if calendars are available, reload should not fetch
+        fixture.fakeEventStore.calendarInfos = [
+            CalendarInfo(
+                id: "c1", title: "Work",
+                colorHex: "#0066CC", sourceTitle: "Google"
+            )
+        ]
+
+        await viewModel.reloadCalendars()
+        #expect(viewModel.calendarGroups.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary

Adds a "Connect a calendar" affordance that guides users who live in browser-based calendars (e.g. Google Calendar) to add their account to the macOS Calendar app, so Biscotti can see their events via EventKit. The affordance is present at every list state — populated and empty — across **Onboarding** and **Settings → Calendars**.

Built from a design spec (treated as visual/UX intent) mapped onto the existing design system and SwiftUI patterns.

## What's included

**Shared components (in `DesignSystem`, reused by both flows):**
- `ConnectCalendarSheet` — native `.sheet` modeled on `AlertsHelpSheet`: serif title + subtitle, numbered 1–4 how-to steps with `Calendar ▸ Add Account…` as a JetBrains-Mono chip, footer = `Cancel` + sage **Open Calendar** (↗) that launches Calendar.app via `NSWorkspace`.
- `MissingCalendarsHint` — quiet grey "Missing calendars? … More info ›" line, shown only beneath populated lists.
- `MoreInfoLink` — shared sage "More info ›" chevron link.

**Onboarding (`.calendarSelection` step):**
- Rich empty state when no calendars: icon tile + serif headline + Google-in-browser explanation + its own "More info ›".
- `MissingCalendarsHint` beneath the populated toggle list.
- Continue/Skip footer and skip-when-unauthorized navigation left untouched.

**Settings → Calendars:**
- Lighter empty state (headline + one line + "More info ›") that fits the grouped Form aesthetic — no big icon tile.
- `MissingCalendarsHint` beneath the populated list.
- Calendar section extracted to `SettingsCalendarSection.swift` (lint body-length).

**Refresh-on-foreground** on both surfaces (`didBecomeActiveNotification`), guarded to no-op off-step / when unauthorized — so the empty state resolves on its own after the user adds an account and returns. (No full `EKEventStoreChanged` observation — out of scope by design.)

## Notes
- All colors/fonts via DesignSystem tokens, light + dark adaptive (no hardcoded hex, no `colorScheme` branching). We ship JetBrains Mono, not IBM Plex.
- The `Calendar` package data layer is untouched, so no ManualTestApp staleness marking is required.
- The sheet quotes the exact macOS menu path (`Calendar ▸ Add Account…`) — worth a glance against the shipping OS wording.

## Test plan
- `make ci` (lint + 2283 tests + build) green; app target builds.
- New tests cover `reloadCalendars` happy-path + guard no-op for both `OnboardingViewModel` and `SettingsViewModel`; `resetForReplay` resets the sheet state.
- Manual UI pass: onboarding Calendars step (empty + populated), Settings → Calendars (empty + populated), and the sheet from each trigger, in light + dark mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
