### PR TITLE
Fix AttributeGraph cycle in Meeting Detail height measurement

### DIFF
--- a/Packages/BiscottiKit/Sources/MeetingDetailUI/MeetingDetailView.swift
+++ b/Packages/BiscottiKit/Sources/MeetingDetailUI/MeetingDetailView.swift
@@ -268,8 +268,6 @@ public struct MeetingDetailView: View {
     /// `listRowMaxWidth`, matching the ScrollView path's layout.
     private func transcriptListLayout(geo _: GeometryProxy) -> some View {
         transcriptReadyContent
-            .onPreferenceChange(ChromeHeightKey.self) { chromeHeight = $0 }
-            .onPreferenceChange(TransportHeightKey.self) { transportHeight = $0 }
             .safeAreaInset(edge: .bottom, spacing: Self.transportSpacing) {
                 pinnedTransportBar
             }
@@ -296,8 +294,6 @@ public struct MeetingDetailView: View {
             .frame(maxWidth: Tokens.readableContentMaxWidth, alignment: .leading)
             .frame(maxWidth: .infinity)
         }
-        .onPreferenceChange(ChromeHeightKey.self) { chromeHeight = $0 }
-        .onPreferenceChange(TransportHeightKey.self) { transportHeight = $0 }
         .safeAreaInset(edge: .bottom, spacing: Self.transportSpacing) {
             pinnedTransportBar
         }
@@ -314,7 +310,7 @@ public struct MeetingDetailView: View {
     /// **Layout coupling:** the `verticalOverhead` constant mirrors the
     /// padding and divider in `scrollViewLayout(geo:)`. If you change
     /// the padding values or divider there, update this calculation to
-    /// match. The `transportHeight` is measured via `TransportHeightKey`
+    /// match. The `transportHeight` is measured via `onGeometryChange`
     /// in `pinnedTransportBar` -- it accounts for the bottom
     /// `safeAreaInset` that the outer `GeometryReader` does not subtract
     /// from its reported size.
@@ -406,19 +402,15 @@ private extension MeetingDetailView {
             .frame(maxWidth: .infinity)
         }
         .pinnedBarBackground()
-        .background(GeometryReader { transportProxy in
-            Color.clear
-                .preference(
-                    key: TransportHeightKey.self,
-                    value: transportProxy.size.height
-                )
-        })
+        .onGeometryChange(for: CGFloat.self) { $0.size.height } action: {
+            transportHeight = $0
+        }
     }
 
-    /// Header + tags row + calendar card + tab bar, measured for the
-    /// chrome-height preference key. AudioTransport is now pinned to
-    /// the bottom of the panel (see `pinnedTransportBar`), outside
-    /// this scroll region.
+    /// Header + tags row + calendar card + tab bar, with its height
+    /// measured via `onGeometryChange` for `contentFill`. AudioTransport
+    /// is pinned to the bottom of the panel (see `pinnedTransportBar`),
+    /// outside this scroll region.
     var chrome: some View {
         VStack(alignment: .leading, spacing: Tokens.spacingMD) {
             header
@@ -434,13 +426,9 @@ private extension MeetingDetailView {
 
             tabBar
         }
-        .background(GeometryReader { chromeProxy in
-            Color.clear
-                .preference(
-                    key: ChromeHeightKey.self,
-                    value: chromeProxy.size.height
-                )
-        })
+        .onGeometryChange(for: CGFloat.self) { $0.size.height } action: {
+            chromeHeight = $0
+        }
     }
 
     /// The tags row: detail-size pills with hover-remove, followed by
@@ -1065,22 +1053,6 @@ private extension MeetingDetailView {
             Spacer()
         }
         .frame(maxWidth: .infinity)
-    }
-}
-
-// MARK: - Layout preference keys
-
-private struct ChromeHeightKey: PreferenceKey {
-    static let defaultValue: CGFloat = 0
-    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-        value = max(value, nextValue())
-    }
-}
-
-private struct TransportHeightKey: PreferenceKey {
-    static let defaultValue: CGFloat = 0
-    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-        value = max(value, nextValue())
     }
 }
 

--- a/specs/projects/meeting_detail_redesign/architecture.md
+++ b/specs/projects/meeting_detail_redesign/architecture.md
@@ -100,6 +100,14 @@ a **definite** height (not `maxHeight: .infinity`), avoiding the greedy-NSScroll
 in-ScrollView infinite-height trap. 760pt reading cap on the inner column; ivory
 fills the rest of the pane.
 
+> **Superseded 2026-08:** the `GeometryReader` → `PreferenceKey` →
+> `.onPreferenceChange` measurement described here caused
+> "AttributeGraph: cycle detected" warnings at runtime (the geometry → state →
+> layout round-trip *is* a feedback loop, contrary to the claim above).
+> `MeetingDetailView` now measures chrome/transport heights with
+> `onGeometryChange(for:action:)`, which writes `@State` directly with no
+> preference propagation. The height-consumption design below is unchanged.
+
 ---
 
 ## Playback rate (P2)


### PR DESCRIPTION
## Problem

The Meeting Detail screen flooded the console with `=== AttributeGraph: cycle detected through attribute … ===` warnings. Reproduced on hardware: the reliable trigger is the **transcript tab**, where the measured `chrome` lives inside the `List` header row — the geometry → preference → state round-trip propagates through the List's layout machinery, the densest part of AttributeGraph. The ScrollView paths (Notes/Summary) settle in one pass and rarely warn.

## Root cause

`MeetingDetailView.swift` measured chrome and transport-bar heights with the classic AttributeGraph-cycle pattern: a `GeometryReader` in a `.background` wrote a `PreferenceKey`, an `.onPreferenceChange` wrote that into `@State`, and that `@State` sized content via `.frame(height:)` — a layout round-trip SwiftUI flags as a cycle. The `.onPreferenceChange` handlers were duplicated across two container levels (`transcriptListLayout` and `scrollViewLayout`).

## Fix

macOS 15+ `onGeometryChange(for:action:)` reads geometry and writes `@State` directly on the measured view — no preference→state→layout cycle:

- Replace `.background(GeometryReader { … .preference })` on `chrome` and `pinnedTransportBar` with `.onGeometryChange(for: CGFloat.self) { $0.size.height }`.
- Remove all four `.onPreferenceChange` handlers (the duplicated pairs).
- Delete the now-unused `ChromeHeightKey` / `TransportHeightKey` structs.
- Mark the old mechanism as superseded in `specs/projects/meeting_detail_redesign/architecture.md` (its "no layout feedback loop" claim is what reality disproved).

`contentFill(viewportHeight:)`, the `@State` vars, and all `.frame(height:)` consumers are unchanged — only the measurement mechanism changed, so layout is intended to be identical. Measured bounds and modifier position are identical to the old `.background(GeometryReader)` at both sites.

**Supersedes #38** — same fix and diagnosis; that branch (forked at PR #34) no longer applied after 35+ PRs of drift.

## Checks

- `make precommit-checks` green (format + lint + full test suite)
- CR (`/spec cr`) clean — no critical/moderate findings

## On-device verification

- [x] Pre-fix repro: transcript tab, warnings captured during layout activity
- [ ] Post-fix: rerun on transcript tab (and AI summary regenerate) — warnings gone, layout visually unchanged