### PR TITLE
Fix ImplicitStrongCapture error in Transcriber.statusStream

### DIFF
--- a/Packages/Transcription/Sources/Transcription/Transcriber.swift
+++ b/Packages/Transcription/Sources/Transcription/Transcriber.swift
@@ -239,8 +239,8 @@ public actor Transcriber {
             // not lost.
             self.statusContinuations[id] = continuation
             continuation.yield(self.currentStatus)
-            continuation.onTermination = { @Sendable _ in
-                Task { [weak self] in
+            continuation.onTermination = { @Sendable [weak self] _ in
+                Task {
                     await self?.removeContinuation(id: id)
                 }
             }


### PR DESCRIPTION
`make build` failed on `Transcriber.swift:243` — the new `ImplicitStrongCapture` diagnostic flagged the inner `Task { [weak self] }` as disagreeing with the strong `self` implicitly captured by the enclosing `onTermination` closure.

Fix: move `[weak self]` up to the outer closure (after the `@Sendable` attribute).

`make build` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DVhag6dKjqZqzP44XDujq5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transcription status stream cleanup to prevent unnecessary retention during termination.
  * Preserved reliable asynchronous cleanup of transcription stream connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->