### PR TITLE
Fix type-checker timeout in AppShellViewModelTests

### DIFF
--- a/Packages/BiscottiKit/Tests/AppShellUITests/AppShellViewModelTests.swift
+++ b/Packages/BiscottiKit/Tests/AppShellUITests/AppShellViewModelTests.swift
@@ -709,21 +709,17 @@ struct AppShellUpcomingCapTests {
     @MainActor
     func upcomingEventsCappedAt6() async throws {
         let now = Date()
-        let dtos = (0 ..< 9).map { idx in
-            EKEventDTO(
+        let dtos = (0 ..< 9).map { idx -> EKEventDTO in
+            let start: TimeInterval = Double(idx + 1) * 600
+            let end: TimeInterval = start + 3600
+            return EKEventDTO(
                 eventIdentifier: "ev-cap-\(idx)",
                 calendarItemIdentifier: "ci-cap-\(idx)",
                 calendarItemExternalIdentifier: "ext-cap-\(idx)",
-                occurrenceDate: now.addingTimeInterval(
-                    Double(idx + 1) * 600
-                ),
+                occurrenceDate: now.addingTimeInterval(start),
                 title: "Cap Event \(idx)",
-                startDate: now.addingTimeInterval(
-                    Double(idx + 1) * 600
-                ),
-                endDate: now.addingTimeInterval(
-                    Double(idx + 1) * 600 + 3600
-                ),
+                startDate: now.addingTimeInterval(start),
+                endDate: now.addingTimeInterval(end),
                 isAllDay: false,
                 location: "https://zoom.us/j/cap\(idx)",
                 url: nil,

--- a/Packages/BiscottiKit/Tests/HomeUITests/HomeViewModelTests.swift
+++ b/Packages/BiscottiKit/Tests/HomeUITests/HomeViewModelTests.swift
@@ -15,15 +15,17 @@ struct HomeViewModelStateTests {
     @MainActor
     func homeShowsUpcomingPreview() async throws {
         let now = Date()
-        let dtos = (0 ..< 8).map { idx in
-            EKEventDTO(
+        let dtos = (0 ..< 8).map { idx -> EKEventDTO in
+            let start: TimeInterval = Double(idx + 1) * 600
+            let end: TimeInterval = start + 3600
+            return EKEventDTO(
                 eventIdentifier: "ev-\(idx)",
                 calendarItemIdentifier: "ci-\(idx)",
                 calendarItemExternalIdentifier: "ext-\(idx)",
                 occurrenceDate: now,
                 title: "Event \(idx)",
-                startDate: now.addingTimeInterval(Double(idx + 1) * 600),
-                endDate: now.addingTimeInterval(Double(idx + 1) * 600 + 3600),
+                startDate: now.addingTimeInterval(start),
+                endDate: now.addingTimeInterval(end),
                 isAllDay: false,
                 location: "https://zoom.us/j/\(idx)",
                 url: nil,


### PR DESCRIPTION
`swift test` fails to build `AppShellUITests`: the `EKEventDTO` literal in `upcomingEventsCappedAt6` has 22 arguments plus inline `Double(idx + 1) * 600 + 3600` arithmetic and string interpolation, and the compiler gives up — *"unable to type-check this expression in reasonable time"* at `AppShellViewModelTests.swift:728`.

Fix: hoist `start` / `end` into explicitly typed locals before the call.

`swift test --package-path Packages/BiscottiKit` passes (78 + 35 + 19 tests). Verified on top of #77, which is needed for `Transcription` to compile at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DVhag6dKjqZqzP44XDujq5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test readability by assigning event time intervals to local variables before creating test events.
  * Existing generated event data and assertions remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->