### PR TITLE
Reclaim idle memory via malloc_zone_pressure_relief after window close & recording stop

### DIFF
--- a/App/Sources/BiscottiApp.swift
+++ b/App/Sources/BiscottiApp.swift
@@ -331,9 +331,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate,
         let hasVisibleWindows = NSApp.windows.contains { window in
             window.isVisible && window.canBecomeMain
         }
-        if !hasVisibleWindows {
-            NSApp.setActivationPolicy(.accessory)
-        }
+        guard !hasVisibleWindows else { return }
+        NSApp.setActivationPolicy(.accessory)
+        // The window's view tree is being torn down; reclaim its
+        // (transient) footprint back to the OS shortly after, once
+        // SwiftUI has finished deallocating the views.
+        MemoryPressure.relieve(after: 1, reason: "window-close")
     }
 
     /// Shows the main window and switches to regular app mode

--- a/Packages/BiscottiKit/Sources/AppCore/AppCore.swift
+++ b/Packages/BiscottiKit/Sources/AppCore/AppCore.swift
@@ -476,6 +476,11 @@ public final class AppCore {
             await intelligence.runAutoEnhancements(meetingID: meetingID)
         }
 
+        // The audio engine and its capture buffers were just torn down;
+        // reclaim that ~transient footprint back to the OS. Delayed so the
+        // teardown has fully settled before we scavenge.
+        MemoryPressure.relieve(after: 4, reason: "recording-stop")
+
         return meetingID
     }
 

--- a/Packages/BiscottiKit/Sources/AppCore/MemoryPressure.swift
+++ b/Packages/BiscottiKit/Sources/AppCore/MemoryPressure.swift
@@ -1,0 +1,41 @@
+import Darwin
+import Foundation
+import os
+
+/// Returns free heap pages to the kernel to shrink the process's resident
+/// footprint after a large transient allocation is released.
+///
+/// Biscotti lives in the menu bar ~99% of the time; the UI window and an
+/// active recording are the two big memory spikes, and both should fully
+/// recover when they end. `malloc` holds freed pages in per-zone caches
+/// rather than handing them straight back to the OS, so resident memory
+/// stays high even once the views/audio buffers are deallocated.
+/// `malloc_zone_pressure_relief(nil, 0)` walks every zone and scavenges as
+/// much of that cache back to the kernel as it can.
+///
+/// We schedule the scavenge on a short delay so SwiftUI/AppKit have
+/// finished tearing the views down (and audio buffers have drained) before
+/// we ask malloc to reclaim — otherwise the pages aren't free yet.
+public enum MemoryPressure {
+    private static let logger = Logger(
+        subsystem: "net.scosman.biscotti",
+        category: "memory"
+    )
+
+    /// Schedules a malloc pressure-relief pass `delay` seconds from now.
+    ///
+    /// - Parameters:
+    ///   - delay: Seconds to wait before scavenging, giving the triggering
+    ///     teardown time to actually free its allocations.
+    ///   - reason: Short label for the log line (e.g. `"window-close"`).
+    public static func relieve(after delay: TimeInterval, reason: String) {
+        // Hop to a utility queue: the scavenge can briefly block, and there
+        // is no reason to do it on the main thread.
+        DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + delay) {
+            let reclaimed = malloc_zone_pressure_relief(nil, 0)
+            logger.debug(
+                "pressure relief (\(reason, privacy: .public)): reclaimed \(reclaimed) bytes"
+            )
+        }
+    }
+}


### PR DESCRIPTION

Biscotti lives in the menu bar ~99% of the time, but malloc holds freed pages in per-zone caches rather than returning them to the OS, so resident memory stays elevated after the two big transient spikes (the UI window and an active recording) end.

Add a small `MemoryPressure` helper in AppCore that schedules `malloc_zone_pressure_relief(nil, 0)` on a utility queue after a short delay (letting the teardown settle before scavenging), and wire it into the two recovery points:

- 1s after the window closes and the app drops to accessory mode (handleWindowClosed) — also converts the if to a guard.
- 4s after recording stops (AppCore.stopRecording).

First experiment toward shrinking idle footprint back toward the ~27MB launch-to-tray baseline. Pressure relief only reclaims already-freed pages, so it cannot disturb in-flight transcription allocations.