### PR TITLE
Detect Microsoft Teams meetings via the mic-holding modulehost sub-process

### DIFF
--- a/Packages/AudioCapture/Sources/AudioCapture/AudioProcess.swift
+++ b/Packages/AudioCapture/Sources/AudioCapture/AudioProcess.swift
@@ -53,6 +53,8 @@ public struct AudioProcess: Identifiable, Sendable, Equatable {
         // Native meeting apps
         "us.zoom.xos",
         "com.microsoft.teams2",
+        "com.microsoft.teams2.modulehost",
+        "com.microsoft.teams2.helper",
         "Cisco-Systems.Spark",
         "com.cisco.webexmeetingsapp",
         "com.logmein.GoToMeeting",
@@ -81,6 +83,8 @@ public struct AudioProcess: Identifiable, Sendable, Equatable {
     public static let meetingAppNames: [String: String] = [
         "us.zoom.xos": "Zoom",
         "com.microsoft.teams2": "Microsoft Teams",
+        "com.microsoft.teams2.modulehost": "Microsoft Teams",
+        "com.microsoft.teams2.helper": "Microsoft Teams",
         "Cisco-Systems.Spark": "Cisco Webex",
         "com.cisco.webexmeetingsapp": "Cisco Webex",
         "com.logmein.GoToMeeting": "GoTo Meeting",

--- a/Packages/AudioCapture/Tests/AudioCaptureTests/AudioProcessTests.swift
+++ b/Packages/AudioCapture/Tests/AudioCaptureTests/AudioProcessTests.swift
@@ -30,6 +30,24 @@ struct AudioProcessTests {
         #expect(teams.displayName == "Microsoft Teams")
     }
 
+    /// New Teams runs mic capture in a `modulehost` sub-process rather than
+    /// the main bundle, so the sub-processes must be recognized too.
+    @Test("Teams sub-processes are recognized", arguments: [
+        "com.microsoft.teams2.modulehost",
+        "com.microsoft.teams2.helper",
+    ])
+    func teamsSubProcessRecognized(bundleID: String) {
+        let process = AudioProcess(
+            id: 20,
+            bundleID: bundleID,
+            pid: 5679,
+            isRunningInput: true,
+            isRunningOutput: true
+        )
+        #expect(process.isMeetingApp)
+        #expect(process.displayName == "Microsoft Teams")
+    }
+
     @Test("Chrome is recognized")
     func chromeRecognized() {
         let chrome = AudioProcess(

--- a/Packages/BiscottiKit/Sources/MeetingCatalog/BundledMeetingCatalog.swift
+++ b/Packages/BiscottiKit/Sources/MeetingCatalog/BundledMeetingCatalog.swift
@@ -72,6 +72,8 @@ public struct BundledMeetingCatalog: MeetingCatalog {
         // Native meeting apps
         "us.zoom.xos",
         "com.microsoft.teams2",
+        "com.microsoft.teams2.modulehost",
+        "com.microsoft.teams2.helper",
         "Cisco-Systems.Spark",
         "com.cisco.webexmeetingsapp",
         "com.logmein.GoToMeeting",
@@ -123,7 +125,9 @@ public struct BundledMeetingCatalog: MeetingCatalog {
     private static let helperToParent: [String: String] = [
         "com.apple.WebKit.GPU": "com.apple.Safari",
         "com.apple.avconferenced": "com.apple.FaceTime",
-        "com.tinyspeck.slackmacgap.helper": "com.tinyspeck.slackmacgap"
+        "com.tinyspeck.slackmacgap.helper": "com.tinyspeck.slackmacgap",
+        "com.microsoft.teams2.modulehost": "com.microsoft.teams2",
+        "com.microsoft.teams2.helper": "com.microsoft.teams2"
     ]
 
     // MARK: - Compiled regex patterns (cached)

--- a/Packages/BiscottiKit/Tests/MeetingCatalogTests/BundledMeetingCatalogTests.swift
+++ b/Packages/BiscottiKit/Tests/MeetingCatalogTests/BundledMeetingCatalogTests.swift
@@ -11,6 +11,8 @@ struct BundledMeetingCatalogTests {
     @Test("Recognized meeting app bundle IDs", arguments: [
         "us.zoom.xos",
         "com.microsoft.teams2",
+        "com.microsoft.teams2.modulehost",
+        "com.microsoft.teams2.helper",
         "Cisco-Systems.Spark",
         "com.cisco.webexmeetingsapp",
         "com.logmein.GoToMeeting",
@@ -74,9 +76,21 @@ struct BundledMeetingCatalogTests {
         ("com.apple.WebKit.GPU", "Safari"),
         ("com.apple.avconferenced", "FaceTime"),
         ("com.tinyspeck.slackmacgap.helper", "Slack"),
+        ("com.microsoft.teams2.modulehost", "Microsoft Teams"),
+        ("com.microsoft.teams2.helper", "Microsoft Teams"),
     ])
     func helperDisplayName(helperID: String, expectedParentName: String) {
         #expect(catalog.displayName(forBundleID: helperID) == expectedParentName)
+    }
+
+    /// The mic-holding Teams sub-processes must merge into the parent app so
+    /// detection reports one "Microsoft Teams" call, not several.
+    @Test("Teams sub-processes resolve to the parent bundle ID", arguments: [
+        "com.microsoft.teams2.modulehost",
+        "com.microsoft.teams2.helper",
+    ])
+    func teamsHelperResolvesToParent(helperID: String) {
+        #expect(catalog.parentBundleID(forHelperBundleID: helperID) == "com.microsoft.teams2")
     }
 
     @Test("Display name for unknown bundle ID is nil")


### PR DESCRIPTION
Fixes #65.

## Problem

Biscotti never detected an active Microsoft Teams meeting and never offered to record — even though `com.microsoft.teams2` was already in the catalog and all permissions were granted.

## Root cause

New Teams (WebView2-based) does not capture the mic from its main process. It spawns `com.microsoft.teams2.modulehost`, and *that* is the process Core Audio reports with `kAudioProcessPropertyIsRunningInput` set during a call.

Confirmed with the `experiments/AudioLab` Streams view during a live call:

| Bundle ID | Input | Output |
|---|---|---|
| `com.microsoft.teams2.modulehost` | **Active** | Active |
| `com.microsoft.teams2` | — | — |
| `com.microsoft.teams2.helper` (×3) | Idle | Idle |

Because the catalog only listed the main bundle ID, `MeetingDetector.processSnapshot` filtered the mic-holding process out at the `catalog.isMeetingApp(bundleID:)` guard, so the per-app state machine never entered `pendingStart` and `.started` never fired.

This is easy to misdiagnose: the broader, unfiltered mic-user tracking in the same file still fires `.allMicUsersStopped` at the end of a call, so the detection log is not silent — it just never reports a meeting. That sent me looking at permissions and Core Audio listeners before the bundle ID.

## Change

Add `com.microsoft.teams2.modulehost` and `com.microsoft.teams2.helper` to both watchlists (`BundledMeetingCatalog` and the mirrored `AudioProcess.knownMeetingBundleIDs`), and map them to the parent via `helperToParent` — so a call reports as one "Microsoft Teams" meeting rather than several, matching the existing Slack/Safari/FaceTime helper handling.

`helper` is included alongside `modulehost` because it is part of the same Teams process group and was observed registered with the audio system; it was idle in my session, so treat that one as defensive rather than confirmed.

## Testing

- Verified on hardware across several Teams call start/stop cycles: `Meeting detected` → `.started` → notification → recording, and clean `Meeting ended` on hangup.
- Added parameterized tests for sub-process recognition, display-name resolution, and parent mapping. `swift test --package-path Packages/AudioCapture` green (12 tests).
- `make lint` clean.

Note: `swift test --package-path Packages/BiscottiKit` currently fails to build on `main` for an unrelated reason — `Tests/AppShellUITests/AppShellViewModelTests.swift:663` hits "the compiler is unable to type-check this expression in reasonable time" with Xcode 26.6. I confirmed that failure is pre-existing on a clean checkout, so the new `MeetingCatalogTests` cases could not be executed locally. Happy to file that separately if it isn't already known.

## Not included

Issue #65 also mentions that `kAudioProcessPropertyIsRunningInput`/`IsRunningOutput` listeners never fire on macOS (Apple Developer Forums thread 825780) while `LiveProcessActivitySource` still registers listeners on them — meaning a mic-only transition on a process that already has `IsRunning` true can be missed entirely. I prototyped a periodic fallback poll for that, but deliberately left it out here: it contradicts the explicit "fully push-based — no polling loop" decision in `specs/research/audio/phase9_validation_findings.md`, and the bundle ID alone is what fixed detection in my testing. Left for you to decide in #65.