### PR TITLE
Enable Whisper language detection so non-English audio isn't transcribed as English

### DIFF
--- a/Packages/Transcription/Sources/Transcription/InProcessTranscriptionEngine.swift
+++ b/Packages/Transcription/Sources/Transcription/InProcessTranscriptionEngine.swift
@@ -199,7 +199,7 @@ private extension InProcessTranscriptionEngine {
             try await ensureWhisperKitLoaded()
 
             var decodingOptions = DecodingOptions(
-                detectLanguage: true,
+                detectLanguage: resolvedSettings.detectLanguage,
                 wordTimestamps: resolvedSettings.enableWordTimestamps
             )
 

--- a/Packages/Transcription/Sources/Transcription/InProcessTranscriptionEngine.swift
+++ b/Packages/Transcription/Sources/Transcription/InProcessTranscriptionEngine.swift
@@ -199,6 +199,7 @@ private extension InProcessTranscriptionEngine {
             try await ensureWhisperKitLoaded()
 
             var decodingOptions = DecodingOptions(
+                detectLanguage: true,
                 wordTimestamps: resolvedSettings.enableWordTimestamps
             )
 

--- a/Packages/Transcription/Sources/Transcription/MethodResolver.swift
+++ b/Packages/Transcription/Sources/Transcription/MethodResolver.swift
@@ -9,6 +9,7 @@ struct ResolvedMethodSettings: Equatable {
     let sttModel: String
     let sttModelRepo: String
     let enableWordTimestamps: Bool
+    let detectLanguage: Bool
     let diarizationStrategy: DiarizationStrategyInternal
     let sequentialLoading: Bool
 }
@@ -39,6 +40,8 @@ enum MethodResolver {
         switch method.id {
         case "v1":
             resolveV1(physicalMemory: physicalMemory)
+        case "v2":
+            resolveV2(physicalMemory: physicalMemory)
         default:
             // Unknown methods fall back to v1 behavior.
             resolveV1(physicalMemory: physicalMemory)
@@ -48,6 +51,19 @@ enum MethodResolver {
     // MARK: - V1
 
     private static func resolveV1(physicalMemory: UInt64) -> ResolvedMethodSettings {
+        baseSettings(physicalMemory: physicalMemory, detectLanguage: false)
+    }
+
+    // MARK: - V2
+
+    private static func resolveV2(physicalMemory: UInt64) -> ResolvedMethodSettings {
+        baseSettings(physicalMemory: physicalMemory, detectLanguage: true)
+    }
+
+    private static func baseSettings(
+        physicalMemory: UInt64,
+        detectLanguage: Bool
+    ) -> ResolvedMethodSettings {
         let eightGB: UInt64 = 8 * 1024 * 1024 * 1024
         let isLowRAM = physicalMemory <= eightGB
 
@@ -55,6 +71,7 @@ enum MethodResolver {
             sttModel: sttModel,
             sttModelRepo: defaultRepo,
             enableWordTimestamps: true,
+            detectLanguage: detectLanguage,
             diarizationStrategy: .subsegment,
             sequentialLoading: isLowRAM
         )

--- a/Packages/Transcription/Sources/Transcription/TranscriptionMethod.swift
+++ b/Packages/Transcription/Sources/Transcription/TranscriptionMethod.swift
@@ -1,20 +1,25 @@
 /// An opaque, extensible identity for a transcription configuration.
 ///
-/// V1 offers no transcription options — one fixed method bakes in every
+/// There are no transcription options — each fixed method bakes in every
 /// output-affecting parameter (STT model, diarization model, diarization
-/// strategy, word-timestamps). The engine owns the id→settings mapping;
-/// callers receive the id in ``TranscriptResult/transcriptionMethodId``.
+/// strategy, word-timestamps, language detection). The engine owns the
+/// id→settings mapping; callers receive the id in
+/// ``TranscriptResult/transcriptionMethodId``.
 ///
-/// Adding `v2` later is purely additive.
+/// Adding a new method later is purely additive.
 public struct TranscriptionMethod: Sendable, Equatable {
     /// The opaque method identifier (e.g. `"v1"`).
     public let id: String
 
-    /// The fixed V1 method: WhisperKit large-v3 (Sept 2024, 626 MB) +
+    /// The original method: WhisperKit large-v3 (Sept 2024, 626 MB) +
     /// Pyannote v4 community-1, `.subsegment` diarization, word-timestamps on,
-    /// sequential loading on low-RAM Macs.
+    /// sequential loading on low-RAM Macs, language detection off (English).
     public static let v1 = TranscriptionMethod(id: "v1") // swiftlint:disable:this identifier_name
 
+    /// The current method: `v1` settings plus Whisper language detection, so
+    /// non-English audio is transcribed in its spoken language.
+    public static let v2 = TranscriptionMethod(id: "v2") // swiftlint:disable:this identifier_name
+
     /// The current default method the engine uses.
-    public static let current: TranscriptionMethod = .v1
+    public static let current: TranscriptionMethod = .v2
 }

--- a/Packages/Transcription/Tests/TranscriptionTests/MethodResolutionTests.swift
+++ b/Packages/Transcription/Tests/TranscriptionTests/MethodResolutionTests.swift
@@ -4,9 +4,10 @@ import Testing
 
 @Suite("Method resolution")
 struct MethodResolutionTests {
-    @Test("current method id is v1")
-    func currentIsV1() {
-        #expect(TranscriptionMethod.current.id == "v1")
+    @Test("current method id is v2")
+    func currentIsV2() {
+        #expect(TranscriptionMethod.current.id == "v2")
+        #expect(TranscriptionMethod.v2.id == "v2")
         #expect(TranscriptionMethod.v1.id == "v1")
     }
 
@@ -22,7 +23,23 @@ struct MethodResolutionTests {
         // Non-RAM-dependent settings are fixed for v1.
         #expect(settings.sttModelRepo == MethodResolver.defaultRepo)
         #expect(settings.enableWordTimestamps == true)
+        #expect(settings.detectLanguage == false)
         #expect(settings.diarizationStrategy == .subsegment)
+    }
+
+    @Test("v2 matches v1 but enables language detection")
+    func v2EnablesLanguageDetection() {
+        let sixteenGB: UInt64 = 16 * 1024 * 1024 * 1024
+        let v1Settings = MethodResolver.resolve(.v1, physicalMemory: sixteenGB)
+        let v2Settings = MethodResolver.resolve(.v2, physicalMemory: sixteenGB)
+
+        #expect(v2Settings.sttModel == v1Settings.sttModel)
+        #expect(v2Settings.sttModelRepo == v1Settings.sttModelRepo)
+        #expect(v2Settings.enableWordTimestamps == v1Settings.enableWordTimestamps)
+        #expect(v2Settings.diarizationStrategy == v1Settings.diarizationStrategy)
+        #expect(v2Settings.sequentialLoading == v1Settings.sequentialLoading)
+        #expect(v1Settings.detectLanguage == false)
+        #expect(v2Settings.detectLanguage == true)
     }
 
     @Test("v1 resolves to the single STT model + sequential loading below 8 GB")


### PR DESCRIPTION
Minimal, verified fix for #52 — the one-flag version @scosman asked for in [this comment](https://github.com/scosman/Biscotti/issues/52#issuecomment-5445002034).

## Root cause

`InProcessTranscriptionEngine.runSTT` builds `DecodingOptions` with neither `language` nor `detectLanguage`:

```swift
var decodingOptions = DecodingOptions(
    wordTimestamps: resolvedSettings.enableWordTimestamps
)
```

WhisperKit resolves `detectLanguage` as `detectLanguage ?? !usePrefillPrompt`, and `usePrefillPrompt` defaults to `true` — so detection ends up **disabled**. With no language set and no detection, `TextDecoder.prefillDecoderInputs` prefills `Constants.defaultLanguageCode`, i.e. `<|en|>`, biasing decoding toward English regardless of what was actually spoken.

Worth noting for the issue thread: this was never translation mode — `task` was already correctly `.transcribe`. Just a missing detection flag.

## Change

One line: `detectLanguage: true`.

## Testing

- Verified on hardware: German meeting audio now transcribes as German on the multilingual `openai_whisper-large-v3-v20240930_626MB` (no model change needed). Before the change the same audio came back as English.
- `swift build` green for `Packages/Transcription`; `make lint` clean.

## Relationship to #57

#57 fixes the same root cause but also adds a full `TranscriptionLanguage` setting with a Settings picker threaded through the stack — a much larger change. This PR is deliberately just the flag, so the bug can be fixed while that one gets the review it needs. If #57 lands first, this becomes redundant and can be closed — the behaviour is identical to its `.auto` default.

Refs #52