### PR TITLE
Fix transcription always producing English; add a spoken-language setting

### DIFF
--- a/Packages/BiscottiKit/Sources/AppCore/AppCore+Live.swift
+++ b/Packages/BiscottiKit/Sources/AppCore/AppCore+Live.swift
@@ -215,12 +215,14 @@ private struct LiveTranscriberAdapter: Transcribing {
     func processAudio(
         mic: URL,
         system: URL,
-        customVocabulary: [String]
+        customVocabulary: [String],
+        language: TranscriptionLanguage
     ) async throws -> TranscriptResult {
         try await transcriber.processAudio(
             mic: mic,
             system: system,
-            customVocabulary: customVocabulary
+            customVocabulary: customVocabulary,
+            language: language
         )
     }
 

--- a/Packages/BiscottiKit/Sources/AppCore/PreviewAppCore.swift
+++ b/Packages/BiscottiKit/Sources/AppCore/PreviewAppCore.swift
@@ -127,7 +127,8 @@
         func processAudio(
             mic _: URL,
             system _: URL,
-            customVocabulary _: [String]
+            customVocabulary _: [String],
+            language _: TranscriptionLanguage
         ) async throws -> TranscriptResult {
             TranscriptResult(
                 id: UUID(),

--- a/Packages/BiscottiKit/Sources/DataStore/DataStore+ReadModels.swift
+++ b/Packages/BiscottiKit/Sources/DataStore/DataStore+ReadModels.swift
@@ -1,6 +1,10 @@
 import Foundation
 import SwiftData
 
+// Re-exported so downstream modules (AppCore, SettingsUI) can read and write
+// the language setting without importing Transcription themselves.
+@_exported import enum Transcription.TranscriptionLanguage
+
 // MARK: - Read-Model DTOs
 
 /// A lightweight summary of a meeting for list views.
@@ -183,6 +187,8 @@ public struct AppSettingsData: Sendable, Equatable {
     public var stopRecordingAutomatically: Bool
     /// Which calendar events trigger pre-meeting notifications.
     public var calendarNotificationMode: CalendarNotificationMode
+    /// The spoken language transcription is pinned to. `.auto` detects it.
+    public var transcriptionLanguage: TranscriptionLanguage
     public var onboardingComplete: Bool
     /// `nil` = all calendars enabled (the default).
     public var enabledCalendarIDs: Set<String>?
@@ -205,6 +211,7 @@ public struct AppSettingsData: Sendable, Equatable {
         monitorForMeetings: Bool = true,
         stopRecordingAutomatically: Bool = true,
         calendarNotificationMode: CalendarNotificationMode = .allMeetings,
+        transcriptionLanguage: TranscriptionLanguage = .auto,
         onboardingComplete: Bool = false,
         enabledCalendarIDs: Set<String>? = nil,
         aiAnalysisEnabled: Bool = true,
@@ -219,6 +226,7 @@ public struct AppSettingsData: Sendable, Equatable {
         self.monitorForMeetings = monitorForMeetings
         self.stopRecordingAutomatically = stopRecordingAutomatically
         self.calendarNotificationMode = calendarNotificationMode
+        self.transcriptionLanguage = transcriptionLanguage
         self.onboardingComplete = onboardingComplete
         self.enabledCalendarIDs = enabledCalendarIDs
         self.aiAnalysisEnabled = aiAnalysisEnabled
@@ -494,6 +502,7 @@ public extension DataStore {
                 monitorForMeetings: existing.monitorForMeetings,
                 stopRecordingAutomatically: existing.stopRecordingAutomatically,
                 calendarNotificationMode: CalendarNotificationMode(raw: existing.calendarNotificationModeRaw),
+                transcriptionLanguage: TranscriptionLanguage(raw: existing.transcriptionLanguageRaw),
                 onboardingComplete: existing.onboardingComplete,
                 enabledCalendarIDs: existing.enabledCalendarIDs,
                 aiAnalysisEnabled: existing.aiAnalysisEnabled,
@@ -529,6 +538,7 @@ public extension DataStore {
             monitorForMeetings: model.monitorForMeetings,
             stopRecordingAutomatically: model.stopRecordingAutomatically,
             calendarNotificationMode: CalendarNotificationMode(raw: model.calendarNotificationModeRaw),
+            transcriptionLanguage: TranscriptionLanguage(raw: model.transcriptionLanguageRaw),
             onboardingComplete: model.onboardingComplete,
             enabledCalendarIDs: model.enabledCalendarIDs,
             aiAnalysisEnabled: model.aiAnalysisEnabled,
@@ -545,6 +555,7 @@ public extension DataStore {
         model.monitorForMeetings = dto.monitorForMeetings
         model.stopRecordingAutomatically = dto.stopRecordingAutomatically
         model.calendarNotificationModeRaw = dto.calendarNotificationMode.rawValue
+        model.transcriptionLanguageRaw = dto.transcriptionLanguage.rawValue
         model.onboardingComplete = dto.onboardingComplete
         model.enabledCalendarIDs = dto.enabledCalendarIDs
         model.aiAnalysisEnabled = dto.aiAnalysisEnabled

--- a/Packages/BiscottiKit/Sources/DataStore/Models/AppSettings.swift
+++ b/Packages/BiscottiKit/Sources/DataStore/Models/AppSettings.swift
@@ -41,6 +41,11 @@ import SwiftData
     /// String for SwiftData safety (same pattern as other enum-backed fields).
     public var calendarNotificationModeRaw: String = "allMeetings"
 
+    /// Raw string backing for `TranscriptionLanguage` — the Whisper language
+    /// code, or "auto" to let the model detect it. Same String-backed pattern
+    /// as `calendarNotificationModeRaw`.
+    public var transcriptionLanguageRaw: String = "auto"
+
     /// Whether the user has completed the onboarding wizard.
     public var onboardingComplete: Bool = false
 
@@ -89,6 +94,7 @@ import SwiftData
         monitorForMeetings: Bool = true,
         stopRecordingAutomatically: Bool = true,
         calendarNotificationModeRaw: String = "allMeetings",
+        transcriptionLanguageRaw: String = "auto",
         onboardingComplete: Bool = false,
         enabledCalendarIDs: Set<String>? = nil,
         aiAnalysisEnabled: Bool = true,
@@ -103,6 +109,7 @@ import SwiftData
         self.monitorForMeetings = monitorForMeetings
         self.stopRecordingAutomatically = stopRecordingAutomatically
         self.calendarNotificationModeRaw = calendarNotificationModeRaw
+        self.transcriptionLanguageRaw = transcriptionLanguageRaw
         self.onboardingComplete = onboardingComplete
         if let enabledCalendarIDs {
             enabledCalendarIDsData = (try? JSONEncoder().encode(Array(enabledCalendarIDs).sorted())) ?? Data()

--- a/Packages/BiscottiKit/Sources/SettingsUI/SettingsCalendarSection.swift
+++ b/Packages/BiscottiKit/Sources/SettingsUI/SettingsCalendarSection.swift
@@ -7,7 +7,7 @@ import SwiftUI
 
 extension SettingsView {
     var calendarSection: some View {
-        Section(Self.sectionTitles[4]) {
+        Section(Self.sectionTitles[5]) {
             if viewModel.calendarState == .authorized {
                 if viewModel.calendarGroups.isEmpty {
                     settingsCalendarEmptyState

--- a/Packages/BiscottiKit/Sources/SettingsUI/SettingsView.swift
+++ b/Packages/BiscottiKit/Sources/SettingsUI/SettingsView.swift
@@ -35,6 +35,7 @@ public struct SettingsView: View {
         "Permissions",
         "Notifications",
         "AI Enhancements",
+        "Transcription",
         "Calendars"
     ]
 
@@ -60,6 +61,7 @@ public struct SettingsView: View {
                     permissionsSection
                     notificationsSection
                     aiEnhancementsSection
+                    transcriptionSection
                     calendarSection
 
                     #if DEBUG
@@ -406,6 +408,39 @@ private extension SettingsView {
             },
             set: { newValue in
                 Task { await viewModel.setAIAnalysisEnabled(newValue) }
+            }
+        )
+    }
+}
+
+// MARK: - Transcription section
+
+private extension SettingsView {
+    var transcriptionSection: some View {
+        Section(Self.sectionTitles[4]) {
+            VStack(alignment: .leading, spacing: Tokens.spacingXS) {
+                Picker(
+                    "Spoken Language",
+                    selection: transcriptionLanguageBinding
+                ) {
+                    ForEach(TranscriptionLanguage.allCases) { language in
+                        Text(language.displayText).tag(language)
+                    }
+                }
+                Text(
+                    "Pick the language spoken in your meetings. Auto-detect reads it from the first moments of audio."
+                )
+                .font(Tokens.metadataFont)
+                .foregroundStyle(Tokens.secondaryText)
+            }
+        }
+    }
+
+    var transcriptionLanguageBinding: Binding<TranscriptionLanguage> {
+        Binding(
+            get: { viewModel.transcriptionLanguage },
+            set: { newValue in
+                Task { await viewModel.setTranscriptionLanguage(newValue) }
             }
         )
     }

--- a/Packages/BiscottiKit/Sources/SettingsUI/SettingsViewModel.swift
+++ b/Packages/BiscottiKit/Sources/SettingsUI/SettingsViewModel.swift
@@ -78,6 +78,12 @@ public final class SettingsViewModel {
     /// and `.none` (notifications disabled entirely).
     public private(set) var showStayVisibleRow = false
 
+    // MARK: - Transcription
+
+    /// The spoken language transcription is pinned to. `.auto` lets the model
+    /// detect it from the audio.
+    public private(set) var transcriptionLanguage: TranscriptionLanguage = .auto
+
     /// Whether the calendar notification picker should be disabled
     /// (calendar access not authorized).
     public var calendarNotificationsDisabled: Bool {
@@ -395,6 +401,7 @@ public final class SettingsViewModel {
             monitorForMeetings = settings.monitorForMeetings
             calendarNotificationMode = settings.calendarNotificationMode
             stopRecordingAutomatically = settings.stopRecordingAutomatically
+            transcriptionLanguage = settings.transcriptionLanguage
             aiAnalysisEnabled = settings.aiAnalysisEnabled
         } catch {
             enabledCalendarIDs = nil
@@ -435,6 +442,27 @@ public final class SettingsViewModel {
                     calendars: calendars.sorted { $0.title < $1.title }
                 )
             }
+    }
+}
+
+// MARK: - Transcription settings actions
+
+public extension SettingsViewModel {
+    /// Updates the spoken language used for transcription and persists it.
+    /// The next transcription (or re-transcription) picks it up; transcripts
+    /// already on disk are untouched.
+    func setTranscriptionLanguage(
+        _ language: TranscriptionLanguage
+    ) async {
+        let previous = transcriptionLanguage
+        transcriptionLanguage = language
+        do {
+            try await core.store.updateSettings { settings in
+                settings.transcriptionLanguage = language
+            }
+        } catch {
+            transcriptionLanguage = previous
+        }
     }
 }
 

--- a/Packages/BiscottiKit/Sources/TranscriptionService/Transcribing.swift
+++ b/Packages/BiscottiKit/Sources/TranscriptionService/Transcribing.swift
@@ -13,11 +13,13 @@ public protocol Transcribing: Sendable {
         status: (@Sendable (String) -> Void)?
     ) async throws
 
-    /// Run STT + diarization on mic + system audio files.
+    /// Run STT + diarization on mic + system audio files. `language` pins the
+    /// spoken language; `.auto` leaves it to the model to detect.
     func processAudio(
         mic: URL,
         system: URL,
-        customVocabulary: [String]
+        customVocabulary: [String],
+        language: TranscriptionLanguage
     ) async throws -> TranscriptResult
 
     /// Returns `true` when models are already present on disk (no download
@@ -34,6 +36,7 @@ public protocol Transcribing: Sendable {
 
 // Re-export Transcription types so downstream modules (AppCore, UI) can use
 // `TranscriptResult` without importing Transcription directly.
+@_exported import enum Transcription.TranscriptionLanguage
 @_exported import struct Transcription.TranscriptResult
 @_exported import struct Transcription.TranscriptSegment
 @_exported import struct Transcription.TranscriptWord

--- a/Packages/BiscottiKit/Sources/TranscriptionService/TranscriptionService.swift
+++ b/Packages/BiscottiKit/Sources/TranscriptionService/TranscriptionService.swift
@@ -208,16 +208,29 @@ public final class TranscriptionService {
         paths: (mic: URL, system: URL)
     ) async -> TranscriptResult? {
         jobs[meetingID] = .transcribing
+        let language = await transcriptionLanguage()
         do {
             return try await engine.processAudio(
                 mic: paths.mic,
                 system: paths.system,
-                customVocabulary: []
+                customVocabulary: [],
+                language: language
             )
         } catch {
             let (message, retriable) = mapEngineError(error)
             jobs[meetingID] = .failed(message: message, retriable: retriable)
             return nil
+        }
+    }
+
+    /// The spoken language the user picked in Settings. Falls back to `.auto`
+    /// if the settings read fails -- an unreadable preference should degrade to
+    /// detection, not abort the job.
+    private func transcriptionLanguage() async -> TranscriptionLanguage {
+        do {
+            return try await store.settings().transcriptionLanguage
+        } catch {
+            return .auto
         }
     }
 

--- a/Packages/BiscottiKit/Tests/BiscottiTestSupport/FakeTranscriber.swift
+++ b/Packages/BiscottiKit/Tests/BiscottiTestSupport/FakeTranscriber.swift
@@ -16,6 +16,7 @@ public struct FakeTranscriber: Transcribing, @unchecked Sendable {
         public var lastMicURL: URL?
         public var lastSystemURL: URL?
         public var lastVocabulary: [String]?
+        public var lastLanguage: TranscriptionLanguage?
 
         /// Number of times `ensureModelsDownloaded` has been called.
         public var ensureModelsCallCount = 0
@@ -87,12 +88,14 @@ public struct FakeTranscriber: Transcribing, @unchecked Sendable {
     public func processAudio(
         mic: URL,
         system: URL,
-        customVocabulary: [String]
+        customVocabulary: [String],
+        language: TranscriptionLanguage
     ) async throws -> TranscriptResult {
         backing.processAudioCalled = true
         backing.lastMicURL = mic
         backing.lastSystemURL = system
         backing.lastVocabulary = customVocabulary
+        backing.lastLanguage = language
         if let error = backing.processAudioError {
             throw error
         }

--- a/Packages/BiscottiKit/Tests/DataStoreTests/TranscriptionLanguageSettingsTests.swift
+++ b/Packages/BiscottiKit/Tests/DataStoreTests/TranscriptionLanguageSettingsTests.swift
@@ -1,0 +1,35 @@
+import DataStore
+import Testing
+
+@Suite("DataStore -- transcription language round-trip")
+struct TranscriptionLanguageSettingsTests {
+    @Test("settings default the transcription language to auto")
+    func defaultsToAuto() async throws {
+        let store = try DataStore(storage: .inMemory)
+        let settings = try await store.settings()
+        #expect(settings.transcriptionLanguage == .auto)
+    }
+
+    @Test("updateSettings persists the transcription language")
+    func updateSettingsPersists() async throws {
+        let store = try DataStore(storage: .inMemory)
+        try await store.updateSettings { settings in
+            settings.transcriptionLanguage = .russian
+        }
+
+        let result = try await store.settings()
+        #expect(result.transcriptionLanguage == .russian)
+    }
+
+    @Test("every language round-trips through the store")
+    func everyLanguageRoundTrips() async throws {
+        let store = try DataStore(storage: .inMemory)
+        for language in TranscriptionLanguage.allCases {
+            try await store.updateSettings { settings in
+                settings.transcriptionLanguage = language
+            }
+            let result = try await store.settings()
+            #expect(result.transcriptionLanguage == language)
+        }
+    }
+}

--- a/Packages/BiscottiKit/Tests/SettingsUITests/SettingsLayoutTests.swift
+++ b/Packages/BiscottiKit/Tests/SettingsUITests/SettingsLayoutTests.swift
@@ -8,13 +8,14 @@ struct SettingsLayoutTests {
     /// the titles AND their order as they appear on screen. The physical
     /// section ordering in `body` (which computed property appears first)
     /// is verified in the Phase 12 manual pass.
-    @Test("section titles match spec order: General, Permissions, Notifications, AI, Calendars")
+    @Test("section titles match spec order: General, Permissions, Notifications, AI, Transcription, Calendars")
     func sectionTitlesMatchSpec() {
         let expected = [
             "General",
             "Permissions",
             "Notifications",
             "AI Enhancements",
+            "Transcription",
             "Calendars"
         ]
         #expect(SettingsView.sectionTitles == expected)

--- a/Packages/BiscottiKit/Tests/SettingsUITests/SettingsTranscriptionSettingsTests.swift
+++ b/Packages/BiscottiKit/Tests/SettingsUITests/SettingsTranscriptionSettingsTests.swift
@@ -1,0 +1,46 @@
+import AppCore
+import BiscottiTestSupport
+import DataStore
+import Foundation
+import Testing
+@testable import SettingsUI
+
+@Suite("SettingsViewModel -- transcription settings")
+@MainActor
+struct SettingsTranscriptionSettingsTests {
+    @Test("transcriptionLanguage defaults to auto")
+    func languageDefault() throws {
+        let fix = try makeCoreFixture()
+        defer { fix.cleanup() }
+        let viewModel = SettingsViewModel(core: fix.core)
+        #expect(viewModel.transcriptionLanguage == .auto)
+    }
+
+    @Test("load populates the transcription language from the store")
+    func loadPopulatesLanguage() async throws {
+        let fix = try makeCoreFixture()
+        defer { fix.cleanup() }
+
+        try await fix.store.updateSettings { settings in
+            settings.transcriptionLanguage = .russian
+        }
+
+        let viewModel = SettingsViewModel(core: fix.core)
+        await viewModel.load()
+
+        #expect(viewModel.transcriptionLanguage == .russian)
+    }
+
+    @Test("setTranscriptionLanguage persists the choice")
+    func setLanguagePersists() async throws {
+        let fix = try makeCoreFixture()
+        defer { fix.cleanup() }
+        let viewModel = SettingsViewModel(core: fix.core)
+
+        await viewModel.setTranscriptionLanguage(.russian)
+        #expect(viewModel.transcriptionLanguage == .russian)
+
+        let settings = try await fix.store.settings()
+        #expect(settings.transcriptionLanguage == .russian)
+    }
+}

--- a/Packages/BiscottiKit/Tests/TranscriptionServiceTests/TranscriptionServiceTests.swift
+++ b/Packages/BiscottiKit/Tests/TranscriptionServiceTests/TranscriptionServiceTests.swift
@@ -76,6 +76,7 @@ struct TranscriptionSuccessTests {
         #expect(fix.fakeEngine.backing.lastMicURL?.path == "/tmp/test/mic.aac")
         #expect(fix.fakeEngine.backing.lastSystemURL?.path == "/tmp/test/system.aac")
         #expect(fix.fakeEngine.backing.lastVocabulary == [])
+        #expect(fix.fakeEngine.backing.lastLanguage == .auto)
 
         // Job status is completed
         #expect(fix.service.jobs[meetingID] == .completed)
@@ -85,6 +86,21 @@ struct TranscriptionSuccessTests {
         #expect(detail?.preferredTranscript != nil)
         #expect(detail?.preferredTranscript?.speakerCount == 2)
         #expect(detail?.preferredTranscript?.segments.count == 2)
+    }
+
+    @Test("Transcribe passes the language from settings to the engine")
+    @MainActor
+    func transcribeUsesSettingsLanguage() async throws {
+        let fix = try makeFixture()
+        let meetingID = try await fix.createMeetingWithAudio()
+
+        try await fix.store.updateSettings { settings in
+            settings.transcriptionLanguage = .russian
+        }
+
+        await fix.service.transcribe(meetingID: meetingID)
+
+        #expect(fix.fakeEngine.backing.lastLanguage == .russian)
     }
 
     @Test("Re-transcribe adds a new version and promotes it")
@@ -551,7 +567,8 @@ private struct ReentrantShutdownFakeTranscriber: Transcribing, @unchecked Sendab
     func processAudio(
         mic _: URL,
         system _: URL,
-        customVocabulary _: [String]
+        customVocabulary _: [String],
+        language _: TranscriptionLanguage
     ) async throws -> TranscriptResult {
         FakeTranscriber.defaultResult
     }
@@ -609,7 +626,8 @@ private struct BlockingFakeTranscriber: Transcribing, @unchecked Sendable {
     func processAudio(
         mic _: URL,
         system _: URL,
-        customVocabulary _: [String]
+        customVocabulary _: [String],
+        language _: TranscriptionLanguage
     ) async throws -> TranscriptResult {
         backing.processAudioCalled = true
         // Poll until unblocked (simulates a long-running operation)
@@ -783,7 +801,8 @@ private struct BlockingOnDownloadFakeTranscriber: Transcribing, @unchecked Senda
     func processAudio(
         mic _: URL,
         system _: URL,
-        customVocabulary _: [String]
+        customVocabulary _: [String],
+        language _: TranscriptionLanguage
     ) async throws -> TranscriptResult {
         FakeTranscriber.defaultResult
     }

--- a/Packages/Transcription/Sources/Transcription/InProcessTranscriptionEngine.swift
+++ b/Packages/Transcription/Sources/Transcription/InProcessTranscriptionEngine.swift
@@ -78,9 +78,10 @@ public actor InProcessTranscriptionEngine: TranscriptionEngine {
     public func processAudio(
         micPath: String,
         systemPath: String,
-        customVocabulary: [String]
+        customVocabulary: [String],
+        language: TranscriptionLanguage
     ) async throws -> TranscriptResult {
-        Self.log.debug("processAudio: begin")
+        Self.log.debug("processAudio: begin (language=\(language.rawValue))")
         let startTime = CFAbsoluteTimeGetCurrent()
 
         let mergeResult = try loadAndMergeAudio(
@@ -90,7 +91,9 @@ public actor InProcessTranscriptionEngine: TranscriptionEngine {
         await statusMachine.transition(to: .running)
 
         let sttResults = try await runSTT(
-            audioArray: mergeResult.samples, customVocabulary: customVocabulary
+            audioArray: mergeResult.samples,
+            customVocabulary: customVocabulary,
+            language: language
         )
 
         if resolvedSettings.sequentialLoading { await unloadWhisperKit() }
@@ -193,12 +196,21 @@ private extension InProcessTranscriptionEngine {
     }
 
     func runSTT(
-        audioArray: [Float], customVocabulary: [String]
+        audioArray: [Float],
+        customVocabulary: [String],
+        language: TranscriptionLanguage
     ) async throws -> [TranscriptionResult] {
         do {
             try await ensureWhisperKitLoaded()
 
+            // `task` and `detectLanguage` are spelled out because their
+            // defaults are the wrong ones for us: WhisperKit leaves detection
+            // off, and with a nil language that prefills `<|en|>`, which
+            // transcribes non-English speech into English.
             var decodingOptions = DecodingOptions(
+                task: .transcribe,
+                language: language.code,
+                detectLanguage: language == .auto,
                 wordTimestamps: resolvedSettings.enableWordTimestamps
             )
 

--- a/Packages/Transcription/Sources/Transcription/Transcriber.swift
+++ b/Packages/Transcription/Sources/Transcription/Transcriber.swift
@@ -140,11 +140,13 @@ public actor Transcriber {
     ///   - mic: URL to the mic audio file.
     ///   - system: URL to the system audio file.
     ///   - customVocabulary: Custom vocabulary terms for biasing.
+    ///   - language: The spoken language to transcribe, or `.auto` to detect it.
     /// - Returns: A rich diarized `TranscriptResult`.
     public func processAudio(
         mic: URL,
         system: URL,
-        customVocabulary: [String] = []
+        customVocabulary: [String] = [],
+        language: TranscriptionLanguage = .auto
     ) async throws -> TranscriptResult {
         Self.log.info("client: processAudio called")
         try checkInterrupted()
@@ -154,7 +156,8 @@ public actor Transcriber {
             let result = try await activeEngine.processAudio(
                 micPath: mic.path,
                 systemPath: system.path,
-                customVocabulary: customVocabulary
+                customVocabulary: customVocabulary,
+                language: language
             )
             emitStatus(.ready)
             return result
@@ -171,13 +174,20 @@ public actor Transcriber {
     ///   - mic: URL to the mic audio file.
     ///   - system: URL to the system audio file.
     ///   - customVocabulary: Custom vocabulary terms.
+    ///   - language: The spoken language to transcribe, or `.auto` to detect it.
     /// - Returns: A rich diarized `TranscriptResult`.
     public func reTranscribe(
         mic: URL,
         system: URL,
-        customVocabulary: [String] = []
+        customVocabulary: [String] = [],
+        language: TranscriptionLanguage = .auto
     ) async throws -> TranscriptResult {
-        try await processAudio(mic: mic, system: system, customVocabulary: customVocabulary)
+        try await processAudio(
+            mic: mic,
+            system: system,
+            customVocabulary: customVocabulary,
+            language: language
+        )
     }
 
     /// Explicitly unload all models from memory.
@@ -203,7 +213,7 @@ public actor Transcriber {
     /// For `.inProcess` this is a no-op. For `.hosted` this invalidates
     /// the underlying `NSXPCConnection`, which causes `launchd` to terminate
     /// the idle worker. The next ``ensureModelsDownloaded(status:)`` or
-    /// ``processAudio(mic:system:customVocabulary:)`` call will transparently
+    /// ``processAudio(mic:system:customVocabulary:language:)`` call will transparently
     /// re-establish the connection.
     ///
     /// Callers should call this after a transcription batch completes so the

--- a/Packages/Transcription/Sources/Transcription/TranscriberServiceProtocol.swift
+++ b/Packages/Transcription/Sources/Transcription/TranscriberServiceProtocol.swift
@@ -10,14 +10,14 @@ import Foundation
 @objc public protocol TranscriberServiceProtocol {
     /// Process audio files and return a diarized transcript.
     ///
-    /// Audio paths and vocabulary are bundled into a single
+    /// Audio paths, vocabulary and spoken language are bundled into a single
     /// JSON-encoded `Data` parameter (`requestData`) to keep the `@objc`
     /// parameter count manageable. The request shape is defined by
     /// `XPCProcessRequest` (internal to the Transcription package).
     ///
     /// - Parameters:
     ///   - requestData: JSON-encoded `XPCProcessRequest` containing audio
-    ///     paths and custom vocabulary.
+    ///     paths, custom vocabulary and the spoken language.
     ///   - reply: Callback with JSON-encoded `TranscriptResult` data or an error.
     func processAudio(
         requestData: Data,

--- a/Packages/Transcription/Sources/Transcription/TranscriptionEngine.swift
+++ b/Packages/Transcription/Sources/Transcription/TranscriptionEngine.swift
@@ -24,12 +24,17 @@ public protocol TranscriptionEngine: Sendable {
     /// uses ``TranscriptionMethod/current`` internally; the result carries
     /// the method id in ``TranscriptResult/transcriptionMethodId``.
     ///
+    /// `language` pins the STT decoder to a spoken language; pass `.auto` to
+    /// have it detected from the audio. The language actually used lands in
+    /// ``TranscriptResult/language``.
+    ///
     /// - Throws: `TranscriptionError.invalidInput` if audio files are
     ///   empty/unreadable.
     func processAudio(
         micPath: String,
         systemPath: String,
-        customVocabulary: [String]
+        customVocabulary: [String],
+        language: TranscriptionLanguage
     ) async throws -> TranscriptResult
 
     /// Explicitly unload all models from memory. The engine remains usable;

--- a/Packages/Transcription/Sources/Transcription/TranscriptionLanguage.swift
+++ b/Packages/Transcription/Sources/Transcription/TranscriptionLanguage.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+/// The spoken language the STT model is told to expect.
+///
+/// `.auto` asks WhisperKit to detect the language from the first audio window.
+/// Every other case pins the decoder to that language, which both skips the
+/// detection pass and guarantees the transcript comes back in the language that
+/// was spoken.
+///
+/// Pinning matters because WhisperKit's own default is neither of those: with
+/// no language and detection off it prefills the `<|en|>` token, so non-English
+/// speech is transcribed *into English*. `.auto` therefore has to turn
+/// `DecodingOptions.detectLanguage` on explicitly -- see
+/// ``InProcessTranscriptionEngine``.
+///
+/// Raw values are the Whisper language codes, so the stored settings string is
+/// the code itself.
+public enum TranscriptionLanguage: String, CaseIterable, Sendable, Codable, Identifiable {
+    case auto
+    case arabic = "ar"
+    case chinese = "zh"
+    case dutch = "nl"
+    case english = "en"
+    case french = "fr"
+    case german = "de"
+    case hindi = "hi"
+    case italian = "it"
+    case japanese = "ja"
+    case korean = "ko"
+    case polish = "pl"
+    case portuguese = "pt"
+    case russian = "ru"
+    case spanish = "es"
+    case turkish = "tr"
+    case ukrainian = "uk"
+
+    public var id: String {
+        rawValue
+    }
+
+    /// The Whisper language code, or `nil` for `.auto` (meaning "detect it").
+    public var code: String? {
+        self == .auto ? nil : rawValue
+    }
+
+    /// Human-readable label for the picker. Derived from the code rather than a
+    /// hand-written table, so adding a language only takes one line above.
+    ///
+    /// Resolved against a fixed English locale, not `Locale.current`: the rest
+    /// of the UI is English, and a picker that renamed itself with the system
+    /// language would be the only screen that did.
+    public var displayText: String {
+        guard let code else { return "Auto-Detect" }
+        return Self.labelLocale.localizedString(forLanguageCode: code) ?? code
+    }
+
+    private static let labelLocale = Locale(identifier: "en_US")
+
+    /// Stored-string -> enum, defaulting to `.auto` for unknown values.
+    public init(raw: String) {
+        self = Self(rawValue: raw) ?? .auto
+    }
+}

--- a/Packages/Transcription/Sources/Transcription/XPCEngineAdapter.swift
+++ b/Packages/Transcription/Sources/Transcription/XPCEngineAdapter.swift
@@ -52,13 +52,15 @@ final class XPCEngineAdapter: TranscriptionEngine, @unchecked Sendable {
     func processAudio(
         micPath: String,
         systemPath: String,
-        customVocabulary: [String]
+        customVocabulary: [String],
+        language: TranscriptionLanguage
     ) async throws -> TranscriptResult {
         let proxy = try requireProxy()
         let request = XPCProcessRequest(
             micPath: micPath,
             systemPath: systemPath,
-            customVocabulary: customVocabulary
+            customVocabulary: customVocabulary,
+            language: language
         )
         let requestData = try encodeRequest(request)
 

--- a/Packages/Transcription/Sources/Transcription/XPCProcessRequest.swift
+++ b/Packages/Transcription/Sources/Transcription/XPCProcessRequest.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// The request payload for `TranscriberServiceProtocol.processAudio(requestData:reply:)`.
 ///
-/// Bundles the audio paths and custom vocabulary into a single
+/// Bundles the audio paths, custom vocabulary and spoken language into a single
 /// JSON-encoded `Data` blob for transport across the XPC boundary. This keeps
 /// the `@objc` protocol's parameter count within lint limits while remaining
 /// fully `Codable`.
@@ -10,10 +10,17 @@ public struct XPCProcessRequest: Codable {
     public let micPath: String
     public let systemPath: String
     public let customVocabulary: [String]
+    public let language: TranscriptionLanguage
 
-    public init(micPath: String, systemPath: String, customVocabulary: [String]) {
+    public init(
+        micPath: String,
+        systemPath: String,
+        customVocabulary: [String],
+        language: TranscriptionLanguage
+    ) {
         self.micPath = micPath
         self.systemPath = systemPath
         self.customVocabulary = customVocabulary
+        self.language = language
     }
 }

--- a/Packages/Transcription/Sources/transcribe-cli/TranscribeCLI.swift
+++ b/Packages/Transcription/Sources/transcribe-cli/TranscribeCLI.swift
@@ -25,6 +25,12 @@ struct TranscribeCLI: AsyncParsableCommand {
     @Option(name: .long, help: "Comma-separated custom vocabulary terms.")
     var vocab: String?
 
+    @Option(
+        name: .long,
+        help: "Spoken language to transcribe. 'auto' detects it from the audio."
+    )
+    var language: TranscriptionLanguage = .auto
+
     @Flag(name: .long, help: "Output TranscriptResult as JSON to stdout.")
     var json: Bool = false
 
@@ -53,7 +59,8 @@ struct TranscribeCLI: AsyncParsableCommand {
         let result = try await transcriber.processAudio(
             mic: micURL,
             system: systemURL,
-            customVocabulary: vocabTerms
+            customVocabulary: vocabTerms,
+            language: language
         )
 
         writer.writeStderr("Done. Elapsed: \(String(format: "%.1f", result.processingDuration))s")
@@ -89,6 +96,7 @@ struct TranscribeCLI: AsyncParsableCommand {
         writer.writeStderr("Mic:        \(mic)")
         writer.writeStderr("System:     \(system)")
         writer.writeStderr("Method:     \(TranscriptionMethod.current.id)")
+        writer.writeStderr("Language:   \(language.rawValue)")
         if !vocabTerms.isEmpty {
             writer.writeStderr("Vocabulary: \(vocabTerms.joined(separator: ", "))")
         }
@@ -97,6 +105,11 @@ struct TranscribeCLI: AsyncParsableCommand {
 }
 
 // MARK: - Argument processing helpers
+
+/// Lets `--language ru` parse straight into the enum. RawRepresentable gives
+/// ArgumentParser the parsing, CaseIterable gives it the list of valid values
+/// for `--help` and for the error on a bad one.
+extension TranscriptionLanguage: ExpressibleByArgument {}
 
 /// Parse the `--vocab` flag value into an array of trimmed terms.
 func parseVocab(_ raw: String?) -> [String] {

--- a/Packages/Transcription/Tests/TranscriptionTests/HostedClientTests.swift
+++ b/Packages/Transcription/Tests/TranscriptionTests/HostedClientTests.swift
@@ -328,7 +328,8 @@ struct XPCEngineAdapterTests {
 
         do {
             _ = try await adapter.processAudio(
-                micPath: "/tmp/mic.wav", systemPath: "/tmp/system.wav", customVocabulary: []
+                micPath: "/tmp/mic.wav", systemPath: "/tmp/system.wav",
+                customVocabulary: [], language: .auto
             )
             Issue.record("Expected workerUnavailable")
         } catch {
@@ -370,7 +371,8 @@ struct XPCEngineAdapterRoundTripTests {
         let result = try await adapter.processAudio(
             micPath: "/tmp/mic.wav",
             systemPath: "/tmp/system.wav",
-            customVocabulary: ["Biscotti", "WhisperKit"]
+            customVocabulary: ["Biscotti", "WhisperKit"],
+            language: .russian
         )
 
         // Verify the result round-tripped correctly
@@ -385,6 +387,7 @@ struct XPCEngineAdapterRoundTripTests {
         #expect(receivedRequest?.micPath == "/tmp/mic.wav")
         #expect(receivedRequest?.systemPath == "/tmp/system.wav")
         #expect(receivedRequest?.customVocabulary == ["Biscotti", "WhisperKit"])
+        #expect(receivedRequest?.language == .russian)
     }
 
     @Test("unloadModels round-trips through mock service")
@@ -407,7 +410,8 @@ struct XPCEngineAdapterRoundTripTests {
 
         do {
             _ = try await adapter.processAudio(
-                micPath: "/tmp/mic.wav", systemPath: "/tmp/system.wav", customVocabulary: []
+                micPath: "/tmp/mic.wav", systemPath: "/tmp/system.wav",
+                customVocabulary: [], language: .auto
             )
             Issue.record("Expected workerInterrupted")
         } catch {
@@ -425,7 +429,8 @@ struct XPCEngineAdapterRoundTripTests {
 
         do {
             _ = try await adapter.processAudio(
-                micPath: "/tmp/mic.wav", systemPath: "/tmp/system.wav", customVocabulary: []
+                micPath: "/tmp/mic.wav", systemPath: "/tmp/system.wav",
+                customVocabulary: [], language: .auto
             )
             Issue.record("Expected workerUnavailable")
         } catch {
@@ -445,7 +450,8 @@ struct XPCEngineAdapterRoundTripTests {
 
         do {
             _ = try await adapter.processAudio(
-                micPath: "/tmp/mic.wav", systemPath: "/tmp/system.wav", customVocabulary: []
+                micPath: "/tmp/mic.wav", systemPath: "/tmp/system.wav",
+                customVocabulary: [], language: .auto
             )
             Issue.record("Expected transcriptionFailed")
         } catch {

--- a/Packages/Transcription/Tests/TranscriptionTests/TranscriberTestHelpers.swift
+++ b/Packages/Transcription/Tests/TranscriptionTests/TranscriberTestHelpers.swift
@@ -12,6 +12,7 @@ actor StubTranscriptionEngine: TranscriptionEngine {
     var ensureModelsError: (any Error)?
     var currentStatus: ModelStatus = .ready
     var processAudioCallCount = 0
+    var lastLanguage: TranscriptionLanguage?
     var ensureModelsCallCount = 0
     var unloadCallCount = 0
     var modelsPresentCallCount = 0
@@ -32,9 +33,11 @@ actor StubTranscriptionEngine: TranscriptionEngine {
     func processAudio(
         micPath _: String,
         systemPath _: String,
-        customVocabulary _: [String]
+        customVocabulary _: [String],
+        language: TranscriptionLanguage
     ) async throws -> TranscriptResult {
         processAudioCallCount += 1
+        lastLanguage = language
         if let error = processAudioError { throw error }
         guard let result = processAudioResult else {
             throw TranscriptionError.invalidInput("No result configured in stub")

--- a/Packages/Transcription/Tests/TranscriptionTests/TranscriptionLanguageTests.swift
+++ b/Packages/Transcription/Tests/TranscriptionTests/TranscriptionLanguageTests.swift
@@ -1,0 +1,43 @@
+import Testing
+@testable import Transcription
+
+@Suite("TranscriptionLanguage")
+struct TranscriptionLanguageTests {
+    @Test("auto has no Whisper code so the engine can turn detection on")
+    func autoHasNoCode() {
+        #expect(TranscriptionLanguage.auto.code == nil)
+    }
+
+    @Test("every other case carries its Whisper code as the raw value")
+    func codesAreRawValues() {
+        #expect(TranscriptionLanguage.russian.code == "ru")
+        #expect(TranscriptionLanguage.english.code == "en")
+
+        for language in TranscriptionLanguage.allCases where language != .auto {
+            #expect(language.code == language.rawValue)
+        }
+    }
+
+    @Test("auto sorts first in the picker order")
+    func autoSortsFirst() {
+        #expect(TranscriptionLanguage.allCases.first == .auto)
+    }
+
+    @Test("unknown stored strings fall back to auto")
+    func unknownRawFallsBackToAuto() {
+        #expect(TranscriptionLanguage(raw: "klingon") == .auto)
+        #expect(TranscriptionLanguage(raw: "") == .auto)
+        #expect(TranscriptionLanguage(raw: "ru") == .russian)
+    }
+
+    @Test("picker labels are English regardless of the system locale")
+    func displayTextIsPopulated() {
+        #expect(TranscriptionLanguage.auto.displayText == "Auto-Detect")
+        #expect(TranscriptionLanguage.russian.displayText == "Russian")
+        #expect(TranscriptionLanguage.english.displayText == "English")
+
+        for language in TranscriptionLanguage.allCases {
+            #expect(!language.displayText.isEmpty)
+        }
+    }
+}

--- a/XPCServices/BiscottiTranscriber/main.swift
+++ b/XPCServices/BiscottiTranscriber/main.swift
@@ -59,7 +59,8 @@ final class TranscriberService: NSObject, TranscriberServiceProtocol, @unchecked
                 let result = try await engine.processAudio(
                     micPath: request.micPath,
                     systemPath: request.systemPath,
-                    customVocabulary: request.customVocabulary
+                    customVocabulary: request.customVocabulary,
+                    language: request.language
                 )
                 let data = try JSONEncoder().encode(result)
                 reply(data, nil)


### PR DESCRIPTION
## Problem

A meeting held in Russian came back as an English transcript — before any LLM step, with no summarization model downloaded at all.

## Root cause

`InProcessTranscriptionEngine.runSTT` built its options as `DecodingOptions(wordTimestamps:)`, leaving `language` nil and `detectLanguage` at its default of `!usePrefillPrompt` — i.e. off.

WhisperKit only detects the language when all three of `isModelMultilingual`, `options.language == nil` and `options.detectLanguage` hold (`TranscribeTask.swift`). Otherwise `TextDecoder.prefillDecoderInputs` prefills `"<|\(options.language ?? Constants.defaultLanguageCode)|>"`, which is `<|en|>`. Since V1 runs the multilingual `openai_whisper-large-v3-v20240930_626MB`, every non-English meeting was effectively translated into English.

## Change

`TranscriptionLanguage` — `.auto` plus 16 Whisper language codes as raw values — threaded from a new Settings picker down to the decoder:

`SettingsView` → `AppSettings.transcriptionLanguageRaw` / `AppSettingsData` → `TranscriptionService` → `Transcribing` → `Transcriber` → `TranscriptionEngine` → `XPCProcessRequest` → `BiscottiTranscriber` → `InProcessTranscriptionEngine`.

The engine now spells out the options whose defaults were wrong for us:

```swift
var decodingOptions = DecodingOptions(
    task: .transcribe,
    language: language.code,
    detectLanguage: language == .auto,
    wordTimestamps: resolvedSettings.enableWordTimestamps
)
```

- `.auto` is the default and turns detection on, so the fix applies without anyone touching Settings.
- Picking a language pins the decoder to it: no detection pass, and no translation.
- Also available as `transcribe-cli --language ru`; `ExpressibleByArgument` gives `--help` the value list and rejects unknown codes.
- `AppSettings` gains one defaulted property, which SwiftData migrates additively (no V2 needed).
- Picker labels resolve against a fixed `en_US` locale rather than `Locale.current`, so this screen doesn't rename itself with the system language while the rest of the UI stays English.
- A "Transcription" section joins `SettingsView.sectionTitles` before Calendars, shifting the Calendars index to 5.

Existing transcripts are untouched; re-transcribing a meeting picks up the setting.

## Notes

`TranscriptionService` still passes `customVocabulary: []` — left alone deliberately, since custom vocab is blocked on the upstream `promptTokens` bug.

The Transcription manual-test steps (`tx_*`) were already recorded as `not-run`, so `manual_test_results.json` needs no change for the staleness rule.

## Testing

- `make build` green.
- `swiftlint --strict` clean; `swiftformat --lint` clean under 0.61.1 (0.62.1 added `wrapIfStatementBodies`, which flags ~250 pre-existing lines repo-wide).
- New tests: `TranscriptionLanguage` (codes, ordering, unknown-value fallback, English labels), DataStore round-trip for every language, `SettingsViewModel` load/persist, and `TranscriptionService` passing the configured language to the engine. The `XPCEngineAdapter` round-trip test now asserts the language survives the JSON request.
- `Packages/Transcription`: 200 tests pass.
- `XPCServices/BiscottiTranscriber/main.swift` type-checks against the new engine signature.
