### PR TITLE
Fix flaky package-tier CI tests

### DIFF
--- a/Packages/BiscottiKit/Tests/AppCoreTests/AppCoreBackgroundTests.swift
+++ b/Packages/BiscottiKit/Tests/AppCoreTests/AppCoreBackgroundTests.swift
@@ -96,11 +96,17 @@ struct AppCoreDetectionPipelineTests {
     @Test("ad-hoc detection suppressed within calendar suppression window")
     @MainActor
     func suppressedAfterCalendarPrompt() async throws {
+        // Start the meeting 60s out, NOT ~1s out: AppCore skips events
+        // whose start is already past when the timer is scheduled
+        // (`delay > 0` guard in scheduleCalendarTimers), and under
+        // parallel-test load the fixture setup + onLaunch can consume
+        // real seconds -- which made a now+1s event stale and the
+        // calendar notification never fire (flake). 60s of margin is
+        // safe; the fake scheduler advances past it below.
         let now = Date()
-        // Create a meeting starting in 1 second so the calendar timer fires
         let dto = makeMeetingDTO(
             title: "Imminent Meeting",
-            start: now.addingTimeInterval(1),
+            start: now.addingTimeInterval(60),
             end: now.addingTimeInterval(3600)
         )
 
@@ -123,8 +129,10 @@ struct AppCoreDetectionPipelineTests {
         await fix.core.onLaunch()
 
         // Fire the calendar-start timer and poll until the MainActor
-        // task that posts the calendar notification runs.
-        fakeScheduler.advance(by: .seconds(2))
+        // task that posts the calendar notification runs. The delay
+        // computed at schedule time is < 60s (setup latency shaved off
+        // the now+60s start), so 65 fake seconds always covers it.
+        fakeScheduler.advance(by: .seconds(65))
         try await pollUntil {
             !fix.fakeNotificationCenter.addedRequests.isEmpty
         }

--- a/Packages/BiscottiKit/Tests/MeetingDetectionTests/MeetingDetectionTests.swift
+++ b/Packages/BiscottiKit/Tests/MeetingDetectionTests/MeetingDetectionTests.swift
@@ -218,9 +218,12 @@ struct MicUserTrackingTests {
         )])
         await collector.settle()
 
-        // Mic user stops
+        // Mic user stops. Wait for the debounce to resolve BEFORE
+        // stopping the detector: stop() cancels a pending debounce, so
+        // a bare settle() races the debounce task under load and can
+        // lose the event entirely.
         source.emit([])
-        await collector.settle()
+        await collector.waitForEvents(count: 1)
 
         detector.stop()
         await collector.settle()
@@ -438,22 +441,15 @@ struct MicStopDebounceTests {
             meetingBundleIDs: ["us.zoom.xos"],
             displayNames: ["us.zoom.xos": "Zoom"]
         )
-        // OneShotImmediateClock: the first sleep (the per-app start
-        // debounce or the first mic-stop debounce that fires) fires
-        // immediately; subsequent ones block. We use this to suppress
-        // the flap's mic debounce while letting the real gap's debounce
-        // resolve after detector.stop() cleanup.
-        //
-        // Actually, for this test we need:
-        // 1. First dropout: mic debounce starts (blocks with NeverClock)
-        //    -> cancelled on reappearance
-        // 2. Second dropout: mic debounce starts (fires with ImmediateClock)
-        //
-        // Use ImmediateClock -- both debounces fire instantly, but the
-        // first one is cancelled before it resolves because the
-        // reappearance snapshot processes before the debounce task runs.
-        let detector = makeImmediateDetector(
-            catalog: catalog, source: source
+        // GateClock: debounce sleeps park until the test opens the
+        // gate. The flap's debounce cannot resolve (and emit) before
+        // the reappearance snapshot cancels it, and the real gap's
+        // debounce resolves only when the test says so. (The previous
+        // ImmediateClock version was flaky: the debounce task could be
+        // scheduled ahead of the observe loop's reappearance snapshot.)
+        let clock = GateClock()
+        let detector = makeGateDetector(
+            clock: clock, catalog: catalog, source: source
         )
         let collector = EventCollector()
         collector.start(from: detector)
@@ -467,8 +463,9 @@ struct MicStopDebounceTests {
         )])
         await collector.settle()
 
-        // Brief dropout + immediate reappearance (flap)
-        // The reappearance snapshot cancels the pending mic debounce
+        // Brief dropout + immediate reappearance (flap). Snapshots are
+        // processed in FIFO order: the drop enters the debounce (which
+        // parks on the closed gate), the reappearance cancels it.
         source.emit([])
         source.emit([makeProcess(
             bundleID: "com.spotify.client",
@@ -477,11 +474,16 @@ struct MicStopDebounceTests {
         )])
         await collector.settle()
 
-        // Verify no event from the flap
+        // Real sustained gap -- mic user stops for good. The new
+        // debounce parks on the closed gate.
+        source.emit([])
+        await collector.settle()
+
+        // Verify no event from the flap before the gate opens
         #expect(collector.events.isEmpty)
 
-        // Real sustained gap -- mic user stops for good
-        source.emit([])
+        // Open the gate: the real gap's debounce resolves and fires
+        clock.open()
         await collector.waitForEvents(count: 1)
 
         detector.stop()
@@ -801,20 +803,21 @@ struct AppleSystemServiceDenylistTests {
 @Suite("MeetingDetection — Mic Stop Self-Verify")
 @MainActor
 struct MicStopSelfVerifyTests {
-    @Test("mic-stop debounce does not emit if non-self mic user reappears at resolve")
+    @Test("mic-stop debounce does not emit if non-self mic user reappears before the debounce fires")
     func micStopSuppressedWhenMicReappears() async {
         let source = FakeActivitySource()
         let catalog = FakeMeetingCatalog(
             meetingBundleIDs: ["us.zoom.xos"],
             displayNames: ["us.zoom.xos": "Zoom"]
         )
-        // ImmediateClock: the debounce fires quickly. The key is that
-        // we re-add a mic user before the debounce resolves. Because
-        // the AsyncStream for-await loop processes buffered snapshots
-        // before yielding to the debounce Task, the hadNonSelfMicUsers
-        // flag is restored to true before resolveMicStopDebounce runs.
-        let detector = makeImmediateDetector(
-            catalog: catalog, source: source
+        // GateClock: the debounce parks on the closed gate, so it
+        // cannot win a scheduling race against the snapshot stream.
+        // (The ImmediateClock version of this test was flaky in CI:
+        // the debounce task could resolve before the observe loop
+        // processed the reappearance snapshot, emitting an event.)
+        let clock = GateClock()
+        let detector = makeGateDetector(
+            clock: clock, catalog: catalog, source: source
         )
         let collector = EventCollector()
         collector.start(from: detector)
@@ -829,15 +832,20 @@ struct MicStopSelfVerifyTests {
         await collector.settle()
 
         // Mic user drops then reappears in rapid succession.
-        // The drop triggers the debounce; the reappearance both cancels
-        // the debounce (primary guard) AND sets hadNonSelfMicUsers=true
-        // (self-verify guard).
+        // Snapshots are processed in FIFO order: the drop enters the
+        // debounce (parked on the closed gate), the reappearance
+        // cancels it and restores hadNonSelfMicUsers = true.
         source.emit([])
         source.emit([makeProcess(
             bundleID: "com.spotify.client",
             isRunningInput: true,
             isRunningOutput: false
         )])
+        await collector.settle()
+
+        // Even with the debounce window fully elapsed, the cancelled
+        // debounce must not emit.
+        clock.open()
         await collector.settle()
 
         // No allMicUsersStopped because the mic user is present

--- a/Packages/BiscottiKit/Tests/MeetingDetectionTests/TestHelpers.swift
+++ b/Packages/BiscottiKit/Tests/MeetingDetectionTests/TestHelpers.swift
@@ -132,6 +132,14 @@ private final class ContinuationBox: @unchecked Sendable {
         lock.unlock()
     }
 
+    func resume() {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !resumed, let cont = continuation else { return }
+        resumed = true
+        cont.resume()
+    }
+
     func resume(throwing error: Error) {
         lock.lock()
         defer { lock.unlock() }
@@ -189,6 +197,96 @@ struct NeverClock: Clock {
             }
         } onCancel: {
             box.resume(throwing: CancellationError())
+        }
+    }
+}
+
+// MARK: - GateClock
+
+/// A clock whose `sleep` parks until the test opens the gate.
+///
+/// Unlike `ImmediateClock`, a debounce driven by this clock CANNOT
+/// resolve until the test says so. This removes the scheduling race
+/// that made the ImmediateClock flap tests flaky in CI: with an
+/// uncontrolled immediate sleep, the debounce task could run (and
+/// emit) before the observe loop processed the buffered
+/// reappearance snapshot that was supposed to cancel it.
+///
+/// After `open()`, all parked sleepers resume and later sleeps
+/// return immediately (the clock behaves like `ImmediateClock`).
+/// Cancellation always interrupts a parked sleep, so a debounce
+/// cancelled before `open()` can never emit.
+final class GateClock: Clock, @unchecked Sendable {
+    typealias Duration = Swift.Duration
+
+    struct Instant: InstantProtocol {
+        var offset: Swift.Duration
+        static var zero: Instant {
+            Instant(offset: .zero)
+        }
+
+        func advanced(by duration: Swift.Duration) -> Instant {
+            Instant(offset: offset + duration)
+        }
+
+        func duration(to other: Instant) -> Swift.Duration {
+            other.offset - offset
+        }
+
+        static func < (lhs: Instant, rhs: Instant) -> Bool {
+            lhs.offset < rhs.offset
+        }
+    }
+
+    private let lock = NSLock()
+    private var isOpen = false
+    private var sleepers: [ContinuationBox] = []
+
+    var now: Instant {
+        .zero
+    }
+
+    var minimumResolution: Swift.Duration {
+        .zero
+    }
+
+    func sleep(
+        until _: Instant, tolerance _: Swift.Duration?
+    ) async throws {
+        try Task.checkCancellation()
+
+        let box = ContinuationBox()
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+                box.store(cont)
+                let resumeNow = lock.withLock {
+                    if !isOpen {
+                        sleepers.append(box)
+                    }
+                    return isOpen
+                }
+                if resumeNow {
+                    box.resume()
+                } else if Task.isCancelled {
+                    box.resume(throwing: CancellationError())
+                }
+            }
+        } onCancel: {
+            box.resume(throwing: CancellationError())
+        }
+    }
+
+    /// Opens the gate: resumes all parked sleepers and lets all
+    /// subsequent sleeps return immediately.
+    func open() {
+        let parked = lock.withLock {
+            isOpen = true
+            let boxes = sleepers
+            sleepers.removeAll()
+            return boxes
+        }
+        for box in parked {
+            box.resume()
         }
     }
 }
@@ -336,6 +434,22 @@ func makeNeverDetector(
         catalog: catalog,
         source: source,
         clock: AnyClock(NeverClock())
+    )
+}
+
+/// Creates a detector whose debounce sleeps park until `clock.open()`.
+/// Use for tests that must control exactly when a debounce fires (or
+/// prove a cancelled debounce cannot fire at all).
+@MainActor
+func makeGateDetector(
+    clock: GateClock,
+    catalog: FakeMeetingCatalog,
+    source: FakeActivitySource
+) -> MeetingDetector {
+    MeetingDetector(
+        catalog: catalog,
+        source: source,
+        clock: AnyClock(clock)
     )
 }
 

--- a/Packages/BiscottiKit/Tests/ModelManagementUITests/ManageModelsViewModelTests.swift
+++ b/Packages/BiscottiKit/Tests/ModelManagementUITests/ManageModelsViewModelTests.swift
@@ -96,8 +96,9 @@ struct ManageModelsViewModelTests {
         let firstID = try #require(LLMModelCatalog.all.first?.id)
         viewModel.download(id: firstID)
 
-        // Wait for the background Task to complete
-        try await Task.sleep(for: .milliseconds(50))
+        // Poll for the background Task to complete -- a fixed sleep
+        // races the task under parallel-test load
+        try await pollUntil { fixture.modelManager.isModelAvailable }
 
         // Verify ModelManager received the download
         #expect(fixture.modelManager.isModelAvailable == true)
@@ -124,8 +125,8 @@ struct ManageModelsViewModelTests {
         let viewModel = ManageModelsViewModel(core: fixture.core)
         viewModel.choose(id: secondID)
 
-        // Wait for the background Task to complete
-        try await Task.sleep(for: .milliseconds(50))
+        // Poll for the background Task to complete
+        try await pollUntil { fixture.modelManager.activeModelID == secondID }
 
         #expect(fixture.modelManager.activeModelID == secondID)
     }
@@ -172,8 +173,12 @@ struct ManageModelsViewModelTests {
         // Target should be cleared immediately
         #expect(viewModel.deleteTarget == nil)
 
-        // Wait for the background Task to complete
-        try await Task.sleep(for: .milliseconds(50))
+        // Poll for the background Task to complete
+        try await pollUntil {
+            viewModel.modelChoices.first {
+                $0.model.id == downloadedChoice.model.id
+            }?.isDownloaded == false
+        }
 
         // Model should no longer be downloaded
         let refreshedChoices = viewModel.modelChoices


### PR DESCRIPTION
## Summary

Fixes 4 flaky tests that caused repeated package-tier CI failures that passed on re-run (2026-08-24, 2026-08-27 runs). Test-only change — no production code touched.

| Test | Root cause | Fix |
|---|---|---|
| MeetingDetection `flapThenRealGapEmitsOnce`, `micStopSuppressedWhenMicReappears` | `ImmediateClock` debounce `Task` raced the observe loop's reappearance snapshot on the MainActor — debounce could emit before being cancelled | New `GateClock` test helper: debounce sleeps park until the test opens the gate; both tests rewritten deterministically |
| MeetingDetection `allMicUsersStoppedFires` | `settle()` (50 ms) before `detector.stop()` — `stop()` cancels a starved debounce and loses the event | `waitForEvents(count: 1)` before stop |
| `ManageModelsViewModelTests` (3 sites) | Bare `Task.sleep(50ms)` waiting on background Tasks | Shared `pollUntil` from `BiscottiTestSupport` |
| AppCore `suppressedAfterCalendarPrompt` | Meeting start `Date()+1s` went stale under load; `scheduleCalendarTimers` skips already-started events (`delay > 0` guard) → calendar notification never fired | Start at `+60s`, advance fake scheduler 65 s |

## Verification

- MeetingDetection suite: 15 consecutive green runs
- Full BiscottiKit suite (1931 tests): 5 consecutive green runs (was failing 3/3 before)
- `make lint`, `make test`, `make precommit-checks`: exit 0
- Spec `/cr` verdict: clean (3 Mild notes below)

## CR Mild notes (future improvements, not addressed here)

- `suppressedAfterCalendarPrompt` final assert can pass vacuously under load (cannot fail spuriously) — would benefit from a positive "detector consumed the snapshot" signal
- `EventCollector.waitForEvents` gives up silently after ~5 s; an `Issue.record` on timeout would make failures self-explaining
- `ImmediateClock` is duplicated between `BiscottiTestSupport` and `MeetingDetectionTests` (pre-existing); unify if a third target needs `GateClock`