### PR TITLE
CI: drop the Icon Composer icon before the app-tier build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,5 +66,18 @@ jobs:
       # and BiscottiKit is built by xcodebuild as a local package dependency.
       - name: Install dev tools
         run: brew install xcodegen
+      # CI-ONLY WORKAROUND — do not mirror this locally.
+      # Compiling the Icon Composer bundle App/Resources/AppIcon.icon kills
+      # AssetCatalogAgent on the runner ("IBPlatformToolFailureException: The
+      # tool closed the connection"), failing CompileAssetCatalogVariant. The
+      # same icon builds fine on the identical Xcode 26.3 (17C529) locally, so
+      # this is a headless-runner fault, not bad icon data. app-tier exists to
+      # prove the app still compiles and links, which does not need the icon.
+      # Deleting it here touches the runner's checkout only; the icon stays in
+      # the repo and in every local/release build.
+      # TODO: remove this step once the runner's Xcode can compile .icon
+      # bundles; re-check by deleting it and watching this job.
+      - name: Drop Icon Composer icon (CI-only workaround)
+        run: rm -rf App/Resources/AppIcon.icon
       - name: Generate + build app
         run: make build-app


### PR DESCRIPTION
## Problem

`app-tier` (App build) has failed on **every** `main` run since 2026-07-07 — the day `App/Resources/AppIcon.icon` was added. The failure is always the same:

```
*** Terminating app due to uncaught exception 'IBPlatformToolFailureException',
    reason: 'The tool closed the connection (AssetCatalogAgent-AssetRuntime)
Command CompileAssetCatalogVariant failed with a nonzero exit code
```

`AssetCatalogAgent` dies while compiling the Icon Composer bundle.

## Why this is not an Xcode-version problem

The same icon builds clean locally on the **identical** Xcode 26.3 (17C529) that `ci.yml` pins via `DEVELOPER_DIR`. Same version, same committed icon, same code, opposite result — so the toolchain version is not the variable.

Pinning an older Xcode is not an option regardless:

- `ci.yml:7-9` documents that the runner's default Xcode 16.4 lacks `Schema.Version: Sendable` in its SwiftData SDK, which breaks `swift test`/`xcodebuild` under Swift 6. That is why the 26.3 pin exists.
- Icon Composer `.icon` bundles are an Xcode 26 feature; an older Xcode cannot compile `AppIcon.icon` at all.

This looks like a headless-runner fault, not bad icon data.

## The fix

`app-tier` exists to prove the app still compiles and links. That does not need the icon. So the job deletes it from the runner's checkout before building.

**The icon is not reverted.** It stays in the repo and in every local and release build. Only the ephemeral CI checkout is touched.

## Verified locally

With the icon removed and DerivedData cleared:

- `make build-app` exits **0**
- **zero** errors or warnings
- still emits a valid `Biscotti.app` containing a compiled `Assets.car`

Nothing references the icon by name — `project.yml` picks it up implicitly via `sources: - Resources`, and `Info.plist` carries no `CFBundleIconName`/`CFBundleIconFile`. So removing it drops the icon and nothing else.

## Trade-off

`app-tier` no longer exercises icon compilation. A `TODO` in the step says to delete it and re-check once the runner's Xcode can handle `.icon` bundles.

## Note on the other red check

`package-tier` is expected to fail on this branch. `main` is currently red on `make lint` because SwiftFormat is unpinned and Homebrew has drifted to 0.62.x. That is unrelated to this change and is fixed by #51.

🤖 Generated with [Claude Code](https://claude.com/claude-code)