### PR TITLE
Fix Copy button feedback not rendering on the Notes tab

### DIFF
--- a/Packages/BiscottiKit/Sources/MeetingDetailUI/MeetingDetailView.swift
+++ b/Packages/BiscottiKit/Sources/MeetingDetailUI/MeetingDetailView.swift
@@ -604,6 +604,15 @@ private extension MeetingDetailView {
                 case .notes:
                     viewModel.copyNotes()
                 }
+                // Release focus from the Notes/Summary MarkdownEditor's
+                // NSTextView (if it currently holds first responder) so
+                // this button's own "Copied" feedback below is guaranteed
+                // to redraw immediately. Without this, clicking Copy
+                // while actively editing Notes silently copies the text
+                // but leaves the button showing "Copy" -- AppKit defers
+                // the button's redraw while an NSTextView elsewhere in
+                // the window still owns keyboard focus.
+                NSApp.keyWindow?.makeFirstResponder(nil)
                 didCopy = true
                 copyResetTask?.cancel()
                 copyResetTask = Task {


### PR DESCRIPTION
## Problem

Closes #54.

Clicking **Copy** on the **Notes** tab copies the notes text correctly, but the button's "Copied ✓" confirmation frequently doesn't appear -- it keeps showing "Copy". This is most noticeable right after typing in the notes editor (leaving it focused) and then clicking Copy without clicking elsewhere first. The Summary tab's identical button doesn't show this because users typically copy a freshly-generated summary without ever clicking into its editor.

This is a distinct bug from the Transcript-tab one (#53 / #55) -- the Notes tab uses the same `scrollViewLayout` `ScrollView` path as Summary, not the `List`-based path that caused #53, and I confirmed there's no structural difference in Biscotti's own view code between Notes and Summary's chrome/button wiring.

## Root cause

The Notes editor (`MarkdownEditor`, backed by `swift-markdown-engine`'s `NativeTextViewWrapper`) is a real `NSTextView` hosted via `NSViewRepresentable`. When it holds first responder / keyboard focus and the user clicks a sibling SwiftUI `.borderless` `Button` elsewhere in the same window, the button's action does fire (the copy happens), but AppKit can defer redrawing sibling SwiftUI-native content until the text view yields focus. The `didCopy` state flip is computed correctly, but the checkmark doesn't reach the screen until something else forces a redraw later.

## Fix

Explicitly resign first responder (`NSApp.keyWindow?.makeFirstResponder(nil)`) at the start of the Copy button's action, alongside the existing `didCopy = true` state change, so its own redraw is never deferred behind an active text-editing session. This is a one-line, low-risk change scoped to the shared Copy button (in `MeetingDetailView.swift`), so it applies uniformly to all three tabs -- also a reasonable UX default (a toolbar action blurring whatever text field you were just typing in).

## Checks

- `swift build --target MeetingDetailUI` succeeds cleanly with no new warnings.
- This is a single self-contained hunk with no test-visible surface (it doesn't touch any `MeetingDetailViewModel` method the existing `CopyNotesTests` exercise), so no test changes were needed.
- As noted on #55, I hit a pre-existing, unrelated Swift 6.3 type-checker timeout in `AppShellUITests.swift` that blocks a full local `swift test` run in this environment; confirmed via `git stash` that it reproduces identically on a clean `main` checkout.

## ⚠️ On-device verification recommended

This is a focus/redraw-timing issue, so the strongest confirmation is visual: type in the Notes tab's editor, leave the cursor there, click Copy without clicking away first, and confirm the button flips to "Copied ✓" immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
