### PR TITLE
Fail make build on compiler warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,8 +72,17 @@ generate: ## Generate Xcode projects from project.yml files
 	cd App && xcodegen generate
 	cd ManualTestApp && xcodegen generate
 
+# Compiler warnings are errors in `make build` (and therefore `make ci`).
+# SwiftLint/SwiftFormat only see style; this is what makes the compiler
+# itself strict, so deprecations (e.g. SwiftNIO's NIOAny writes) fail the
+# build instead of shipping as noise. NOT yet on `make test`: the test
+# targets still carry ~8 pre-existing warnings (swift-testing `#require`
+# patterns, a deprecated `String(cString:)`). Once those are fixed, add
+# $(SWIFT_STRICT) to the test target too.
+SWIFT_STRICT := -Xswiftc -warnings-as-errors
+
 build: ## Build all SPM packages
-	@for pkg in $(PACKAGES); do echo "==> Building $$pkg"; swift build --package-path $$pkg || exit 1; done
+	@for pkg in $(PACKAGES); do echo "==> Building $$pkg"; swift build --package-path $$pkg $(SWIFT_STRICT) || exit 1; done
 
 test: ## GATING: run package tests
 	@for pkg in $(PACKAGES); do \


### PR DESCRIPTION
## Why
No gate (`build`, `test`, `ci`, pre-commit) treated compiler warnings as failures: `swift build` exits 0 with warnings, and SwiftLint/SwiftFormat only see style. Warnings of every kind — deprecations, unused results, redundant/ambiguous macro patterns — accumulate silently across the codebase (the SwiftNIO `NIOAny` `write`/`writeAndFlush` deprecations that triggered this were just the latest example of many similar cases).

## What
- Adds `SWIFT_STRICT := -Xswiftc -warnings-as-errors` and applies it to `make build` (and therefore `make ci`): any new warning in production code now fails the gate, whatever its kind.
- `make test` stays lenient for now: test targets carry ~8 pre-existing warnings of exactly this kind (swift-testing `#require` patterns, a deprecated `String(cString:)`). Once those are fixed deliberately, $(SWIFT_STRICT) extends to the test target — noted in the Makefile comment.

## Verification
- Reintroduced the deprecated NIOAny writes temporarily: `make build` failed (exit 2) with all three deprecations promoted to errors; restored the fix and `make build` is clean.
- Full `make precommit-checks` green (format + lint + all package tests).